### PR TITLE
Add due-date-tiered sentence pipeline allocation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ npx expo start --web  # opens on localhost:8081
 - **Tapped words are always marked missed** — front-phase tapping auto-marks as missed (rating≤2).
 - **al-prefix is NOT a separate lemma** — الكلب and كلب are the same lemma. All import paths dedup.
 - **Be conservative with ElevenLabs TTS** — costs real money. Only generate for sentences that will be shown.
-- **Sentence pipeline cap**: 800 active sentences. Cron runs `rotate_stale_sentences.py` then `update_material.py` every 3h. `warm_sentence_cache()` also runs after every session load and detects recency-exhausted words (≥3 sentences but all shown <24h, generates fresh ones, max 20/run).
+- **Sentence pipeline cap**: 800 active sentences with **due-date tiered allocation** (`pipeline_tiers.py`). Words due within 12h get 3 sentences (floor 2), 12-36h get 2 (floor 1), 36-72h get 1 (floor 0), 72h+ get 0 (JIT fills when due). This prevents large imports from permanently filling the pool. Cron runs `update_material.py` every 3h. `warm_sentence_cache()` runs after every session load (tier-aware gap detection + recency-exhausted, max 20/run).
 - **Canonical lemma is the unit of scheduling** — variant forms tracked via `variant_stats_json` but never get independent FSRS cards.
 - **All import paths must run variant detection** — `detect_variants_llm()` + `detect_definite_variants()` + `mark_variants()` post-import.
 - **All import paths must run quality gate** — `import_quality.classify_lemmas()` filters junk, classifies standard/proper_name/onomatopoeia.

--- a/backend/app/services/material_generator.py
+++ b/backend/app/services/material_generator.py
@@ -361,12 +361,18 @@ MIN_SENTENCES_PER_WORD = 3
 PIPELINE_CAP = 800
 
 
-def rotate_stale_sentences(db, min_shown: int = 1, min_active: int = 2) -> int:
+def rotate_stale_sentences(db, min_shown: int = 1, min_active: int = 2, tier_lookup: dict | None = None) -> int:
     """Retire stale sentences where all scaffold words are fully known.
 
+    Uses due-date tiers: sentences for soon-due words get higher floor protection.
     Returns the number of sentences retired.
     """
     from scripts.rotate_stale_sentences import compute_diversity_score
+
+    if tier_lookup is None:
+        from app.services.pipeline_tiers import compute_word_tiers, build_tier_lookup
+        word_tiers = compute_word_tiers(db)
+        tier_lookup = build_tier_lookup(word_tiers)
 
     sentences = db.query(Sentence).filter(Sentence.is_active == True).all()  # noqa: E712
     all_sw = db.query(SentenceWord).all()
@@ -403,7 +409,9 @@ def rotate_stale_sentences(db, min_shown: int = 1, min_active: int = 2) -> int:
         target_id = sent.target_lemma_id
         already_retiring = retire_per_target.get(target_id, 0)
         active = active_per_target.get(target_id, 0)
-        if active - already_retiring > min_active:
+        wt = tier_lookup.get(target_id) if target_id else None
+        effective_floor = max(min_active, wt.cap_floor if wt else 0)
+        if active - already_retiring > effective_floor:
             sent.is_active = False
             retire_per_target[target_id] = already_retiring + 1
             retired += 1
@@ -455,6 +463,11 @@ def warm_sentence_cache(llm_model: str = "gemini") -> dict:
     # ── Phase 1: DB read ──
     db = SessionLocal()
     try:
+        # Compute due-date tiers for tier-aware decisions
+        from app.services.pipeline_tiers import compute_word_tiers, build_tier_lookup
+        word_tiers = compute_word_tiers(db)
+        tier_lookup = build_tier_lookup(word_tiers)
+
         # Check pipeline cap — rotate stale sentences first to make room
         total_active = (
             db.query(func.count(Sentence.id))
@@ -462,7 +475,7 @@ def warm_sentence_cache(llm_model: str = "gemini") -> dict:
             .scalar() or 0
         )
         if total_active >= PIPELINE_CAP:
-            rotated = rotate_stale_sentences(db)
+            rotated = rotate_stale_sentences(db, tier_lookup=tier_lookup)
             stats["rotated"] = rotated
             total_active -= rotated
 
@@ -473,7 +486,7 @@ def warm_sentence_cache(llm_model: str = "gemini") -> dict:
         # Collect all words needing sentences
         gap_word_ids: list[int] = []
 
-        # 1. Focus cohort words with < 2 active sentences
+        # 1. Focus cohort words below their tier-based sentence target
         cohort = get_focus_cohort(db)
         if cohort:
             sentence_counts = dict(
@@ -485,11 +498,16 @@ def warm_sentence_cache(llm_model: str = "gemini") -> dict:
                 .group_by(Sentence.target_lemma_id)
                 .all()
             )
