### PR TITLE
feat: surface root/pattern info across all card types

### DIFF
--- a/backend/app/routers/review.py
+++ b/backend/app/routers/review.py
@@ -506,6 +506,29 @@ def wrap_up_quiz(body: WrapUpIn, db: Session = Depends(get_db)):
                     "knowledge_state": ks,
                 })
 
+        # Root family for wrap-up card
+        rf = []
+        if root_obj:
+            siblings = (
+                db.query(Lemma)
+                .filter(Lemma.root_id == root_obj.root_id, Lemma.lemma_id != lemma.lemma_id, Lemma.canonical_lemma_id.is_(None))
+                .all()
+            )
+            sibling_ulk = {
+                ulk.lemma_id: ulk.knowledge_state
+                for ulk in db.query(UserLemmaKnowledge)
+                .filter(UserLemmaKnowledge.lemma_id.in_([s.lemma_id for s in siblings]))
+                .all()
+            } if siblings else {}
+            for sib in siblings:
+                rf.append({
+                    "lemma_id": sib.lemma_id,
+                    "lemma_ar": sib.lemma_ar,
+                    "gloss_en": sib.gloss_en,
+                    "transliteration": sib.transliteration_ala_lc,
+                    "state": sibling_ulk.get(sib.lemma_id, "new"),
+                })
+
         cards.append(WrapUpCardOut(
             lemma_id=lemma.lemma_id,
             lemma_ar=lemma.lemma_ar,
@@ -516,6 +539,7 @@ def wrap_up_quiz(body: WrapUpIn, db: Session = Depends(get_db)):
             forms_json=lemma.forms_json,
             root=root_obj.root if root_obj else None,
             root_meaning=root_obj.core_meaning_en if root_obj else None,
+            root_id=root_obj.root_id if root_obj else None,
             etymology_json=lemma.etymology_json,
             memory_hooks_json=lemma.memory_hooks_json,
             wazn=lemma.wazn,
@@ -523,6 +547,7 @@ def wrap_up_quiz(body: WrapUpIn, db: Session = Depends(get_db)):
             forms_translit=lemma.forms_translit_json or _compute_forms_translit(lemma.forms_json),
             pattern_examples=pe,
             is_acquiring=lemma.lemma_id in acquiring_ids,
+            root_family=rf,
         ))
 
     log_interaction(

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -466,6 +466,7 @@ class WrapUpCardOut(BaseModel):
     forms_json: dict | list | None = None
     root: str | None = None
     root_meaning: str | None = None
+    root_id: int | None = None
     etymology_json: dict | None = None
     memory_hooks_json: dict | None = None
     is_acquiring: bool = False
@@ -473,6 +474,7 @@ class WrapUpCardOut(BaseModel):
     wazn_meaning: str | None = None
     forms_translit: dict | None = None
     pattern_examples: list[dict] = []
+    root_family: list[dict] = []
 
 
 class WrapUpOut(BaseModel):

--- a/backend/app/services/word_selector.py
+++ b/backend/app/services/word_selector.py
@@ -17,10 +17,11 @@ from datetime import datetime, timezone, timedelta
 from typing import Optional
 
 from sqlalchemy.orm import Session
-from sqlalchemy import func
+from sqlalchemy import func, case
 
 from app.models import Root, Lemma, UserLemmaKnowledge, ReviewLog, Sentence, StoryWord, Story
 from app.services.grammar_service import grammar_pattern_score
+from app.services.transliteration import transliterate_arabic
 
 
 # Semantic categories that should NOT be introduced together
@@ -516,6 +517,59 @@ def select_next_words(
             + category_penalty
         )
 
+        # Compute forms_translit
+        ft = lemma.forms_translit_json
+        if not ft and lemma.forms_json:
+            ft = {}
+            for fk, fv in lemma.forms_json.items():
+                if fk in ("gender", "verb_form") or not fv or not isinstance(fv, str):
+                    continue
+                tr = transliterate_arabic(fv)
+                if tr:
+                    ft[fk] = tr
+            ft = ft or None
+
+        # Pattern examples (other words with same wazn from touched roots)
+        pe = []
+        if lemma.wazn:
+            touched_root_ids = (
+                db.query(Lemma.root_id)
+                .join(UserLemmaKnowledge, UserLemmaKnowledge.lemma_id == Lemma.lemma_id)
+                .filter(Lemma.root_id.isnot(None))
+                .distinct()
+                .subquery()
+            )
+            examples = (
+                db.query(Lemma, UserLemmaKnowledge.knowledge_state)
+                .outerjoin(UserLemmaKnowledge, UserLemmaKnowledge.lemma_id == Lemma.lemma_id)
+                .filter(
+                    Lemma.wazn == lemma.wazn,
+                    Lemma.root_id.in_(touched_root_ids),
+                    Lemma.lemma_id != lemma.lemma_id,
+                    Lemma.canonical_lemma_id.is_(None),
+                )
+                .order_by(
+                    case(
+                        (UserLemmaKnowledge.knowledge_state.in_(["known", "learning"]), 0),
+                        else_=1,
+                    ),
+                    Lemma.frequency_rank.asc().nullslast(),
+                )
+                .limit(4)
+                .all()
+            )
+            for ex, ks in examples:
+                ex_root = db.query(Root).filter(Root.root_id == ex.root_id).first() if ex.root_id else None
+                pe.append({
+                    "lemma_id": ex.lemma_id,
+                    "lemma_ar": ex.lemma_ar,
+                    "gloss_en": ex.gloss_en,
+                    "transliteration": ex.transliteration_ala_lc,
+                    "root": ex_root.root if ex_root else None,
+                    "root_meaning": ex_root.core_meaning_en if ex_root else None,
+                    "knowledge_state": ks,
+                })
+
         scored.append({
             "lemma_id": lemma.lemma_id,
             "lemma_ar": lemma.lemma_ar,
@@ -528,6 +582,7 @@ def select_next_words(
             "root": lemma.root.root if lemma.root else None,
             "root_meaning": lemma.root.core_meaning_en if lemma.root else None,
             "forms_json": lemma.forms_json,
+            "forms_translit": ft,
             "grammar_features": lemma.grammar_features_json or [],
             "audio_url": lemma.audio_url,
             "example_ar": lemma.example_ar,
@@ -537,6 +592,7 @@ def select_next_words(
             "word_category": lemma.word_category,
             "wazn": lemma.wazn,
             "wazn_meaning": lemma.wazn_meaning,
+            "pattern_examples": pe,
             "story_title": (story_lemmas[lemma.lemma_id]["title"] if lemma.lemma_id in story_lemmas else None),
             "story_id": (
                 book_pages[lemma.lemma_id]["story_id"] if lemma.lemma_id in book_pages

--- a/frontend/app/index.tsx
+++ b/frontend/app/index.tsx
@@ -1191,34 +1191,63 @@ export function ReviewScreen({ fixedMode }: { fixedMode: ReviewMode }) {
           </Text>
         </View>
         <ScrollView
-          contentContainerStyle={styles.sentenceArea}
+          contentContainerStyle={styles.reintroScrollContent}
           showsVerticalScrollIndicator={false}
         >
-          <Text style={styles.wordOnlyArabic}>{wc.lemma_ar}</Text>
-          {wc.transliteration && (
-            <Text style={styles.sentenceTranslit}>{wc.transliteration}</Text>
-          )}
-          {wrapUpRevealed && (
-            <>
-              <View style={styles.divider} />
-              <Text style={styles.wordOnlyGloss}>{wc.gloss_en || ""}</Text>
-              {wc.root && (
-                <Text style={[styles.sentenceTranslit, { marginTop: 4 }]}>
-                  Root: {wc.root}{wc.root_meaning ? ` \u2014 ${wc.root_meaning}` : ""}
-                </Text>
-              )}
-              {wc.etymology_json?.derivation && (
-                <Text style={[styles.sentenceTranslit, { fontStyle: "italic", marginTop: 4 }]}>
-                  {wc.etymology_json.derivation}
-                </Text>
-              )}
-              {wc.memory_hooks_json?.mnemonic && (
-                <Text style={[styles.sentenceTranslit, { fontStyle: "italic", marginTop: 2 }]}>
-                  {wc.memory_hooks_json.mnemonic}
-                </Text>
-              )}
-            </>
-          )}
+          <View style={[styles.eiHero, { borderRadius: 16 }]}>
+            <Text style={styles.eiArabic}>{wc.lemma_ar}</Text>
+            {wc.transliteration && (
+              <Text style={styles.eiTranslit}>{wc.transliteration}</Text>
+            )}
+            {wrapUpRevealed && (
+              <>
+                <View style={styles.divider} />
+                <Text style={styles.eiEnglish}>{wc.gloss_en || ""}</Text>
+                <View style={styles.eiChipsArea}>
+                  {wc.pos && (
+                    <View style={styles.eiChipPos}>
+                      <Text style={styles.eiChipPosText}>{posLabel(wc.pos, wc.forms_json)}</Text>
+                    </View>
+                  )}
+                  {wc.root && wc.root_id && (
+                    <Pressable
+                      style={[styles.eiChipOutline, { borderColor: "#9b59b630", backgroundColor: "#9b59b620" }]}
+                      onPress={() => router.push(`/root/${wc.root_id}`)}
+                    >
+                      <Text style={{ fontSize: 14, fontWeight: "600", fontFamily: fontFamily.arabic, writingDirection: "rtl", color: "#9b59b6" }}>{wc.root}</Text>
+                      {wc.root_meaning && (
+                        <Text style={{ fontSize: 12, fontWeight: "600", color: "#9b59b6" }} numberOfLines={1}>{wc.root_meaning}</Text>
+                      )}
+                      <Text style={{ color: "#9b59b660", fontSize: 10 }}>{" \u203A"}</Text>
+                    </Pressable>
+                  )}
+                  {wc.wazn && (
+                    <Pressable
+                      style={[styles.eiChipOutline, { borderColor: "#f39c1230", backgroundColor: "#f39c1220" }]}
+                      onPress={() => router.push(`/pattern/${encodeURIComponent(wc.wazn!)}`)}
+                    >
+                      <Text style={{ fontSize: 12, fontWeight: "600", color: "#f39c12" }}>{wc.wazn}</Text>
+                      {wc.wazn_meaning && (
+                        <Text style={{ fontSize: 12, fontWeight: "600", color: "#f39c12" }} numberOfLines={1}>{wc.wazn_meaning}</Text>
+                      )}
+                      <Text style={{ color: "#f39c1260", fontSize: 10 }}>{" \u203A"}</Text>
+                    </Pressable>
+                  )}
+                </View>
+                <FormsStrip pos={wc.pos} forms={wc.forms_json} formsTranslit={wc.forms_translit} />
+                {wc.etymology_json?.derivation && (
+                  <Text style={[styles.eiInfoText, { fontStyle: "italic", marginTop: 4, fontSize: 12, color: colors.textSecondary }]}>
+                    {wc.etymology_json.derivation}
+                  </Text>
+                )}
+                {wc.memory_hooks_json?.mnemonic && (
+                  <View style={[styles.eiMnemonicCard, { marginTop: 4 }]}>
+                    <Text style={styles.eiInfoText}>{wc.memory_hooks_json.mnemonic}</Text>
+                  </View>
+                )}
+              </>
+            )}
+          </View>
         </ScrollView>
         <View style={styles.bottomActions}>
           {!wrapUpRevealed ? (
@@ -1823,6 +1852,7 @@ export function ReviewScreen({ fixedMode }: { fixedMode: ReviewMode }) {
           reserveSpace={false}
           onNavigateToDetail={(id) => router.push(`/word/${id}`)}
           onNavigateToPattern={(wazn) => router.push(`/pattern/${encodeURIComponent(wazn)}`)}
+          onNavigateToRoot={(rootId) => router.push(`/root/${rootId}`)}
           onPrev={handleLookupPrev}
           onNext={handleLookupNext}
           hasPrev={tappedCursor > 0}

--- a/frontend/app/story/[id].tsx
+++ b/frontend/app/story/[id].tsx
@@ -360,6 +360,7 @@ export default function StoryReadScreen() {
               reserveSpace={false}
               onNavigateToDetail={(lemmaId) => router.push(`/word/${lemmaId}`)}
               onNavigateToPattern={(wazn) => router.push(`/pattern/${encodeURIComponent(wazn)}`)}
+              onNavigateToRoot={(rootId) => router.push(`/root/${rootId}`)}
               surfaceTranslit={null}
             />
           )}

--- a/frontend/lib/review/WordInfoCard.tsx
+++ b/frontend/lib/review/WordInfoCard.tsx
@@ -19,6 +19,7 @@ interface WordInfoCardProps {
   reserveSpace?: boolean;
   onNavigateToDetail?: (lemmaId: number) => void;
   onNavigateToPattern?: (wazn: string) => void;
+  onNavigateToRoot?: (rootId: number) => void;
   onPrev?: () => void;
   onNext?: () => void;
   hasPrev?: boolean;
@@ -161,6 +162,7 @@ export default function WordInfoCard({
   reserveSpace = true,
   onNavigateToDetail,
   onNavigateToPattern,
+  onNavigateToRoot,
   onPrev,
   onNext,
   hasPrev = false,
@@ -248,7 +250,7 @@ export default function WordInfoCard({
         <GrammarParticleView info={particleInfo} />
       ) : (
         <ScrollView style={{ maxHeight: 200 }} showsVerticalScrollIndicator={true} nestedScrollEnabled>
-          <RevealedView result={result} surfaceForm={surfaceForm} onNavigateToDetail={onNavigateToDetail} onNavigateToPattern={onNavigateToPattern} surfaceTranslit={surfaceTranslit} confusionData={markState === "did_not_recognize" ? confusionData : null} />
+          <RevealedView result={result} surfaceForm={surfaceForm} onNavigateToDetail={onNavigateToDetail} onNavigateToPattern={onNavigateToPattern} onNavigateToRoot={onNavigateToRoot} surfaceTranslit={surfaceTranslit} confusionData={markState === "did_not_recognize" ? confusionData : null} />
         </ScrollView>
       )}
     </Animated.View>
@@ -285,6 +287,7 @@ function RevealedView({
   surfaceForm,
   onNavigateToDetail,
   onNavigateToPattern,
+  onNavigateToRoot,
   surfaceTranslit,
   confusionData,
 }: {
@@ -292,6 +295,7 @@ function RevealedView({
   surfaceForm?: string | null;
   onNavigateToDetail?: (lemmaId: number) => void;
   onNavigateToPattern?: (wazn: string) => void;
+  onNavigateToRoot?: (rootId: number) => void;
   surfaceTranslit?: string | null;
   confusionData?: ConfusionAnalysis | null;
 }) {
@@ -494,20 +498,28 @@ function RevealedView({
 
       {/* Root info */}
       {result.root && (
-        <View style={styles.rootLine}>
-          <Text style={styles.rootLetters}>{result.root}</Text>
-          {result.root_meaning && <Text style={styles.rootMeaning}>{result.root_meaning}</Text>}
-        </View>
+        onNavigateToRoot && result.root_id ? (
+          <Pressable onPress={() => onNavigateToRoot(result.root_id!)} style={styles.rootLink}>
+            <Text style={styles.rootLetters}>{result.root}</Text>
+            {result.root_meaning && <Text style={styles.rootMeaning}>{result.root_meaning}</Text>}
+            <Ionicons name="chevron-forward" size={12} color="#9b59b6" />
+          </Pressable>
+        ) : (
+          <View style={styles.rootLine}>
+            <Text style={styles.rootLetters}>{result.root}</Text>
+            {result.root_meaning && <Text style={styles.rootMeaning}>{result.root_meaning}</Text>}
+          </View>
+        )
       )}
 
       {/* Known root siblings */}
       {knownSiblings.length > 0 && (
         <View style={styles.siblingRow}>
           {knownSiblings.slice(0, 5).map((s) => (
-            <View key={s.lemma_id} style={styles.siblingPill}>
+            <Pressable key={s.lemma_id} style={styles.siblingPill} onPress={onNavigateToDetail ? () => onNavigateToDetail(s.lemma_id) : undefined}>
               <Text style={styles.siblingAr}>{s.lemma_ar}</Text>
               <Text style={styles.siblingEn} numberOfLines={1}>{s.gloss_en ?? "?"}</Text>
-            </View>
+            </Pressable>
           ))}
         </View>
       )}
@@ -747,6 +759,11 @@ const styles = StyleSheet.create({
 
   /* Root */
   rootLine: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+  },
+  rootLink: {
     flexDirection: "row",
     alignItems: "center",
     gap: 6,

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -176,12 +176,14 @@ export interface WrapUpCard {
   forms_json: WordForms | null;
   root: string | null;
   root_meaning: string | null;
+  root_id: number | null;
   etymology_json: EtymologyData | null;
   memory_hooks_json?: MemoryHooksData | null;
   wazn?: string | null;
   wazn_meaning?: string | null;
   forms_translit?: Record<string, string> | null;
   pattern_examples?: PatternExample[];
+  root_family?: { lemma_id: number; lemma_ar: string; gloss_en: string | null; transliteration?: string | null; state: string }[];
 }
 
 export interface RecapItem {


### PR DESCRIPTION
## Summary
- **WordInfoCard**: root line now clickable (navigates to root detail page), root siblings tappable (navigates to word detail)
- **Wrap-up cards**: upgraded from plain text to info-dense layout matching intro cards — root/pattern navigation chips, forms strip, mnemonic card
- **Learn candidates**: pattern_examples and forms_translit now populated by backend (were always expected by frontend but never sent)
- **Story reader**: root navigation added to WordInfoCard

Also nuked all 1870 pre-Sonnet memory hooks and started background regeneration with Sonnet overgenerate-and-rank (797 were Haiku-era, 190 had broken `lang: "?"` cognate format).

🤖 Generated with [Claude Code](https://claude.com/claude-code)