### PR TITLE
fix: unify sentence generation through verified pipeline

### DIFF
--- a/backend/app/services/material_generator.py
+++ b/backend/app/services/material_generator.py
@@ -13,7 +13,7 @@ from app.models import Lemma, Sentence, SentenceWord, UserLemmaKnowledge
 logger = logging.getLogger(__name__)
 
 
-def generate_material_for_word(lemma_id: int, needed: int = 2, model_override: str = "gemini") -> None:
+def generate_material_for_word(lemma_id: int, needed: int = 2, model_override: str = "gemini") -> int:
     """Background task: generate sentences + audio for a word.
 
     Uses a generate-then-write pattern to avoid holding the DB lock during
@@ -48,7 +48,7 @@ def generate_material_for_word(lemma_id: int, needed: int = 2, model_override: s
     try:
         lemma = db.query(Lemma).filter(Lemma.lemma_id == lemma_id).first()
         if not lemma:
-            return
+            return 0
         # Snapshot lemma data for use after DB close
         lemma_ar = lemma.lemma_ar
         gloss_en = lemma.gloss_en or ""
@@ -94,7 +94,7 @@ def generate_material_for_word(lemma_id: int, needed: int = 2, model_override: s
     clean_target, san_warnings = sanitize_arabic_word(lemma_ar)
     if not clean_target or " " in clean_target or "too_short" in san_warnings:
         logger.warning(f"Skipping generation for uncleanable lemma {lemma_id}: {lemma_ar!r}")
-        return
+        return 0
     target_bare = strip_diacritics(clean_target)
     all_bare_forms = set(lemma_lookup.keys())
 
@@ -111,7 +111,7 @@ def generate_material_for_word(lemma_id: int, needed: int = 2, model_override: s
         )
     except AllProvidersFailed:
         logger.warning(f"LLM unavailable for sentence generation (lemma {lemma_id})")
-        return
+        return 0
 
     # Validate and prepare sentences in memory
     valid_sentences: list[dict] = []
@@ -210,12 +210,12 @@ def generate_material_for_word(lemma_id: int, needed: int = 2, model_override: s
         })
 
     if not valid_sentences:
-        return
+        return 0
 
     # ── Phase 3: DB write (milliseconds) ──
     db = SessionLocal()
+    stored = 0
     try:
-        stored = 0
         for vs in valid_sentences:
             sent = Sentence(
                 arabic_text=vs["arabic"],
@@ -248,6 +248,7 @@ def generate_material_for_word(lemma_id: int, needed: int = 2, model_override: s
         db.rollback()
     finally:
         db.close()
+    return stored
 
 
 def store_multi_target_sentence(

--- a/backend/scripts/generate_sentences.py
+++ b/backend/scripts/generate_sentences.py
@@ -2,20 +2,20 @@
 """Batch generate sentences for all known words.
 
 Populates the sentences + sentence_words tables so the sentence-centric
-review mode has content to work with.
+review mode has content to work with. Uses generate_material_for_word()
+which includes LLM disambiguation and verification of word mappings.
 
 Usage:
     python scripts/generate_sentences.py                    # generate 3 sentences per word
     python scripts/generate_sentences.py --target-count 2   # generate 2 per word
     python scripts/generate_sentences.py --word-id 42       # single word only
