### PR TITLE
Raise pipeline caps to fix sentence drought

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ npx expo start --web  # opens on localhost:8081
 - **Tapped words are always marked missed** — front-phase tapping auto-marks as missed (rating≤2).
 - **al-prefix is NOT a separate lemma** — الكلب and كلب are the same lemma. All import paths dedup.
 - **Be conservative with ElevenLabs TTS** — costs real money. Only generate for sentences that will be shown.
-- **Sentence pipeline cap**: 600 active sentences. Cron runs `rotate_stale_sentences.py` then `update_material.py` every 6h. `warm_sentence_cache()` also runs after every session load and detects recency-exhausted words (≥2 sentences but all shown <24h, generates fresh ones, max 5/run).
+- **Sentence pipeline cap**: 800 active sentences. Cron runs `rotate_stale_sentences.py` then `update_material.py` every 3h. `warm_sentence_cache()` also runs after every session load and detects recency-exhausted words (≥3 sentences but all shown <24h, generates fresh ones, max 20/run).
 - **Canonical lemma is the unit of scheduling** — variant forms tracked via `variant_stats_json` but never get independent FSRS cards.
 - **All import paths must run variant detection** — `detect_variants_llm()` + `detect_definite_variants()` + `mark_variants()` post-import.
 - **All import paths must run quality gate** — `import_quality.classify_lemmas()` filters junk, classifies standard/proper_name/onomatopoeia.

--- a/backend/app/services/material_generator.py
+++ b/backend/app/services/material_generator.py
@@ -355,8 +355,8 @@ def generate_word_audio(lemma_id: int) -> None:
         db.close()
 
 
-MIN_SENTENCES_PER_WORD = 2
-PIPELINE_CAP = 600
+MIN_SENTENCES_PER_WORD = 3
+PIPELINE_CAP = 800
 
 
 def rotate_stale_sentences(db, min_shown: int = 1, min_active: int = 2) -> int:
@@ -485,7 +485,7 @@ def warm_sentence_cache(llm_model: str = "gemini") -> dict:
             )
             gaps = [lid for lid in cohort if sentence_counts.get(lid, 0) < MIN_SENTENCES_PER_WORD]
             stats["cohort_gaps"] = len(gaps)
-            gap_word_ids.extend(gaps[:10])
+            gap_word_ids.extend(gaps[:20])
 
         # 2. Likely auto-introduction candidates
         active_topic = ensure_active_topic(db)
@@ -510,7 +510,7 @@ def warm_sentence_cache(llm_model: str = "gemini") -> dict:
         recency_cutoff = now - timedelta(days=1)
         gap_word_set = set(gap_word_ids)
         recency_exhausted_count = 0
-        MAX_RECENCY_EXHAUSTED = 5
+        MAX_RECENCY_EXHAUSTED = 20
         if cohort:
             for lid in cohort:
                 if lid in gap_word_set:

--- a/backend/scripts/update_material.py
+++ b/backend/scripts/update_material.py
@@ -61,10 +61,10 @@ from app.services.tts import (
     get_cached_path,
 )
 
-MIN_SENTENCES = 2  # per-word target for backfill generation
+MIN_SENTENCES = 3  # per-word target for backfill generation
 MIN_SENTENCES_CAP_ENFORCEMENT = 1  # per-word floor during cap enforcement (JIT handles gaps)
-TARGET_PIPELINE_SENTENCES = 600  # hard cap — JIT generation fills gaps with current vocabulary
-CAP_HEADROOM = 30  # retire this many below cap to leave room for multi-target backfill
+TARGET_PIPELINE_SENTENCES = 800  # hard cap — JIT generation fills gaps with current vocabulary
+CAP_HEADROOM = 50  # retire this many below cap to leave room for multi-target backfill
 
 
 def get_existing_counts(db: Session) -> dict[int, int]:

--- a/docs/scheduling-system.md
+++ b/docs/scheduling-system.md
@@ -1016,8 +1016,8 @@ Two paths for sentence availability:
 
 1. **Pre-generated (warm cache)**: `scripts/update_material.py` runs on cron,
    generating multi-target sentences for words prioritized by FSRS due date. Target:
-   `MIN_SENTENCES=2` per word. Pool cap: 600 active sentences with `CAP_HEADROOM=30`
-   (retires down to 270 so backfill always has budget for multi-target generation).
+   `MIN_SENTENCES=3` per word. Pool cap: 800 active sentences with `CAP_HEADROOM=50`
+   (retires down to 750 so backfill always has budget for multi-target generation).
 
 2. **On-demand (JIT)**: During `build_session()` with `skip_on_demand=False` (prefetch
    requests only), if a due word has no comprehensible sentence, generate one synchronously.
@@ -1049,18 +1049,20 @@ Rule-based validation pipeline:
 
 ### Pipeline Cap & Retirement
 
-**Cap enforcement** (`update_material.py` Step 0): Hard cap of 600 active sentences.
-Step 0 retires down to `300 - CAP_HEADROOM` (270) to leave budget for multi-target
+**Cap enforcement** (`update_material.py` Step 0): Hard cap of 800 active sentences.
+Step 0 retires down to `800 - CAP_HEADROOM` (750) to leave budget for multi-target
 backfill in Step A. Retirement priority: never-shown stale → shown stale → oldest,
 always keeping at least 1 sentence per word.
 
 **Warm cache** (`warm_sentence_cache()`) now rotates stale sentences before checking
 the cap, so it can free space even when over the limit. After rotation, it allows up to
