### PR TITLE
Make story generation async with polling

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -216,7 +216,7 @@ class Story(Base):
     body_en = Column(Text, nullable=True)
     transliteration = Column(Text, nullable=True)
     source = Column(String(20), nullable=False)  # generated/imported/book_ocr
-    status = Column(String(20), default="active", index=True)  # active/completed/too_difficult/skipped/suspended
+    status = Column(String(20), default="active", index=True)  # active/completed/too_difficult/skipped/suspended/generating/failed
     page_count = Column(Integer, nullable=True)
     total_words = Column(Integer, default=0)
     known_count = Column(Integer, default=0)

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -1,14 +1,18 @@
 """Story generation, import, and reading API endpoints."""
 
+import logging
+
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 from sqlalchemy.orm import Session
 
-from app.database import get_db
+from app.database import SessionLocal, get_db
+from app.models import Story
 from app.schemas import (
     BookPageDetailOut,
     StoryCompleteIn,
     StoryDetailOut,
     StoryGenerateIn,
+    StoryGenerateOut,
     StoryImportIn,
     StoryLookupIn,
     StoryLookupOut,
@@ -28,31 +32,71 @@ from app.services.story_service import (
     suspend_story,
 )
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter(prefix="/api/stories", tags=["stories"])
 
 
-@router.post("/generate", response_model=StoryDetailOut)
+def _generate_story_background(
+    story_id: int,
+    difficulty: str,
+    max_sentences: int,
+    length: str,
+    topic: str | None,
+):
+    """Run story generation in background, updating the placeholder row."""
+    db = SessionLocal()
+    try:
+        story, new_lemma_ids = generate_story(
+            db,
+            difficulty=difficulty,
+            max_sentences=max_sentences,
+            length=length,
+            topic=topic,
+            existing_story_id=story_id,
+        )
+        if new_lemma_ids:
+            from app.services.lemma_enrichment import enrich_lemmas_batch
+            enrich_lemmas_batch(new_lemma_ids)
+    except Exception as e:
+        logger.exception("Background story generation failed for story %d", story_id)
+        try:
+            placeholder = db.query(Story).get(story_id)
+            if placeholder and placeholder.status == "generating":
+                placeholder.status = "failed"
+                db.commit()
+        except Exception:
+            logger.exception("Failed to mark story %d as failed", story_id)
+    finally:
+        db.close()
+
+
+@router.post("/generate", response_model=StoryGenerateOut)
 def generate_story_endpoint(
     body: StoryGenerateIn,
     background_tasks: BackgroundTasks,
     db: Session = Depends(get_db),
 ):
-    try:
-        story, new_lemma_ids = generate_story(
-            db,
-            difficulty=body.difficulty,
-            max_sentences=body.max_sentences,
-            length=body.length,
-            topic=body.topic,
-        )
-    except ValueError as e:
-        raise HTTPException(status_code=422, detail=str(e))
+    placeholder = Story(
+        body_ar="",
+        source="generated",
+        status="generating",
+        difficulty_level=body.difficulty,
+    )
+    db.add(placeholder)
+    db.commit()
+    db.refresh(placeholder)
 
-    if new_lemma_ids:
-        from app.services.lemma_enrichment import enrich_lemmas_batch
-        background_tasks.add_task(enrich_lemmas_batch, new_lemma_ids)
+    background_tasks.add_task(
+        _generate_story_background,
+        placeholder.id,
+        body.difficulty,
+        body.max_sentences,
+        body.length,
+        body.topic,
+    )
 
-    return get_story_detail(db, story.id)
+    return {"id": placeholder.id, "status": "generating"}
 
 
 @router.post("/import", response_model=StoryDetailOut)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -523,6 +523,11 @@ class StoryGenerateIn(BaseModel):
     topic: str | None = None
 
 
+class StoryGenerateOut(BaseModel):
+    id: int
+    status: str
+
+
 class StoryImportIn(BaseModel):
     arabic_text: str
     title: str | None = None

--- a/backend/app/services/story_service.py
+++ b/backend/app/services/story_service.py
@@ -47,7 +47,7 @@ KNOWN_SAMPLE_SIZE = 500
 MAX_STORY_ATTEMPTS = 1
 MAX_CORRECTION_ROUNDS = 3
 TERMINAL_STORY_STATUSES = {"completed"}
-HIDDEN_STORY_STATUSES = {"deleted"}
+HIDDEN_STORY_STATUSES = {"deleted", "failed"}
 
 STORY_SYSTEM_PROMPT = f"""\
 You are a brilliant Arabic storyteller — think Borges writing flash fiction with a \
@@ -602,11 +602,14 @@ def generate_story(
     max_sentences: int = 6,
     length: str = "medium",
     topic: str | None = None,
+    existing_story_id: int | None = None,
 ) -> tuple["Story", list[int]]:
     """Generate a story using Opus with self-correction for 100% vocabulary compliance.
 
     Strategy: generate once, then iteratively correct unknown words rather than
     regenerating the entire story from scratch.
+
+    If existing_story_id is provided, updates that row instead of creating a new one.
 
     Returns (story, new_lemma_ids).
     """
@@ -744,18 +747,30 @@ Respond with JSON: {{"title_ar": "...", "title_en": "...", "body_ar": "corrected
 
     knowledge_map = _build_knowledge_map(db)
 
-    story = Story(
-        title_ar=result.get("title_ar"),
-        title_en=result.get("title_en"),
-        body_ar=body_ar,
-        body_en=result.get("body_en"),
-        transliteration=result.get("transliteration"),
-        source="generated",
-        status="active",
-        difficulty_level=difficulty,
-    )
-    db.add(story)
-    db.flush()
+    if existing_story_id:
+        story = db.query(Story).get(existing_story_id)
+        if not story:
+            raise ValueError(f"Story placeholder {existing_story_id} not found")
+        story.title_ar = result.get("title_ar")
+        story.title_en = result.get("title_en")
+        story.body_ar = body_ar
+        story.body_en = result.get("body_en")
+        story.transliteration = result.get("transliteration")
+        story.status = "active"
+        db.flush()
+    else:
+        story = Story(
+            title_ar=result.get("title_ar"),
+            title_en=result.get("title_en"),
+            body_ar=body_ar,
+            body_en=result.get("body_en"),
+            transliteration=result.get("transliteration"),
+            source="generated",
+            status="active",
+            difficulty_level=difficulty,
+        )
+        db.add(story)
+        db.flush()
 
     total, known, func = _create_story_words(
         db, story, body_ar, lemma_lookup, knowledge_map
@@ -1176,6 +1191,25 @@ def get_story_detail(db: Session, story_id: int) -> dict:
     story = db.query(Story).filter(Story.id == story_id).first()
     if not story or story.status == "deleted":
         raise ValueError(f"Story {story_id} not found")
+
+    if story.status in ("generating", "failed"):
+        return {
+            "id": story.id,
+            "title_ar": story.title_ar,
+            "title_en": story.title_en,
+            "body_ar": story.body_ar or "",
+            "body_en": story.body_en,
+            "transliteration": story.transliteration,
+            "source": story.source,
+            "status": story.status,
+            "readiness_pct": 0,
+            "unknown_count": 0,
+            "total_words": 0,
+            "known_count": 0,
+            "page_count": None,
+            "created_at": story.created_at.isoformat() if story.created_at else "",
+            "words": [],
+        }
 
     story_lemma_ids = {sw.lemma_id for sw in story.words if sw.lemma_id}
     knowledge_map = _build_knowledge_map(db, lemma_ids=story_lemma_ids or None)

--- a/frontend/app/stories.tsx
+++ b/frontend/app/stories.tsx
@@ -18,7 +18,7 @@ import { useRouter, useFocusEffect } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
 import * as ImagePicker from "expo-image-picker";
 import { colors, fonts, fontFamily } from "../lib/theme";
-import { getStories, generateStory, importStory, deleteStory, suspendStory, prefetchStoryDetails, extractTextFromImage } from "../lib/api";
+import { getStories, generateStory, getStoryDetail, importStory, deleteStory, suspendStory, prefetchStoryDetails, extractTextFromImage } from "../lib/api";
 import { clearStoryLookups } from "../lib/offline-store";
 import { netStatus } from "../lib/net-status";
 import { StoryListItem } from "../lib/types";
@@ -81,16 +81,40 @@ export default function StoriesScreen() {
     setShowGenerate(false);
     setGenerating(true);
     try {
-      const story = await generateStory({
+      const { id } = await generateStory({
         length: genLength,
         topic: genTopic.trim() || undefined,
       });
       setGenTopic("");
       setGenLength("medium");
-      router.push(`/story/${story.id}`);
+
+      // Poll until story is ready (timeout after 5 min)
+      let elapsed = 0;
+      const poll = setInterval(async () => {
+        elapsed += 2000;
+        if (elapsed > 300_000) {
+          clearInterval(poll);
+          setGenerating(false);
+          Alert.alert("Story generation timed out", "Check the stories list — it may still appear.");
+          return;
+        }
+        try {
+          const detail = await getStoryDetail(id);
+          if (detail.status !== "generating") {
+            clearInterval(poll);
+            setGenerating(false);
+            if (detail.status === "failed") {
+              Alert.alert("Story generation failed", "Please try again.");
+            } else {
+              router.push(`/story/${id}`);
+            }
+          }
+        } catch {
+          // Story detail may 404 briefly, keep polling
+        }
+      }, 2000);
     } catch (e) {
       console.error("Failed to generate story:", e);
-    } finally {
       setGenerating(false);
     }
   }

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -590,8 +590,8 @@ export async function generateStory(opts?: {
   difficulty?: string;
   length?: string;
   topic?: string;
-}): Promise<StoryDetail> {
-  return fetchApi<StoryDetail>("/api/stories/generate", {
+}): Promise<{ id: number; status: string }> {
+  return fetchApi<{ id: number; status: string }>("/api/stories/generate", {
     method: "POST",
     body: JSON.stringify({
       difficulty: opts?.difficulty || "beginner",

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -588,7 +588,7 @@ export interface StoryListItem {
   title_ar: string | null;
   title_en: string | null;
   source: "generated" | "imported" | "book_ocr";
-  status: "active" | "completed" | "suspended";
+  status: "active" | "completed" | "suspended" | "generating" | "failed";
   readiness_pct: number;
   unknown_count: number;
   total_words: number;


### PR DESCRIPTION
## Summary
- Story generation (Opus + up to 3 correction rounds) takes 30-150s, causing HTTP timeouts on iPhone
- POST `/api/stories/generate` now returns immediately with `{id, status: "generating"}`
- Generation runs in FastAPI BackgroundTasks, updating the placeholder Story row when done
- Frontend polls `GET /api/stories/{id}` every 2s until status transitions to `active` or `failed`
- 5-minute client-side timeout safety net

Generated with [Claude Code](https://claude.com/claude-code)