-    python scripts/generate_sentences.py --dry-run           # validate but don't write to DB
+    python scripts/generate_sentences.py --dry-run           # preview only
     python scripts/generate_sentences.py --model gemini      # use a specific model
 """
 
 import argparse
 import sys
 import time
-from datetime import datetime, timezone
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
@@ -23,26 +23,9 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from sqlalchemy import func
 
 from app.database import SessionLocal
-from app.models import Lemma, Sentence, SentenceWord, UserLemmaKnowledge
+from app.models import Lemma, Sentence, UserLemmaKnowledge
 from app.services.activity_log import log_activity
-from app.services.llm import (
-    AllProvidersFailed,
-    generate_sentences_batch,
-)
-from app.services.sentence_generator import (
-    get_content_word_counts,
-    get_avoid_words,
-    sample_known_words_weighted,
-    KNOWN_SAMPLE_SIZE,
-)
-from app.services.sentence_validator import (
-    ValidationResult,
-    build_lemma_lookup,
-    map_tokens_to_lemmas,
-    strip_diacritics,
-    tokenize_display,
-    validate_sentence,
-)
+from app.services.material_generator import generate_material_for_word
 
 
 def get_existing_sentence_counts(db) -> dict[int, int]:
@@ -56,129 +39,12 @@ def get_existing_sentence_counts(db) -> dict[int, int]:
     return {lid: cnt for lid, cnt in rows}
 
 
-def store_sentence(
-    db,
-    gen_result,
-    target_lemma: Lemma,
-    lemma_lookup: dict[str, int],
-    dry_run: bool = False,
-) -> bool:
-    """Validate and store a generated sentence + its word mappings.
-
-    Returns True if stored successfully, False if validation failed.
-    """
-    target_bare = strip_diacritics(target_lemma.lemma_ar)
-    all_bare_forms = set(lemma_lookup.keys())
-
-    validation = validate_sentence(
-        arabic_text=gen_result.arabic,
-        target_bare=target_bare,
-        known_bare_forms=all_bare_forms,
-    )
-
-    if not validation.valid:
-        return False
-
-    if dry_run:
-        print(f"    [dry-run] Valid: {gen_result.arabic}")
-        print(f"              EN: {gen_result.english}")
-        return True
-
-    # Create Sentence record
-    sent = Sentence(
-        arabic_text=gen_result.arabic,
-        arabic_diacritized=gen_result.arabic,
-        english_translation=gen_result.english,
-        transliteration=gen_result.transliteration,
-        source="llm",
-        target_lemma_id=target_lemma.lemma_id,
-        created_at=datetime.now(timezone.utc),
-    )
-    db.add(sent)
-    db.flush()
-
-    # Tokenize and map to lemmas
-    tokens = tokenize_display(gen_result.arabic)
-    mappings = map_tokens_to_lemmas(
-        tokens=tokens,
-        lemma_lookup=lemma_lookup,
-        target_lemma_id=target_lemma.lemma_id,
-        target_bare=target_bare,
-    )
-
-    for m in mappings:
-        sw = SentenceWord(
-            sentence_id=sent.id,
-            position=m.position,
-            surface_form=m.surface_form,
-            lemma_id=m.lemma_id,
-            is_target_word=m.is_target,
-        )
-        db.add(sw)
-
-    return True
-
-
-def generate_for_word(
-    db,
-    target_lemma: Lemma,
-    known_words: list[dict[str, str]],
-    lemma_lookup: dict[str, int],
-    needed: int,
-    dry_run: bool = False,
-    model: str = "gemini",
-    delay: float = 0,
-    avoid_words: list[str] | None = None,
-) -> tuple[int, int]:
-    """Generate sentences for a single word. Returns (stored, failed)."""
-    stored = 0
-    failed = 0
-    max_batches = 3  # at most 3 LLM calls per word
-
-    for batch_num in range(max_batches):
-        if stored >= needed:
-            break
-
-        remaining = needed - stored
-        if delay > 0 and batch_num > 0:
-            time.sleep(delay)
-        try:
-            results = generate_sentences_batch(
-                target_word=target_lemma.lemma_ar,
-                target_translation=target_lemma.gloss_en or "",
-                known_words=known_words,
-                count=min(remaining + 1, 3),  # ask for 1 extra to account for validation failures
-                difficulty_hint="beginner",
-                model_override=model,
-                avoid_words=avoid_words,
-            )
-        except AllProvidersFailed as e:
-            print(f"    LLM error: {e}")
-            failed += 1
-            break
-
-        if not results:
-            failed += 1
-            continue
-
-        for res in results:
-            if stored >= needed:
-                break
-            if store_sentence(db, res, target_lemma, lemma_lookup, dry_run):
-                stored += 1
-            else:
-                failed += 1
-
-    return stored, failed
-
-
 def main():
     parser = argparse.ArgumentParser(description="Batch generate sentences for known words")
     parser.add_argument("--target-count", type=int, default=3, help="Sentences per word (default: 3)")
     parser.add_argument("--word-id", type=int, help="Generate for a single lemma_id only")
-    parser.add_argument("--dry-run", action="store_true", help="Validate without writing to DB")
-    parser.add_argument("--model", default="gemini", help="LLM model: gemini/openai/anthropic (default: gemini)")
-    parser.add_argument("--delay", type=float, default=0, help="Seconds to wait between LLM calls (for rate limiting)")
+    parser.add_argument("--dry-run", action="store_true", help="Preview without writing to DB")
+    parser.add_argument("--model", default="gemini", help="LLM model (default: gemini)")
     args = parser.parse_args()
 
     db = SessionLocal()
@@ -194,19 +60,6 @@ def main():
         if not all_lemmas:
             print("No lemmas with FSRS cards found. Run import first.")
             return
-
-        # Build known words list and lemma lookup
-        known_words = [
-            {"arabic": lem.lemma_ar, "english": lem.gloss_en or "", "lemma_id": lem.lemma_id}
-            for lem in all_lemmas
-        ]
-        lemma_lookup = build_lemma_lookup(all_lemmas)
-
-        # Diversity: compute content word counts and avoid list
-        content_word_counts = get_content_word_counts(db)
-        avoid_words = get_avoid_words(content_word_counts, known_words)
-        if avoid_words:
-            print(f"Avoiding overused words: {', '.join(avoid_words)}")
 
         # Existing sentence counts
         existing_counts = get_existing_sentence_counts(db)
@@ -224,13 +77,12 @@ def main():
         targets.sort(key=lambda l: existing_counts.get(l.lemma_id, 0))
 
         total_stored = 0
-        total_failed = 0
         total_skipped = 0
         start_time = time.time()
 
         print(f"Generating sentences for {len(targets)} words (target: {args.target_count} each)")
         print(f"Model: {args.model} | Dry run: {args.dry_run}")
-        print(f"Known vocabulary: {len(known_words)} words")
+        print(f"Known vocabulary: {len(all_lemmas)} words")
         print("-" * 60)
 
         for i, lemma in enumerate(targets):
@@ -243,44 +95,23 @@ def main():
 
             print(f"[{i+1}/{len(targets)}] {lemma.lemma_ar} ({lemma.gloss_en}) — need {needed}, have {existing}")
 
-            if i > 0 and args.delay > 0:
-                time.sleep(args.delay)
+            if args.dry_run:
+                print(f"    [dry-run] Would generate {needed} sentences")
+                total_stored += needed
+                continue
 
-            # Per-word weighted sample for diversity
-            word_sample = sample_known_words_weighted(
-                known_words, content_word_counts, KNOWN_SAMPLE_SIZE,
-                target_lemma_id=lemma.lemma_id,
+            stored = generate_material_for_word(
+                lemma.lemma_id, needed=needed, model_override=args.model,
             )
-
-            stored, failed = generate_for_word(
-                db=db,
-                target_lemma=lemma,
-                known_words=word_sample,
-                lemma_lookup=lemma_lookup,
-                needed=needed,
-                dry_run=args.dry_run,
-                model=args.model,
-                delay=args.delay,
-                avoid_words=avoid_words,
-            )
-
             total_stored += stored
-            total_failed += failed
 
             if stored > 0:
-                print(f"    -> stored {stored}" + (f", {failed} failed validation" if failed else ""))
-            elif failed > 0:
-                print(f"    -> 0 stored, {failed} failed")
-
-            # Commit after each word so partial runs are useful
-            if not args.dry_run and stored > 0:
-                db.commit()
+                print(f"    -> stored {stored}")
 
         elapsed = time.time() - start_time
         print("-" * 60)
         print(f"Done in {elapsed:.1f}s")
         print(f"  Stored: {total_stored}")
-        print(f"  Failed validation: {total_failed}")
         print(f"  Skipped (already have enough): {total_skipped}")
 
         if not args.dry_run and total_stored > 0:
@@ -290,7 +121,6 @@ def main():
                 summary=f"Generated {total_stored} sentences for {len(targets) - total_skipped} words in {elapsed:.0f}s",
                 detail={
                     "stored": total_stored,
-                    "failed": total_failed,
                     "skipped": total_skipped,
                     "elapsed_seconds": round(elapsed, 1),
                 },

--- a/backend/scripts/pregenerate_material.py
+++ b/backend/scripts/pregenerate_material.py
@@ -29,22 +29,9 @@ load_dotenv(Path(__file__).resolve().parent.parent / ".env")
 from sqlalchemy import func
 
 from app.database import SessionLocal
-from app.models import Lemma, Sentence, SentenceWord, UserLemmaKnowledge
+from app.models import Sentence
 from app.services.word_selector import select_next_words
-from app.services.llm import AllProvidersFailed, generate_sentences_batch
-from app.services.sentence_generator import (
-    get_content_word_counts,
-    get_avoid_words,
-    sample_known_words_weighted,
-    KNOWN_SAMPLE_SIZE,
-)
-from app.services.sentence_validator import (
-    build_lemma_lookup,
-    map_tokens_to_lemmas,
-    strip_diacritics,
-    tokenize_display,
-    validate_sentence,
-)
+from app.services.material_generator import generate_material_for_word
 from app.services.tts import (
     DEFAULT_VOICE_ID,
     TTSError,
@@ -66,87 +53,6 @@ def get_existing_counts(db) -> dict[int, int]:
         .all()
     )
     return {lid: cnt for lid, cnt in rows}
-
-
-def generate_sentences_for_word(
-    db,
-    lemma: Lemma,
-    known_words: list[dict[str, str]],
-    lemma_lookup: dict[str, int],
-    needed: int,
-    model: str = "gemini",
-    delay: float = 1.0,
-    avoid_words: list[str] | None = None,
-) -> int:
-    target_bare = strip_diacritics(lemma.lemma_ar)
-    all_bare = set(lemma_lookup.keys())
-    stored = 0
-
-    for batch in range(3):
-        if stored >= needed:
-            break
-        if batch > 0 and delay > 0:
-            time.sleep(delay)
-
-        try:
-            results = generate_sentences_batch(
-                target_word=lemma.lemma_ar,
-                target_translation=lemma.gloss_en or "",
-                known_words=known_words,
-                count=min(needed - stored + 1, 3),
-                difficulty_hint="beginner",
-                model_override=model,
-                avoid_words=avoid_words,
-            )
-        except AllProvidersFailed as e:
-            print(f"    LLM error: {e}")
-            break
-
-        for res in results:
-            if stored >= needed:
-                break
-
-            validation = validate_sentence(
-                arabic_text=res.arabic,
-                target_bare=target_bare,
-                known_bare_forms=all_bare,
-            )
-            if not validation.valid:
-                continue
-
-            sent = Sentence(
-                arabic_text=res.arabic,
-                arabic_diacritized=res.arabic,
-                english_translation=res.english,
-                transliteration=res.transliteration,
-                source="llm",
-                target_lemma_id=lemma.lemma_id,
-                created_at=datetime.now(timezone.utc),
-            )
-            db.add(sent)
-            db.flush()
-
-            tokens = tokenize_display(res.arabic)
-            mappings = map_tokens_to_lemmas(
-                tokens=tokens,
-                lemma_lookup=lemma_lookup,
-                target_lemma_id=lemma.lemma_id,
-                target_bare=target_bare,
-            )
-            for m in mappings:
-                sw = SentenceWord(
-                    sentence_id=sent.id,
-                    position=m.position,
-                    surface_form=m.surface_form,
-                    lemma_id=m.lemma_id,
-                    is_target_word=m.is_target,
-                )
-                db.add(sw)
-
-            stored += 1
-
-    db.commit()
-    return stored
 
 
 async def generate_audio_for_sentences(db, lemma_id: int) -> int:
@@ -199,25 +105,6 @@ async def main():
 
         print(f"Found {len(candidates)} candidates for pre-generation")
 
-        # Build known words and lemma lookup
-        all_lemmas = (
-            db.query(Lemma)
-            .join(UserLemmaKnowledge)
-            .filter(UserLemmaKnowledge.fsrs_card_json.isnot(None))
-            .all()
-        )
-        known_words = [
-            {"arabic": lem.lemma_ar, "english": lem.gloss_en or "", "lemma_id": lem.lemma_id}
-            for lem in all_lemmas
-        ]
-        lemma_lookup = build_lemma_lookup(all_lemmas)
-
-        # Diversity: compute content word counts and avoid list
-        content_word_counts = get_content_word_counts(db)
-        avoid_words = get_avoid_words(content_word_counts, known_words)
-        if avoid_words:
-            print(f"Avoiding overused words: {', '.join(avoid_words)}")
-
         existing_counts = get_existing_counts(db)
 
         total_sentences = 0
@@ -237,19 +124,11 @@ async def main():
                     print(f"    [dry-run] Would generate {needed} sentences")
                     total_sentences += needed
                 else:
-                    lemma = db.query(Lemma).filter(Lemma.lemma_id == lid).first()
-                    if lemma:
-                        word_sample = sample_known_words_weighted(
-                            known_words, content_word_counts, KNOWN_SAMPLE_SIZE,
-                            target_lemma_id=lemma.lemma_id,
-                        )
-                        stored = generate_sentences_for_word(
-                            db, lemma, word_sample, lemma_lookup,
-                            needed=needed, model=args.model, delay=args.delay,
-                            avoid_words=avoid_words,
-                        )
-                        total_sentences += stored
-                        print(f"    Generated {stored} sentences")
+                    stored = generate_material_for_word(
+                        lid, needed=needed, model_override=args.model,
+                    )
+                    total_sentences += stored
+                    print(f"    Generated {stored} sentences")
 
             if not args.skip_audio and not args.dry_run:
                 audio_count = await generate_audio_for_sentences(db, lid)

--- a/backend/scripts/update_material.py
+++ b/backend/scripts/update_material.py
@@ -35,22 +35,17 @@ from sqlalchemy.orm import Session
 from app.database import SessionLocal
 from app.models import Lemma, Sentence, SentenceWord, UserLemmaKnowledge
 from app.services.activity_log import log_activity
-from app.services.word_selector import select_next_words, get_sentence_difficulty_params
-from app.services.llm import AllProvidersFailed, generate_sentences_batch
+from app.services.word_selector import select_next_words
+from app.services.material_generator import generate_material_for_word
 from app.services.sentence_generator import (
     get_content_word_counts,
     get_avoid_words,
     group_words_for_multi_target,
     generate_validated_sentences_multi_target,
-    sample_known_words_weighted,
-    KNOWN_SAMPLE_SIZE,
 )
 from app.services.sentence_validator import (
     build_lemma_lookup,
-    map_tokens_to_lemmas,
     strip_diacritics,
-    tokenize_display,
-    validate_sentence,
 )
 from app.services.tts import (
     DEFAULT_VOICE_ID,
@@ -138,125 +133,6 @@ def get_known_words_and_lookup(db: Session) -> tuple[list[dict[str, str]], dict[
     ]
     lemma_lookup = build_lemma_lookup(all_lemmas)
     return known_words, lemma_lookup
-
-
-def generate_sentences_for_word(
-    db: Session,
-    lemma: Lemma,
-    known_words: list[dict[str, str]],
-    lemma_lookup: dict[str, int],
-    needed: int,
-    model: str = "gemini",
-    delay: float = 1.0,
-    avoid_words: list[str] | None = None,
-    difficulty_hint: str | None = None,
-    max_words: int | None = None,
-) -> int:
-    """Generate sentences for a word using generate-then-write pattern.
-
-    LLM generation happens without holding the DB lock. Only the final
-    write phase holds the DB briefly (milliseconds).
-    """
-    target_bare = strip_diacritics(lemma.lemma_ar)
-    lemma_ar = lemma.lemma_ar
-    gloss_en = lemma.gloss_en or ""
-    target_lemma_id = lemma.lemma_id
-    all_bare = set(lemma_lookup.keys())
-    rejected_words: list[str] = []
-
-    # Read difficulty params before releasing DB
-    if difficulty_hint is None or max_words is None:
-        diff_params = get_sentence_difficulty_params(db, lemma.lemma_id)
-        if difficulty_hint is None:
-            difficulty_hint = diff_params["difficulty_hint"]
-        if max_words is None:
-            max_words = diff_params["max_words"]
-
-    # ── LLM generation phase (no DB writes) ──
-    valid_sentences: list[dict] = []
-    for batch in range(3):
-        if len(valid_sentences) >= needed:
-            break
-        if batch > 0 and delay > 0:
-            time.sleep(delay)
-
-        try:
-            results = generate_sentences_batch(
-                target_word=lemma_ar,
-                target_translation=gloss_en,
-                known_words=known_words,
-                count=min(needed - len(valid_sentences) + 2, 4),
-                difficulty_hint=difficulty_hint,
-                model_override=model,
-                rejected_words=rejected_words if rejected_words else None,
-                avoid_words=avoid_words,
-                max_words=max_words,
-            )
-        except AllProvidersFailed as e:
-            print(f"    LLM error: {e}")
-            break
-
-        for res in results:
-            if len(valid_sentences) >= needed:
-                break
-
-            validation = validate_sentence(
-                arabic_text=res.arabic,
-                target_bare=target_bare,
-                known_bare_forms=all_bare,
-            )
-            if not validation.valid:
-                for issue in validation.issues:
-                    print(f"    ✗ Rejected: {issue}")
-                for uw in validation.unknown_words:
-                    bare = strip_diacritics(uw)
-                    if bare not in rejected_words:
-                        rejected_words.append(bare)
-                continue
-
-            tokens = tokenize_display(res.arabic)
-            mappings = map_tokens_to_lemmas(
-                tokens=tokens,
-                lemma_lookup=lemma_lookup,
-                target_lemma_id=target_lemma_id,
-                target_bare=target_bare,
-            )
-
-            valid_sentences.append({
-                "arabic": res.arabic,
-                "english": res.english,
-                "transliteration": res.transliteration,
-                "mappings": mappings,
-            })
-
-    # ── DB write phase (milliseconds) ──
-    stored = 0
-    for vs in valid_sentences:
-        sent = Sentence(
-            arabic_text=vs["arabic"],
-            arabic_diacritized=vs["arabic"],
-            english_translation=vs["english"],
-            transliteration=vs["transliteration"],
-            source="llm",
-            target_lemma_id=target_lemma_id,
-            created_at=datetime.now(timezone.utc),
-        )
-        db.add(sent)
-        db.flush()
-
-        for m in vs["mappings"]:
-            sw = SentenceWord(
-                sentence_id=sent.id,
-                position=m.position,
-                surface_form=m.surface_form,
-                lemma_id=m.lemma_id,
-                is_target_word=m.is_target,
-            )
-            db.add(sw)
-        stored += 1
-
-    db.commit()
-    return stored
 
 
 # ── Step 0: Enforce sentence cap by retiring excess ──────────────────
@@ -522,20 +398,13 @@ def step_backfill_sentences(
         if not lemma:
             continue
 
-        word_sample = sample_known_words_weighted(
-            known_words, content_word_counts, KNOWN_SAMPLE_SIZE,
-            target_lemma_id=lemma.lemma_id,
-        )
-
         words_processed += 1
         print(f"  {lemma.lemma_ar} ({lemma.gloss_en}) — have {existing}, need {needed}, due {w['due_str'][:10]}")
         if dry_run:
             total += needed
         else:
-            stored = generate_sentences_for_word(
-                db, lemma, word_sample, lemma_lookup,
-                needed=needed, model=model, delay=delay,
-                avoid_words=avoid_words,
+            stored = generate_material_for_word(
+                lemma.lemma_id, needed=needed, model_override=model,
             )
             total += stored
             if stored:
@@ -677,9 +546,6 @@ def step_pregenerate_candidates(db: Session, dry_run: bool, count: int, model: s
 
     print(f"  Found {len(candidates)} upcoming candidates")
 
-    known_words, lemma_lookup = get_known_words_and_lookup(db)
-    content_word_counts = get_content_word_counts(db)
-    avoid_words = get_avoid_words(content_word_counts, known_words)
     budget = TARGET_PIPELINE_SENTENCES - total_active
 
     total = 0
@@ -698,16 +564,12 @@ def step_pregenerate_candidates(db: Session, dry_run: bool, count: int, model: s
         if dry_run:
             total += needed
         else:
-            lemma = db.query(Lemma).filter(Lemma.lemma_id == lid).first()
-            if lemma:
-                stored = generate_sentences_for_word(
-                    db, lemma, known_words, lemma_lookup,
-                    needed=needed, model=model, delay=delay,
-                    avoid_words=avoid_words,
-                )
-                total += stored
-                if stored:
-                    print(f"    Generated {stored} sentences")
+            stored = generate_material_for_word(
+                lid, needed=needed, model_override=model,
+            )
+            total += stored
+            if stored:
+                print(f"    Generated {stored} sentences")
 
     print(f"  → Total sentences: {total}")
     return total


### PR DESCRIPTION
## Summary
- Three scripts had their own copy of sentence generation that skipped LLM verification — the cron generated 20-50 unverified sentences every 3h, which was the main source of bad lemma mappings
- All scripts now call `generate_material_for_word()` which includes disambiguation + LLM verification + correction
- 467 lines of duplicated unverified code removed

Generated with [Claude Code](https://claude.com/claude-code)