-`PIPELINE_CAP + 10` (310) before skipping generation. The warm cache identifies three
-types of gap words: (1) focus cohort words with < 2 active sentences, (2) likely
-auto-introduction candidates with < 2 sentences, (3) **recency-exhausted words** — words
-with ≥ 2 sentences but ALL shown in the last 24h (capped at 5 per warm run). This ensures
-high-frequency reviewers always have fresh sentences available. (Fix: 2026-02-23)
+`PIPELINE_CAP + 10` (810) before skipping generation. The warm cache identifies three
+types of gap words: (1) focus cohort words with < 3 active sentences, (2) likely
+auto-introduction candidates with < 3 sentences, (3) **recency-exhausted words** — words
+with ≥ 3 sentences but ALL shown in the last 24h (capped at 20 per warm run). This ensures
+high-frequency reviewers always have fresh sentences available.
+(Fix: 2026-02-23 initial, 2026-02-24 raised cap 600→800, MIN_SENTENCES 2→3,
+MAX_RECENCY_EXHAUSTED 5→20, CAP_HEADROOM 30→50, cron 6h→3h)
 
 Old, low-diversity sentences are retired via `is_active=False`. The retirement script
 (`scripts/rotate_stale_sentences.py`) deactivates sentences with overexposed scaffold
@@ -1473,10 +1475,11 @@ remaining cards on the next card advance. See Section 8 "Sentence Pre-Warming" f
 
 | Constant | Value | Purpose |
 |----------|-------|---------|
-| `PIPELINE_CAP` | 600 | Max active sentences |
-| `CAP_HEADROOM` | 30 | Step 0 retires to cap minus this (→270) |
-| `MIN_SENTENCES_PER_WORD` | 2 | Target sentences per word for backfill |
-| Warm cache cap | 310 | `PIPELINE_CAP + 10` — warm cache allowed slightly over |
+| `PIPELINE_CAP` | 800 | Max active sentences |
+| `CAP_HEADROOM` | 50 | Step 0 retires to cap minus this (→750) |
+| `MIN_SENTENCES_PER_WORD` | 3 | Target sentences per word for backfill |
+| `MAX_RECENCY_EXHAUSTED` | 20 | Warm cache: max recency-exhausted words per run |
+| Warm cache cap | 810 | `PIPELINE_CAP + 10` — warm cache allowed slightly over |
 
 ---
 

--- a/research/experiment-log.md
+++ b/research/experiment-log.md
@@ -4,6 +4,46 @@ Running lab notebook for Alif's learning algorithm. Each entry documents what ch
 
 ---
 
+## 2026-02-24: Pipeline Drought Fix — Raise All Caps
+
+### Problem
+Pipeline drought recurring: sessions collapsed from 24 to 1-2 cards within a single day of heavy usage (10+ sessions). Diagnosis showed 59% of focus words (72/122) had zero eligible sentences despite 606 active sentences — the pool was at capacity but sentences clustered around well-known words, not the acquiring words that need frequent review.
+
+### Root Causes
+1. Generation rate (120/day) < consumption rate (~155/day) — net deficit ~35/day
+2. Warm cache recency cap too low (5) — only 5 exhausted words addressed per warm run, 24 were exhausted
+3. MIN_SENTENCES_PER_WORD=2 too low — acquiring words exhaust 2 sentences after a single session
+4. Pipeline cap at ceiling (606/600) — no headroom for burst generation
+
+### Changes
+| Constant | Old | New | Rationale |
+|----------|-----|-----|-----------|
+| `PIPELINE_CAP` | 600 | 800 | More headroom for high-velocity days |
+| `MIN_SENTENCES_PER_WORD` | 2 | 3 | 3 sentences per word survives 2 sessions without exhaustion |
+| `MAX_RECENCY_EXHAUSTED` | 5 | 20 | Address all exhausted words per warm run, not just 5 |
+| `CAP_HEADROOM` | 30 | 50 | Larger retirement buffer for multi-target generation |
+| Warm cache gap limit | 10 | 20 | Process more gap words per warm run |
+| Cron frequency | 6h | 3h | Double the generation rate: 240/day vs 120/day |
+
+### Files Changed
+- `backend/app/services/material_generator.py` — PIPELINE_CAP, MIN_SENTENCES_PER_WORD, MAX_RECENCY_EXHAUSTED, gap limit
+- `backend/scripts/update_material.py` — TARGET_PIPELINE_SENTENCES, MIN_SENTENCES, CAP_HEADROOM
+- Server crontab — update_material.py frequency 6h→3h
+- `docs/scheduling-system.md` — updated all constants
+
+### Expected Effect
+- Pipeline fills to ~800 sentences with 3/word coverage
+- Warm cache addresses all recency-exhausted words each run
+- Cron doubles throughput to ~240 sentences/day
+- Sessions should stay 10+ cards even on heavy days (10+ sessions/day)
+
+### Verification
+- Monitor session sizes over next 48h
+- Check `activity_log` for generation counts rising
+- Count focus words without eligible sentences (target: <20%)
+
+---
+
 ## 2026-02-23: Fill Phase Always Runs + Warm Cache Recency-Exhausted Detection
 
 ### Problem


### PR DESCRIPTION
## Summary
- Pipeline cap 600→800, MIN_SENTENCES_PER_WORD 2→3, MAX_RECENCY_EXHAUSTED 5→20
- CAP_HEADROOM 30→50, warm cache gap limit 10→20
- Cron frequency 6h→3h (server-side change after merge)

Fixes recurring pipeline drought where sessions collapsed from 24 to 1-2 cards during heavy usage days (10+ sessions). Root cause: generation rate (120/day) < consumption rate (~155/day), plus warm cache only addressing 5 exhausted words per run when 24+ were exhausted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)