-            gaps = [lid for lid in cohort if sentence_counts.get(lid, 0) < MIN_SENTENCES_PER_WORD]
+            gaps = []
+            for lid in cohort:
+                wt = tier_lookup.get(lid)
+                target = wt.backfill_target if wt else MIN_SENTENCES_PER_WORD
+                if target > 0 and sentence_counts.get(lid, 0) < target:
+                    gaps.append(lid)
             stats["cohort_gaps"] = len(gaps)
             gap_word_ids.extend(gaps[:20])
 
-        # 2. Likely auto-introduction candidates
+        # 2. Likely auto-introduction candidates (not yet in tier system, use default)
         active_topic = ensure_active_topic(db)
         candidates = select_next_words(db, count=5, domain=active_topic)
         for cand in candidates:
@@ -505,8 +523,7 @@ def warm_sentence_cache(llm_model: str = "gemini") -> dict:
                 gap_word_ids.append(lid)
                 stats["intro_gaps"] = stats.get("intro_gaps", 0) + 1
 
-        # 3. Recency-exhausted words: have ≥2 sentences but ALL shown in last 24h
-        #    Generate an extra sentence so the next session has a fresh one available
+        # 3. Recency-exhausted words: have enough sentences but ALL shown in last 24h
         from sqlalchemy import or_
         now = datetime.now(timezone.utc)
         recency_cutoff = now - timedelta(days=1)
@@ -520,8 +537,10 @@ def warm_sentence_cache(llm_model: str = "gemini") -> dict:
                 if recency_exhausted_count >= MAX_RECENCY_EXHAUSTED:
                     break
                 active_count = sentence_counts.get(lid, 0)
