### PR TITLE
fix: tighten LLM pipeline verification across all code paths

### DIFF
--- a/backend/app/routers/review.py
+++ b/backend/app/routers/review.py
@@ -66,16 +66,12 @@ def next_sentences(
 ):
     """Get a sentence-based review session.
 
-    Non-prefetch requests skip on-demand LLM generation for fast response
-    (~0.5s instead of ~30s). A background warm task runs after to generate
-    sentences for uncovered words so the next session is ready.
+    No LLM calls — session builds from pre-generated sentences (<1s).
+    Background warm_sentence_cache generates for uncovered words after.
     """
-    # Prefetch calls do full generation (they run in background anyway).
-    # Direct user requests skip on-demand gen for fast load.
     result = build_session(
         db, limit=limit, mode=mode,
         log_events=not prefetch,
-        skip_on_demand=not prefetch,
         exclude_sentence_ids=set(exclude) if exclude else None,
     )
 

--- a/backend/app/services/book_import_service.py
+++ b/backend/app/services/book_import_service.py
@@ -359,6 +359,9 @@ def create_book_sentences(
             corrections = verify_and_correct_mappings_llm(
                 arabic, english, mapped, lemma_map_for_verify,
             )
+            verification_ran = corrections is not None
+            if corrections is None:
+                corrections = []  # LLM unavailable — store without verification
             for corr in corrections:
                 pos = corr["position"]
                 m = next((m for m in mappings if m.position == pos), None)
@@ -376,6 +379,8 @@ def create_book_sentences(
                 elif not new_lid:
                     logger.warning(f"LLM flagged bad mapping: {m.surface_form} → lemma {m.lemma_id}, nulling out")
                     m.lemma_id = None
+        else:
+            verification_ran = False
 
         target_lid = _pick_primary_target(mappings, db)
 
@@ -389,6 +394,7 @@ def create_book_sentences(
             story_id=story.id,
             is_active=True,
             created_at=datetime.now(timezone.utc),
+            mappings_verified_at=datetime.now(timezone.utc) if verification_ran else None,
             max_word_count=len(tokens),
             page_number=sent_data.get("page_number"),
         )

--- a/backend/app/services/material_generator.py
+++ b/backend/app/services/material_generator.py
@@ -149,9 +149,13 @@ def generate_material_for_word(lemma_id: int, needed: int = 2, model_override: s
                 for lid in [m.lemma_id] + (m.alternative_lemma_ids or [])
                 if lid and lid in all_lemma_by_id
             }
-            mappings = disambiguate_mappings_llm(
+            result = disambiguate_mappings_llm(
                 res.arabic, res.english, mappings, lemma_map_for_disambig,
             )
+            if result is None:
+                logger.warning(f"Disambiguation failed for ambiguous sentence, skipping")
+                continue
+            mappings = result
 
         # Verify mappings — None means verification failed, discard sentence
         lemma_map_for_verify = {
@@ -337,9 +341,14 @@ def store_multi_target_sentence(
         lemma_map_for_disambig = {l.lemma_id: l for l in db.query(Lemma).filter(
             Lemma.lemma_id.in_(list(all_ids))
         ).all()}
-        mappings = disambiguate_mappings_llm(
+        disambig_result = disambiguate_mappings_llm(
             result.arabic, result.english, mappings, lemma_map_for_disambig,
         )
+        if disambig_result is None:
+            logger.warning("Disambiguation failed for ambiguous multi-target sentence, discarding")
+            db.delete(sent)
+            return None
+        mappings = disambig_result
 
     # Verify mappings — None means verification failed, discard sentence
     from app.services.sentence_validator import (

--- a/backend/app/services/sentence_selector.py
+++ b/backend/app/services/sentence_selector.py
@@ -388,7 +388,6 @@ def build_session(
     limit: int = 10,
     mode: str = "reading",
     log_events: bool = True,
-    skip_on_demand: bool = False,
     exclude_sentence_ids: set[int] | None = None,
 ) -> dict:
     """Assemble a sentence-based review session.
@@ -510,7 +509,7 @@ def build_session(
     slots_for_intro = max(intro_slots, undersized_slots)
     auto_introduced_ids = _auto_introduce_words(
         db, slots_for_intro, knowledge_by_id, now,
-        skip_material_gen=skip_on_demand,
+        skip_material_gen=True,
     )
     if auto_introduced_ids:
         # Add newly introduced words to due set and tracking structures
@@ -601,7 +600,7 @@ def build_session(
     if exclude_sentence_ids:
         sentence_ids_with_due -= exclude_sentence_ids
     if not sentence_ids_with_due:
-        return _with_fallbacks(db, session_id, due_lemma_ids, stability_map, total_due, [], limit, reintro_cards=reintro_cards, knowledge_by_id=knowledge_by_id, all_knowledge=all_knowledge, skip_on_demand=skip_on_demand, mode=mode)
+        return _with_fallbacks(db, session_id, due_lemma_ids, stability_map, total_due, [], limit, reintro_cards=reintro_cards, knowledge_by_id=knowledge_by_id, all_knowledge=all_knowledge, mode=mode)
 
     from sqlalchemy import or_
 
@@ -661,7 +660,7 @@ def build_session(
                 sentences.extend(rescue_sents)
 
     if not sentences:
-        return _with_fallbacks(db, session_id, due_lemma_ids, stability_map, total_due, [], limit, reintro_cards=reintro_cards, knowledge_by_id=knowledge_by_id, all_knowledge=all_knowledge, skip_on_demand=skip_on_demand, mode=mode)
+        return _with_fallbacks(db, session_id, due_lemma_ids, stability_map, total_due, [], limit, reintro_cards=reintro_cards, knowledge_by_id=knowledge_by_id, all_knowledge=all_knowledge, mode=mode)
 
     sentence_map: dict[int, Sentence] = {s.id: s for s in sentences}
 
@@ -1150,7 +1149,7 @@ def build_session(
 
     db.commit()
 
-    return _with_fallbacks(db, session_id, due_lemma_ids, stability_map, total_due, items, limit, covered_ids, reintro_cards=reintro_cards, knowledge_by_id=knowledge_by_id, all_knowledge=all_knowledge, base_item_count=base_item_count, skip_on_demand=skip_on_demand, mode=mode)
+    return _with_fallbacks(db, session_id, due_lemma_ids, stability_map, total_due, items, limit, covered_ids, reintro_cards=reintro_cards, knowledge_by_id=knowledge_by_id, all_knowledge=all_knowledge, base_item_count=base_item_count, mode=mode)
 
 
 MAX_REINTRO_PER_SESSION = 3
@@ -1635,8 +1634,8 @@ def _find_pregenerated_sentences_for_words(
 ) -> list[dict]:
     """Find pre-generated sentences for newly introduced words (no LLM calls).
 
-    Used during fill phase when skip_on_demand=True to populate sessions
-    from the existing sentence pool without waiting for LLM generation.
+    Used during fill phase to populate sessions from the existing sentence pool.
+    All sentence generation happens in background (warm_sentence_cache / cron).
     """
     import logging
     from sqlalchemy import or_
@@ -1891,13 +1890,12 @@ def _with_fallbacks(
     knowledge_by_id: dict[int, UserLemmaKnowledge] | None = None,
     all_knowledge: list | None = None,
     base_item_count: int | None = None,
-    skip_on_demand: bool = False,
     mode: str = "reading",
 ) -> dict:
-    """Generate on-demand sentences for uncovered due words, then fill if undersized.
+    """Fill undersized sessions using pre-generated sentences (DB queries only).
 
-    When skip_on_demand=True, skips LLM generation but still runs the fill
-    phase using pre-generated sentences (fast DB queries only).
+    No LLM calls — all sentence generation happens in background via
+    warm_sentence_cache() and the cron. This keeps session build <1s.
     """
     import logging
     logger = logging.getLogger(__name__)
@@ -1907,33 +1905,15 @@ def _with_fallbacks(
     if knowledge_by_id is None:
         knowledge_by_id = {}
 
-    if not skip_on_demand:
-        # Phase 1: On-demand generation for uncovered due words
-        # Use base_item_count (pre-acquisition-repetition) for budget so that
-        # acquisition repetition doesn't block on-demand generation for uncovered words
-        uncovered = due_lemma_ids - covered_ids
-        budget_basis = base_item_count if base_item_count is not None else len(items)
-        on_demand_budget = max(0, limit - budget_basis)
-        if uncovered and on_demand_budget > 0:
-            try:
-                generated_items = _generate_on_demand(db, uncovered, stability_map, on_demand_budget)
-                items.extend(generated_items)
-                for item in generated_items:
-                    covered_ids.add(item["primary_lemma_id"])
-            except Exception:
-                logger.exception("On-demand generation failed, continuing with existing sentences")
-                db.rollback()
-    else:
-        uncovered = due_lemma_ids - covered_ids
-        if uncovered:
-            logger.info(f"Skipping on-demand generation for {len(uncovered)} uncovered words (fast mode)")
+    uncovered = due_lemma_ids - covered_ids
+    if uncovered:
+        logger.info(f"{len(uncovered)} uncovered words — warm_sentence_cache will generate for next session")
 
-    # Phase 2: Fill phase — ALWAYS runs when session is undersized.
-    # When skip_on_demand=True, uses pre-generated sentences (fast DB queries).
-    # When skip_on_demand=False, uses LLM generation for new sentences.
+    # Fill phase — ALWAYS runs when session is undersized.
+    # Uses pre-generated sentences only (fast DB queries, no LLM).
     if len(items) < limit:
         logger.info(
-            f"Fill phase (fast={skip_on_demand}): session has {len(items)}/{limit} items"
+            f"Fill phase: session has {len(items)}/{limit} items"
         )
         try:
             now = datetime.now(timezone.utc)
@@ -1956,15 +1936,10 @@ def _with_fallbacks(
                 fill_due = set(fill_ids)
                 remaining_cap = limit - len(items)
                 if remaining_cap > 0:
-                    if not skip_on_demand:
-                        fill_items = _generate_on_demand(
-                            db, fill_due, stability_map, remaining_cap
-                        )
-                    else:
-                        fill_items = _find_pregenerated_sentences_for_words(
-                            db, fill_due, stability_map, knowledge_by_id,
-                            all_knowledge or [], remaining_cap, mode=mode,
-                        )
+                    fill_items = _find_pregenerated_sentences_for_words(
+                        db, fill_due, stability_map, knowledge_by_id,
+                        all_knowledge or [], remaining_cap, mode=mode,
+                    )
                     for fi in fill_items:
                         if fi.get("selection_info"):
                             fi["selection_info"]["reason"] = "fill_intro"

--- a/backend/app/services/sentence_validator.py
+++ b/backend/app/services/sentence_validator.py
@@ -1070,6 +1070,7 @@ Only include positions where your choice differs from option A (the current mapp
                 m.lemma_id = chosen_id
     except (AllProvidersFailed, Exception) as e:
         _validator_logger.warning(f"LLM mapping disambiguation failed: {e}")
+        return None  # caller should skip sentence with unresolved ambiguities
 
     return mappings
 

--- a/backend/app/services/story_service.py
+++ b/backend/app/services/story_service.py
@@ -499,7 +499,116 @@ Set name_type to "personal" for personal names (people, characters), "place" for
         except Exception as e:
             logger.warning("Variant detection failed for story %d: %s", story.id, e)
 
+    # Step 5: Verify new lemma-StoryWord mappings via LLM
+    if new_lemma_ids:
+        _verify_new_story_mappings(db, story, set(new_lemma_ids))
+
+    # Step 6: Queue enrichment for new lemmas (forms_json, etymology)
+    if new_lemma_ids:
+        try:
+            from app.services.lemma_enrichment import enrich_lemmas_batch
+            import threading
+            threading.Thread(
+                target=enrich_lemmas_batch,
+                args=(new_lemma_ids,),
+                daemon=True,
+            ).start()
+        except Exception as e:
+            logger.warning("Failed to queue enrichment for story %d new lemmas: %s", story.id, e)
+
     return new_lemma_ids
+
+
+def _verify_new_story_mappings(
+    db: Session, story: Story, new_lemma_ids: set[int]
+) -> None:
+    """Verify StoryWord mappings for newly created lemmas using LLM.
+
+    Groups story words into chunks by position, builds a sentence-like context,
+    and calls verify_and_correct_mappings_llm. Wrong mappings are nulled out
+    (never auto-create lemmas from corrections).
+    """
+    from app.services.sentence_validator import (
+        verify_and_correct_mappings_llm,
+        correct_mapping as _correct_mapping,
+        TokenMapping,
+    )
+
+    # Collect story words that reference new lemmas
+    words_to_verify = [
+        sw for sw in story.words
+        if sw.lemma_id and sw.lemma_id in new_lemma_ids
+    ]
+    if not words_to_verify:
+        return
+
+    # Build context: get surrounding text for each new-lemma word
+    all_words = sorted(story.words, key=lambda w: w.position)
+    text_tokens = [sw.surface_form for sw in all_words]
+    full_text = " ".join(text_tokens)
+
+    # Build mappings for verification (only new-lemma words)
+    lemma_ids_needed = {sw.lemma_id for sw in words_to_verify if sw.lemma_id}
+    lemma_map = {
+        l.lemma_id: l for l in db.query(Lemma).filter(
+            Lemma.lemma_id.in_(list(lemma_ids_needed))
+        ).all()
+    }
+
+    # Batch verify in chunks of 15 words to keep LLM context manageable
+    CHUNK_SIZE = 15
+    fixed = 0
+    nulled = 0
+    for i in range(0, len(words_to_verify), CHUNK_SIZE):
+        chunk = words_to_verify[i:i + CHUNK_SIZE]
+        mappings = [
+            TokenMapping(
+                position=sw.position,
+                surface_form=sw.surface_form,
+                lemma_id=sw.lemma_id,
+                is_target=False,
+                is_function_word=sw.is_function_word or False,
+            )
+            for sw in chunk
+        ]
+
+        # Use story text as context (truncated around the chunk)
+        min_pos = min(sw.position for sw in chunk)
+        max_pos = max(sw.position for sw in chunk)
+        context_start = max(0, min_pos - 5)
+        context_end = min(len(text_tokens), max_pos + 6)
+        context_text = " ".join(text_tokens[context_start:context_end])
+
+        corrections = verify_and_correct_mappings_llm(
+            context_text, "", mappings, lemma_map,
+        )
+        if corrections is None or not corrections:
+            continue
+
+        for corr in corrections:
+            pos = corr["position"]
+            sw = next((sw for sw in chunk if sw.position == pos), None)
+            if not sw:
+                continue
+            new_lid = _correct_mapping(
+                db,
+                corr.get("correct_lemma_ar", ""),
+                corr.get("correct_gloss", ""),
+                corr.get("correct_pos", ""),
+            )
+            if new_lid and new_lid != sw.lemma_id:
+                logger.info(f"Story {story.id}: corrected mapping '{sw.surface_form}': #{sw.lemma_id} → #{new_lid}")
+                sw.lemma_id = new_lid
+                fixed += 1
+            elif not new_lid:
+                logger.warning(f"Story {story.id}: nulling bad mapping '{sw.surface_form}' → #{sw.lemma_id}")
+                sw.lemma_id = None
+                sw.gloss_en = None
+                nulled += 1
+
+    if fixed or nulled:
+        db.flush()
+        logger.info(f"Story {story.id}: verified new mappings — {fixed} fixed, {nulled} nulled")
 
 
 _ACTIVELY_LEARNING_STATES = {"acquiring", "learning", "known", "lapsed"}

--- a/backend/tests/test_sentence_selector.py
+++ b/backend/tests/test_sentence_selector.py
@@ -716,11 +716,11 @@ class TestScaffoldDiversity:
 
 
 class TestFillPhasePregenerated:
-    """Fill phase should use pre-generated sentences when skip_on_demand=True."""
+    """Fill phase should use pre-generated sentences (no LLM calls in session build)."""
 
-    def test_fill_uses_pregenerated_in_fast_mode(self, db_session):
-        """When skip_on_demand=True and session is undersized, fill phase
-        should introduce words and find their pre-generated sentences."""
+    def test_fill_uses_pregenerated(self, db_session):
+        """When session is undersized, fill phase should introduce words
+        and find their pre-generated sentences."""
         # 1 due word → produces 1-card session (undersized for limit=5)
         _seed_word(db_session, 1, "كتاب", "book", due_hours=-1)
         _seed_sentence(db_session, 1, "الكتاب", "the book", 1, [("الكتاب", 1)])
@@ -751,7 +751,7 @@ class TestFillPhasePregenerated:
             ))
         db_session.commit()
 
-        result = build_session(db_session, limit=5, skip_on_demand=True)
+        result = build_session(db_session, limit=5)
         # Should have at least the 1 due word; if fill phase works,
         # it may introduce more words with pre-generated sentences
         assert len(result["items"]) >= 1


### PR DESCRIPTION
## Summary
- Fix book import crash when LLM verification unavailable (TypeError on None iteration)
- Remove on-demand sentence generation from session building — sessions now build from pre-generated sentences only (<1s, no LLM)
- disambiguate_mappings_llm returns None on failure instead of silently passing wrong mappings through
- Story import: verify new lemma-StoryWord mappings via LLM, queue enrichment for new lemmas

Generated with [Claude Code](https://claude.com/claude-code)