-                if active_count < MIN_SENTENCES_PER_WORD:
-                    continue
+                wt = tier_lookup.get(lid)
+                target = wt.backfill_target if wt else MIN_SENTENCES_PER_WORD
+                if active_count < target:
+                    continue  # already a gap word, handled above
                 fresh_count = (
                     db.query(func.count(Sentence.id))
                     .filter(
@@ -540,6 +559,12 @@ def warm_sentence_cache(llm_model: str = "gemini") -> dict:
             if recency_exhausted_count:
                 stats["recency_exhausted"] = recency_exhausted_count
                 logger.info(f"Warm cache: {recency_exhausted_count} recency-exhausted words need fresh sentences")
+
+        # Sort gap words by tier urgency (most urgent first)
+        gap_word_ids.sort(key=lambda lid: (
+            tier_lookup[lid].tier if lid in tier_lookup else 4,
+            tier_lookup[lid].due_dt or datetime.max.replace(tzinfo=timezone.utc) if lid in tier_lookup else datetime.max.replace(tzinfo=timezone.utc),
+        ))
 
         if not gap_word_ids:
             logger.info(f"Warm cache: no gaps found")

--- a/backend/app/services/pipeline_tiers.py
+++ b/backend/app/services/pipeline_tiers.py
@@ -1,0 +1,158 @@
+"""Due-date tiered sentence pipeline allocation.
+
+Assigns words to urgency tiers based on when they're next due for review.
+Used by both the cron backfill (update_material.py) and the warm cache
+(material_generator.py) to allocate sentence pipeline slots proportionally
+to actual review demand instead of treating all words equally.
+"""
+
+import json as _json
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from app.models import UserLemmaKnowledge
+
+
+@dataclass
+class TierConfig:
+    """Configuration for a single due-date tier."""
+
+    tier: int
+    max_hours: Optional[float]  # None = unbounded (tier 4)
+    backfill_target: int  # sentences to generate per word
+    cap_floor: int  # minimum sentences to protect during cap enforcement
+
+
+# Tier boundaries chosen so cron (every 3h) has multiple cycles to fill tier 3
+# before words become tier 2, and tier 2 before they become tier 1.
+TIER_CONFIGS = [
+    TierConfig(tier=1, max_hours=12, backfill_target=3, cap_floor=2),
+    TierConfig(tier=2, max_hours=36, backfill_target=2, cap_floor=1),
+    TierConfig(tier=3, max_hours=72, backfill_target=1, cap_floor=0),
+    TierConfig(tier=4, max_hours=None, backfill_target=0, cap_floor=0),
+]
+
+DEFAULT_TIER = TIER_CONFIGS[-1]
+
+
+@dataclass
+class WordTier:
+    """A word with its computed tier assignment."""
+
+    lemma_id: int
+    due_dt: Optional[datetime]
+    tier: int
+    backfill_target: int
+    cap_floor: int
+
+
+def compute_word_tiers(
+    db: Session,
+    now: Optional[datetime] = None,
+) -> list[WordTier]:
+    """Compute due-date tiers for all active (non-suspended, non-encountered) words.
+
+    Returns a list of WordTier sorted by due date (most urgent first).
+    Words with no computable due date are assigned tier 4.
+    """
+    if now is None:
+        now = datetime.now(timezone.utc)
+
+    knowledges = (
+        db.query(UserLemmaKnowledge)
+        .filter(
+            UserLemmaKnowledge.knowledge_state.notin_(["suspended", "encountered"]),
+        )
+        .all()
+    )
+
+    results: list[WordTier] = []
+    for k in knowledges:
+        due_dt = _extract_due_datetime(k)
+        tier_config = _classify_tier(due_dt, now)
+        results.append(
+            WordTier(
+                lemma_id=k.lemma_id,
+                due_dt=due_dt,
+                tier=tier_config.tier,
+                backfill_target=tier_config.backfill_target,
+                cap_floor=tier_config.cap_floor,
+            )
+        )
+
+    results.sort(key=lambda w: (w.due_dt or datetime.max.replace(tzinfo=timezone.utc)))
+    return results
+
+
+def build_tier_lookup(word_tiers: list[WordTier]) -> dict[int, WordTier]:
+    """Build a lemma_id -> WordTier dict for O(1) lookups."""
+    return {wt.lemma_id: wt for wt in word_tiers}
+
+
+def tier_summary(word_tiers: list[WordTier]) -> dict[int, int]:
+    """Count words per tier for logging."""
+    counts: dict[int, int] = {1: 0, 2: 0, 3: 0, 4: 0}
+    for wt in word_tiers:
+        counts[wt.tier] = counts.get(wt.tier, 0) + 1
+    return counts
+
+
+def _extract_due_datetime(k: UserLemmaKnowledge) -> Optional[datetime]:
+    """Extract the due datetime from a ULK record, handling both
+    acquisition and FSRS states. Returns timezone-aware UTC datetime."""
+    if k.knowledge_state == "acquiring":
+        if k.acquisition_next_due:
+            due_dt = k.acquisition_next_due
+            if due_dt.tzinfo is None:
+                due_dt = due_dt.replace(tzinfo=timezone.utc)
+            return due_dt
+        return None
+
+    if not k.fsrs_card_json:
+        return None
+
+    try:
+        card = (
+            k.fsrs_card_json
+            if isinstance(k.fsrs_card_json, dict)
+            else _json.loads(k.fsrs_card_json)
+        )
+    except (TypeError, ValueError):
+        return None
+
+    due_str = card.get("due", "")
+    if not due_str:
+        return None
+
+    try:
+        due_dt = datetime.fromisoformat(due_str.replace("Z", "+00:00"))
+        if due_dt.tzinfo is None:
+            due_dt = due_dt.replace(tzinfo=timezone.utc)
+        return due_dt
+    except (ValueError, TypeError):
+        return None
+
+
+def _classify_tier(
+    due_dt: Optional[datetime],
+    now: datetime,
+) -> TierConfig:
+    """Classify a word into a tier based on its due datetime."""
+    if due_dt is None:
+        return DEFAULT_TIER
+
+    hours_until_due = (due_dt - now).total_seconds() / 3600
+    # Overdue words (negative hours) always go to tier 1
+    if hours_until_due <= 0:
+        return TIER_CONFIGS[0]
+
+    for config in TIER_CONFIGS:
+        if config.max_hours is None:
+            return config
+        if hours_until_due <= config.max_hours:
+            return config
+
+    return DEFAULT_TIER

--- a/backend/scripts/rotate_stale_sentences.py
+++ b/backend/scripts/rotate_stale_sentences.py
@@ -100,6 +100,10 @@ def main():
     db = SessionLocal()
 
     try:
+        from app.services.pipeline_tiers import compute_word_tiers, build_tier_lookup
+        word_tiers = compute_word_tiers(db)
+        tier_lookup = build_tier_lookup(word_tiers)
+
         sentences = db.query(Sentence).filter(Sentence.is_active == True).all()  # noqa: E712
         all_sw = db.query(SentenceWord).all()
         all_ulk = db.query(UserLemmaKnowledge).all()
@@ -142,14 +146,16 @@ def main():
         # Sort by lowest diversity (least useful sentences first)
         stale.sort(key=lambda x: (x[1]["diversity_score"], -x[1]["scaffold_count"]))
 
-        # Enforce min_active constraint
+        # Enforce min_active constraint (tier-aware: soon-due words get higher floor)
         retire_per_target: dict[int | None, int] = {}
         final_retire: list[tuple[Sentence, dict]] = []
         for sent, scores in stale:
             target_id = sent.target_lemma_id
             already_retiring = retire_per_target.get(target_id, 0)
             active = active_per_target.get(target_id, 0)
-            if active - already_retiring > args.min_active:
+            wt = tier_lookup.get(target_id) if target_id else None
+            effective_floor = max(args.min_active, wt.cap_floor if wt else 0)
+            if active - already_retiring > effective_floor:
                 final_retire.append((sent, scores))
                 retire_per_target[target_id] = already_retiring + 1
 

--- a/backend/scripts/update_material.py
+++ b/backend/scripts/update_material.py
@@ -61,10 +61,9 @@ from app.services.tts import (
     get_cached_path,
 )
 
-MIN_SENTENCES = 3  # per-word target for backfill generation
-MIN_SENTENCES_CAP_ENFORCEMENT = 1  # per-word floor during cap enforcement (JIT handles gaps)
 TARGET_PIPELINE_SENTENCES = 800  # hard cap — JIT generation fills gaps with current vocabulary
 CAP_HEADROOM = 50  # retire this many below cap to leave room for multi-target backfill
+PREGEN_SENTENCES_PER_CANDIDATE = 3  # for step C pre-generation of not-yet-introduced words
 
 
 def get_existing_counts(db: Session) -> dict[int, int]:
@@ -262,16 +261,27 @@ def generate_sentences_for_word(
 
 # ── Step 0: Enforce sentence cap by retiring excess ──────────────────
 
-def step_enforce_cap(db: Session, dry_run: bool, max_sentences: int = TARGET_PIPELINE_SENTENCES) -> int:
+def step_enforce_cap(
+    db: Session,
+    dry_run: bool,
+    max_sentences: int = TARGET_PIPELINE_SENTENCES,
+    tier_lookup: dict | None = None,
+) -> int:
     """Retire excess sentences when over the pipeline cap.
 
     Retirement priority:
       1. Never-shown sentences (times_shown=0) — stale first (no acquiring scaffold)
       2. Shown stale sentences (no acquiring/learning scaffold words)
       3. Oldest by last_reading_shown_at as final tiebreaker
-    Always keeps at least MIN_SENTENCES active per target word.
+    Floor per word is due-date-tier-aware: tier 1 (due <12h) keeps 2,
+    tier 2 (12-36h) keeps 1, tier 3+ keeps 0.
     """
     import json
+
+    if tier_lookup is None:
+        from app.services.pipeline_tiers import compute_word_tiers, build_tier_lookup
+        word_tiers = compute_word_tiers(db)
+        tier_lookup = build_tier_lookup(word_tiers)
 
     existing_counts = get_existing_counts(db)
     total_active = sum(existing_counts.values())
@@ -351,7 +361,9 @@ def step_enforce_cap(db: Session, dry_run: bool, max_sentences: int = TARGET_PIP
         target_id = sent.target_lemma_id
         already_retiring = retire_count_per_target.get(target_id, 0)
         active = existing_counts.get(target_id, 0) if target_id else orphan_count
-        if active - already_retiring <= MIN_SENTENCES_CAP_ENFORCEMENT:
+        wt = tier_lookup.get(target_id) if target_id else None
+        floor = wt.cap_floor if wt else 0
+        if active - already_retiring <= floor:
             continue
 
         if not dry_run:
@@ -377,14 +389,24 @@ def step_enforce_cap(db: Session, dry_run: bool, max_sentences: int = TARGET_PIP
 def step_backfill_sentences(
     db: Session, dry_run: bool, model: str, delay: float,
     max_sentences: int = TARGET_PIPELINE_SENTENCES,
+    tier_lookup: dict | None = None,
 ) -> int:
     print("\n═══ Step A: Backfill sentences (due-date priority) ═══")
 
-    # Get words sorted by due date (most urgent first)
-    due_order = get_words_by_due_date(db)
-    if not due_order:
-        print("  No introduced words found.")
-        return 0
+    # Compute tiers if not provided
+    if tier_lookup is None:
+        from app.services.pipeline_tiers import compute_word_tiers, build_tier_lookup
+        word_tiers = compute_word_tiers(db)
+        tier_lookup = build_tier_lookup(word_tiers)
+    else:
+        word_tiers = sorted(
+            tier_lookup.values(),
+            key=lambda w: (w.due_dt or datetime.max.replace(tzinfo=timezone.utc)),
+        )
+
+    from app.services.pipeline_tiers import tier_summary
+    ts = tier_summary(word_tiers)
+    print(f"  Tier distribution: T1={ts.get(1, 0)} T2={ts.get(2, 0)} T3={ts.get(3, 0)} T4={ts.get(4, 0)}")
 
     existing_counts = get_existing_counts(db)
     total_active = sum(existing_counts.values())
@@ -397,31 +419,36 @@ def step_backfill_sentences(
 
     budget = max_sentences - total_active
     print(f"  Budget: {budget} sentences to generate")
-    print(f"  Words ordered by due date: {len(due_order)} total")
 
     known_words, lemma_lookup = get_known_words_and_lookup(db)
     content_word_counts = get_content_word_counts(db)
     avoid_words = get_avoid_words(content_word_counts, known_words)
 
-    # Collect words needing sentences
+    # Collect words needing sentences — tier-based targets
     words_needing: list[dict] = []
-    for lemma_id, due_str in due_order:
-        existing = existing_counts.get(lemma_id, 0)
-        needed = MIN_SENTENCES - existing
+    for wt in word_tiers:
+        if wt.backfill_target <= 0:
+            continue  # tier 4: skip, JIT fills when needed
+        existing = existing_counts.get(wt.lemma_id, 0)
+        needed = wt.backfill_target - existing
         if needed <= 0:
             continue
-        lemma = db.query(Lemma).filter(Lemma.lemma_id == lemma_id).first()
+        lemma = db.query(Lemma).filter(Lemma.lemma_id == wt.lemma_id).first()
         if not lemma:
             continue
         words_needing.append({
-            "lemma_id": lemma_id,
+            "lemma_id": wt.lemma_id,
             "lemma_ar": lemma.lemma_ar,
             "gloss_en": lemma.gloss_en or "",
             "root_id": lemma.root_id,
-            "due_str": due_str,
+            "due_str": wt.due_dt.isoformat() if wt.due_dt else "none",
             "existing": existing,
             "needed": min(needed, budget),
+            "tier": wt.tier,
+            "backfill_target": wt.backfill_target,
         })
+
+    print(f"  Words needing sentences: {len(words_needing)} (of {len(word_tiers)} total)")
 
     total = 0
     words_processed = 0
@@ -484,7 +511,7 @@ def step_backfill_sentences(
 
         lemma_id = w["lemma_id"]
         existing = existing_counts.get(lemma_id, 0)
-        needed = MIN_SENTENCES - existing
+        needed = w["backfill_target"] - existing
         if needed <= 0:
             continue
 
@@ -659,7 +686,7 @@ def step_pregenerate_candidates(db: Session, dry_run: bool, count: int, model: s
             break
         lid = cand["lemma_id"]
         existing = existing_counts.get(lid, 0)
-        needed = MIN_SENTENCES - existing
+        needed = PREGEN_SENTENCES_PER_CANDIDATE - existing
         if needed <= 0:
             continue
 
@@ -744,9 +771,15 @@ async def main():
 
     db = SessionLocal()
     try:
-        retired_0 = step_enforce_cap(db, args.dry_run, args.max_sentences)
+        from app.services.pipeline_tiers import compute_word_tiers, build_tier_lookup, tier_summary
+        word_tiers = compute_word_tiers(db)
+        tier_lk = build_tier_lookup(word_tiers)
+        ts = tier_summary(word_tiers)
+        print(f"\n  Word tiers: T1={ts.get(1, 0)} T2={ts.get(2, 0)} T3={ts.get(3, 0)} T4={ts.get(4, 0)}")
 
-        sent_a = step_backfill_sentences(db, args.dry_run, args.model, args.delay, args.max_sentences)
+        retired_0 = step_enforce_cap(db, args.dry_run, args.max_sentences, tier_lookup=tier_lk)
+
+        sent_a = step_backfill_sentences(db, args.dry_run, args.model, args.delay, args.max_sentences, tier_lookup=tier_lk)
 
         if not args.skip_audio:
             audio_b = await step_generate_audio(db, args.dry_run, args.limit)

--- a/backend/tests/test_pipeline_tiers.py
+++ b/backend/tests/test_pipeline_tiers.py
@@ -1,0 +1,186 @@
+"""Tests for the due-date-tiered sentence pipeline allocation."""
+
+import json
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.services.pipeline_tiers import (
+    DEFAULT_TIER,
+    TIER_CONFIGS,
+    WordTier,
+    _classify_tier,
+    _extract_due_datetime,
+    build_tier_lookup,
+    compute_word_tiers,
+    tier_summary,
+)
+
+
+NOW = datetime(2026, 3, 3, 12, 0, 0, tzinfo=timezone.utc)
+
+
+class TestClassifyTier:
+    def test_overdue_is_tier_1(self):
+        due = NOW - timedelta(hours=5)
+        result = _classify_tier(due, NOW)
+        assert result.tier == 1
+        assert result.backfill_target == 3
+        assert result.cap_floor == 2
+
+    def test_due_now_is_tier_1(self):
+        result = _classify_tier(NOW, NOW)
+        assert result.tier == 1
+
+    def test_due_in_6h_is_tier_1(self):
+        due = NOW + timedelta(hours=6)
+        result = _classify_tier(due, NOW)
+        assert result.tier == 1
+
+    def test_due_in_12h_is_tier_1(self):
+        due = NOW + timedelta(hours=12)
+        result = _classify_tier(due, NOW)
+        assert result.tier == 1
+
+    def test_due_in_13h_is_tier_2(self):
+        due = NOW + timedelta(hours=13)
+        result = _classify_tier(due, NOW)
+        assert result.tier == 2
+        assert result.backfill_target == 2
+        assert result.cap_floor == 1
+
+    def test_due_in_36h_is_tier_2(self):
+        due = NOW + timedelta(hours=36)
+        result = _classify_tier(due, NOW)
+        assert result.tier == 2
+
+    def test_due_in_37h_is_tier_3(self):
+        due = NOW + timedelta(hours=37)
+        result = _classify_tier(due, NOW)
+        assert result.tier == 3
+        assert result.backfill_target == 1
+        assert result.cap_floor == 0
+
+    def test_due_in_72h_is_tier_3(self):
+        due = NOW + timedelta(hours=72)
+        result = _classify_tier(due, NOW)
+        assert result.tier == 3
+
+    def test_due_in_73h_is_tier_4(self):
+        due = NOW + timedelta(hours=73)
+        result = _classify_tier(due, NOW)
+        assert result.tier == 4
+        assert result.backfill_target == 0
+        assert result.cap_floor == 0
+
+    def test_due_in_2_weeks_is_tier_4(self):
+        due = NOW + timedelta(days=14)
+        result = _classify_tier(due, NOW)
+        assert result.tier == 4
+
+    def test_none_due_is_tier_4(self):
+        result = _classify_tier(None, NOW)
+        assert result.tier == 4
+        assert result == DEFAULT_TIER
+
+
+class TestExtractDueDatetime:
+    def _make_ulk(self, state, acq_due=None, fsrs_json=None):
+        ulk = MagicMock()
+        ulk.knowledge_state = state
+        ulk.acquisition_next_due = acq_due
+        ulk.fsrs_card_json = fsrs_json
+        return ulk
+
+    def test_acquiring_with_due(self):
+        due = datetime(2026, 3, 3, 14, 0, 0, tzinfo=timezone.utc)
+        ulk = self._make_ulk("acquiring", acq_due=due)
+        assert _extract_due_datetime(ulk) == due
+
+    def test_acquiring_naive_datetime(self):
+        due = datetime(2026, 3, 3, 14, 0, 0)  # naive
+        ulk = self._make_ulk("acquiring", acq_due=due)
+        result = _extract_due_datetime(ulk)
+        assert result.tzinfo == timezone.utc
+        assert result == due.replace(tzinfo=timezone.utc)
+
+    def test_acquiring_no_due(self):
+        ulk = self._make_ulk("acquiring", acq_due=None)
+        assert _extract_due_datetime(ulk) is None
+
+    def test_fsrs_with_due_string(self):
+        card = {"due": "2026-03-05T10:00:00+00:00", "stability": 5.0}
+        ulk = self._make_ulk("known", fsrs_json=card)
+        result = _extract_due_datetime(ulk)
+        assert result == datetime(2026, 3, 5, 10, 0, 0, tzinfo=timezone.utc)
+
+    def test_fsrs_with_z_suffix(self):
+        card = {"due": "2026-03-05T10:00:00Z", "stability": 5.0}
+        ulk = self._make_ulk("learning", fsrs_json=card)
+        result = _extract_due_datetime(ulk)
+        assert result == datetime(2026, 3, 5, 10, 0, 0, tzinfo=timezone.utc)
+
+    def test_fsrs_json_string(self):
+        card_str = json.dumps({"due": "2026-03-05T10:00:00+00:00", "stability": 5.0})
+        ulk = self._make_ulk("known", fsrs_json=card_str)
+        result = _extract_due_datetime(ulk)
+        assert result == datetime(2026, 3, 5, 10, 0, 0, tzinfo=timezone.utc)
+
+    def test_fsrs_no_card(self):
+        ulk = self._make_ulk("known", fsrs_json=None)
+        assert _extract_due_datetime(ulk) is None
+
+    def test_fsrs_corrupted_json(self):
+        ulk = self._make_ulk("known", fsrs_json="not json")
+        assert _extract_due_datetime(ulk) is None
+
+    def test_fsrs_empty_due(self):
+        card = {"stability": 5.0}
+        ulk = self._make_ulk("known", fsrs_json=card)
+        assert _extract_due_datetime(ulk) is None
+
+
+class TestBuildTierLookup:
+    def test_lookup(self):
+        tiers = [
+            WordTier(lemma_id=1, due_dt=NOW, tier=1, backfill_target=3, cap_floor=2),
+            WordTier(lemma_id=2, due_dt=NOW + timedelta(days=1), tier=2, backfill_target=2, cap_floor=1),
+        ]
+        lookup = build_tier_lookup(tiers)
+        assert lookup[1].tier == 1
+        assert lookup[2].tier == 2
+        assert 3 not in lookup
+
+
+class TestTierSummary:
+    def test_summary_counts(self):
+        tiers = [
+            WordTier(lemma_id=1, due_dt=NOW, tier=1, backfill_target=3, cap_floor=2),
+            WordTier(lemma_id=2, due_dt=NOW, tier=1, backfill_target=3, cap_floor=2),
+            WordTier(lemma_id=3, due_dt=NOW + timedelta(hours=20), tier=2, backfill_target=2, cap_floor=1),
+            WordTier(lemma_id=4, due_dt=NOW + timedelta(days=10), tier=4, backfill_target=0, cap_floor=0),
+        ]
+        result = tier_summary(tiers)
+        assert result == {1: 2, 2: 1, 3: 0, 4: 1}
+
+
+class TestTierConfigs:
+    def test_tiers_are_ordered(self):
+        for i, config in enumerate(TIER_CONFIGS):
+            assert config.tier == i + 1
+
+    def test_tier_1_most_generous(self):
+        assert TIER_CONFIGS[0].backfill_target == 3
+        assert TIER_CONFIGS[0].cap_floor == 2
+
+    def test_tier_4_zero(self):
+        assert TIER_CONFIGS[3].backfill_target == 0
+        assert TIER_CONFIGS[3].cap_floor == 0
+
+    def test_tier_boundaries_ascending(self):
+        prev = 0
+        for config in TIER_CONFIGS:
+            if config.max_hours is not None:
+                assert config.max_hours > prev
+                prev = config.max_hours

--- a/docs/scheduling-system.md
+++ b/docs/scheduling-system.md
@@ -1047,26 +1047,38 @@ Rule-based validation pipeline:
 4. Match against known forms (lemma_ar_bare + forms_json entries)
 5. ~80 function words (from `FUNCTION_WORD_GLOSSES`) treated as always-known
 
-### Pipeline Cap & Retirement
+### Pipeline Cap & Due-Date Tiered Allocation
+
+**Due-date tiers** (`app/services/pipeline_tiers.py`): Instead of flat per-word sentence
+targets, words are classified into urgency tiers based on when they're next due:
+
+| Tier | Due within | Backfill target | Cap floor | Rationale |
+|------|-----------|-----------------|-----------|-----------|
+| 1 | 12h (or overdue) | 3 | 2 | Today's sessions |
+| 2 | 12-36h | 2 | 1 | Tomorrow's sessions |
+| 3 | 36-72h | 1 | 0 | Cron fills before due |
+| 4 | 72h+ / unknown | 0 | 0 | JIT fills when needed |
+
+This prevents large word imports from permanently filling the pool. With 295 acquiring
+words, only ~200 are due within 12h (tier 1), requiring ~600 sentences — well within
+the 800 cap. Far-out words get 0 pre-generated sentences; JIT handles gaps.
 
 **Cap enforcement** (`update_material.py` Step 0): Hard cap of 800 active sentences.
 Step 0 retires down to `800 - CAP_HEADROOM` (750) to leave budget for multi-target
-backfill in Step A. Retirement priority: never-shown stale → shown stale → oldest,
-always keeping at least 1 sentence per word.
+backfill in Step A. Retirement priority: never-shown stale → shown stale → oldest.
+Floor per word is tier-based: tier 1 keeps at least 2, tier 2 keeps 1, tier 3-4 can
+drop to 0.
 
-**Warm cache** (`warm_sentence_cache()`) now rotates stale sentences before checking
-the cap, so it can free space even when over the limit. After rotation, it allows up to
-`PIPELINE_CAP + 10` (810) before skipping generation. The warm cache identifies three
-types of gap words: (1) focus cohort words with < 3 active sentences, (2) likely
-auto-introduction candidates with < 3 sentences, (3) **recency-exhausted words** — words
-with ≥ 3 sentences but ALL shown in the last 24h (capped at 20 per warm run). This ensures
-high-frequency reviewers always have fresh sentences available.
-(Fix: 2026-02-23 initial, 2026-02-24 raised cap 600→800, MIN_SENTENCES 2→3,
-MAX_RECENCY_EXHAUSTED 5→20, CAP_HEADROOM 30→50, cron 6h→3h)
+**Warm cache** (`warm_sentence_cache()`) computes tiers on every run. Rotates stale
+sentences (tier-aware floors) before checking the cap. After rotation, allows up to
+`PIPELINE_CAP + 10` (810) before skipping generation. Gap detection uses tier-based
+targets instead of flat MIN_SENTENCES_PER_WORD. Gap words sorted by tier urgency so
+the MAX_RECENCY_EXHAUSTED (20) budget goes to most urgent words first.
+(Evolution: 2026-02-23 initial, 2026-02-24 raised cap 600→800, 2026-03-03 tiered allocation)
 
 Old, low-diversity sentences are retired via `is_active=False`. The retirement script
 (`scripts/rotate_stale_sentences.py`) deactivates sentences with overexposed scaffold
-words (all scaffold words fully known, no cross-training value).
+words (all scaffold words fully known, no cross-training value). Floor is tier-aware.
 
 ---
 
@@ -1471,15 +1483,20 @@ remaining cards on the next card advance. See Section 8 "Sentence Pre-Warming" f
 | S₀(Easy) | ~8.3d | Initial stability for "Easy" (root-boost graduation) |
 | Stability floor | 1.0d | Below this, "known" → "lapsed" |
 
-### Sentence Pipeline (`update_material.py`, `material_generator.py`)
+### Sentence Pipeline (`update_material.py`, `material_generator.py`, `pipeline_tiers.py`)
 
 | Constant | Value | Purpose |
 |----------|-------|---------|
 | `PIPELINE_CAP` | 800 | Max active sentences |
 | `CAP_HEADROOM` | 50 | Step 0 retires to cap minus this (→750) |
-| `MIN_SENTENCES_PER_WORD` | 3 | Target sentences per word for backfill |
+| `MIN_SENTENCES_PER_WORD` | 3 | Fallback target for JIT/intro (words not yet in tier system) |
+| `PREGEN_SENTENCES_PER_CANDIDATE` | 3 | Step C pre-generation for not-yet-introduced words |
 | `MAX_RECENCY_EXHAUSTED` | 20 | Warm cache: max recency-exhausted words per run |
 | Warm cache cap | 810 | `PIPELINE_CAP + 10` — warm cache allowed slightly over |
+| Tier 1 boundary | 12h | Due within 12h: target 3, floor 2 |
+| Tier 2 boundary | 36h | Due within 36h: target 2, floor 1 |
+| Tier 3 boundary | 72h | Due within 72h: target 1, floor 0 |
+| Tier 4 | 72h+ | No pre-generation, JIT fills when needed |
 
 ---
 

--- a/research/experiment-log.md
+++ b/research/experiment-log.md
@@ -4,6 +4,37 @@ Running lab notebook for Alif's learning algorithm. Each entry documents what ch
 
 ---
 
+## 2026-03-03: Due-Date-Tiered Sentence Pipeline
+
+### Problem
+The sentence pool cap (800) keeps filling up with large word imports. We've raised it multiple times — the root cause is that the pipeline treats all words equally regardless of when they're due. With 295 acquiring words, it tries to maintain 3 sentences each (885 > 800 cap). Cap enforcement has a flat floor of 1 per word, locking 295 slots even for words not due for days.
+
+### Change
+Replace flat per-word targets with due-date tiers:
+- **Tier 1** (due within 12h or overdue): 3 sentences, floor 2
+- **Tier 2** (12-36h): 2 sentences, floor 1
+- **Tier 3** (36-72h): 1 sentence, floor 0
+- **Tier 4** (72h+): 0 sentences, floor 0 (JIT fills when needed)
+
+Shared `pipeline_tiers.py` module computes tiers from `acquisition_next_due` and `fsrs_card_json["due"]`. Used by `update_material.py` (cap enforcement + backfill), `material_generator.py` (warm cache + rotation), and `rotate_stale_sentences.py`.
+
+### Expected Impact
+With 295 acquiring, 176 overdue: ~710 sentences needed (vs 885 before) — fits within 800. After one session: drops to ~590. Pool size naturally scales with actual demand, not total word count.
+
+### Verification
+- `update_material.py --dry-run` shows tier distribution and reduced demand
+- Pool usage drops without cap change
+- After review sessions, tier 1 shrinks as words advance boxes
+
+### Files Changed
+- `backend/app/services/pipeline_tiers.py` — new: tier computation
+- `backend/scripts/update_material.py` — tiered cap enforcement and backfill
+- `backend/app/services/material_generator.py` — tiered warm cache and rotation
+- `backend/scripts/rotate_stale_sentences.py` — tiered min_active floor
+- `backend/tests/test_pipeline_tiers.py` — unit tests
+
+---
+
 ## 2026-02-27: Fix Stale Word Lookup Cache
 
 ### Problem


### PR DESCRIPTION
## Summary
- Replace flat per-word sentence targets with urgency tiers based on due date
- Tier 1 (due <12h): 3 sentences, floor 2. Tier 2 (12-36h): 2/1. Tier 3 (36-72h): 1/0. Tier 4 (72h+): 0/0 (JIT)
- Pool demand drops from 885 to ~710 with 295 acquiring words — fits within 800 cap without raising it
- Verified on production: dry-run shows T1=293, T2=37, T3=64, T4=296, cap enforcement retired 53 sentences

🤖 Generated with [Claude Code](https://claude.com/claude-code)