### PR TITLE
feat: variant verification audit with Jaccard scoring

### DIFF
--- a/backend/app/services/variant_detection.py
+++ b/backend/app/services/variant_detection.py
@@ -31,15 +31,42 @@ _NEVER_MERGE = {
 }
 
 
+GLOSS_NOISE_WORDS = {
+    "a", "an", "the", "of", "to", "is", "my", "your", "his", "her", "its",
+    "their", "our", "(m)", "(f)", "m", "f", "(masc)", "(fem)",
+}
+
+
+def _tokenize_gloss(gloss: str) -> set[str]:
+    """Tokenize a gloss into meaningful words, stripping noise words."""
+    if not gloss:
+        return set()
+    return set(gloss.lower().replace("(", " ").replace(")", " ").split()) - GLOSS_NOISE_WORDS
+
+
 def _gloss_overlap(gloss_a: str, gloss_b: str) -> bool:
     """Check if two glosses share semantic content (at least one meaningful word)."""
     if not gloss_a or not gloss_b:
         return False
-    noise = {"a", "an", "the", "of", "to", "is", "my", "your", "his", "her", "its",
-             "their", "our", "(m)", "(f)", "m", "f", "(masc)", "(fem)"}
-    words_a = set(gloss_a.lower().replace("(", " ").replace(")", " ").split()) - noise
-    words_b = set(gloss_b.lower().replace("(", " ").replace(")", " ").split()) - noise
+    words_a = _tokenize_gloss(gloss_a)
+    words_b = _tokenize_gloss(gloss_b)
     return bool(words_a & words_b)
+
+
+def compute_jaccard_similarity(gloss_a: str, gloss_b: str) -> float:
+    """Compute Jaccard similarity between two glosses (0.0 = no overlap, 1.0 = identical).
+
+    Tokenizes glosses into meaningful words (stripping noise words like articles,
+    prepositions, gender markers) and computes |intersection| / |union|.
+    """
+    words_a = _tokenize_gloss(gloss_a)
+    words_b = _tokenize_gloss(gloss_b)
+    if not words_a and not words_b:
+        return 0.0
+    union = words_a | words_b
+    if not union:
+        return 0.0
+    return len(words_a & words_b) / len(union)
 
 
 def _has_enclitic(enc0: str) -> bool:
@@ -522,3 +549,49 @@ def detect_variants_llm(
         print(f"Result: {len(confirmed)}/{len(camel_candidates)} confirmed by LLM")
 
     return confirmed
+
+
+def verify_variant_pair(
+    db: Session,
+    variant_lemma: "Lemma",
+    canonical_lemma: "Lemma",
+    model_override: str | None = "claude_haiku",
+) -> bool:
+    """Check whether a variant-canonical pair is semantically valid.
+
+    Intended for import pipelines to verify new variant assignments before
+    committing them. Uses gloss overlap as a fast check, falls back to LLM
+    for ambiguous cases.
+
+    Args:
+        db: Database session (used for LLM decision cache).
+        variant_lemma: The lemma being marked as a variant.
+        canonical_lemma: The proposed canonical lemma.
+        model_override: LLM model for verification.
+
+    Returns:
+        True if the pair is a valid variant relationship, False if they
+        appear to be semantically distinct words.
+    """
+    # Fast path: if glosses overlap, likely a valid variant
+    if _gloss_overlap(variant_lemma.gloss_en, canonical_lemma.gloss_en):
+        return True
+
+    # No gloss overlap — ask LLM to verify
+    candidate = {
+        "id": 0,
+        "word_ar": variant_lemma.lemma_ar_bare or "",
+        "word_gloss": variant_lemma.gloss_en or "",
+        "word_pos": variant_lemma.pos or "",
+        "base_ar": canonical_lemma.lemma_ar_bare or "",
+        "base_gloss": canonical_lemma.gloss_en or "",
+        "base_pos": canonical_lemma.pos or "",
+    }
+    results = evaluate_variants_llm(
+        [candidate], model_override=model_override, db=db,
+    )
+    if not results:
+        # LLM unavailable — err on the side of not merging
+        return False
+
+    return results[0].get("is_variant", False)

--- a/backend/scripts/audit_variants.py
+++ b/backend/scripts/audit_variants.py
@@ -1,0 +1,311 @@
+"""Audit variant-canonical links for semantically distinct words incorrectly merged.
+
+Computes Jaccard gloss similarity between each variant and its canonical lemma.
+Zero-overlap pairs are sent to LLM for verification. Confirmed false positives
+can be unmerged with --fix.
+
+Usage:
+    python3 scripts/audit_variants.py                # dry-run, report only
+    python3 scripts/audit_variants.py --fix          # unmerge confirmed false positives
+    python3 scripts/audit_variants.py --threshold 0.1  # flag pairs below 0.1 Jaccard
+"""
+
+import argparse
+import logging
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from app.database import SessionLocal
+from app.models import Lemma
+from app.services.activity_log import log_activity
+from app.services.variant_detection import compute_jaccard_similarity
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+LLM_BATCH_SIZE = 12
+
+SYSTEM_PROMPT = """\
+You are an Arabic morphology expert. You will be given pairs of Arabic words \
+where one has been marked as a "variant" (same dictionary entry) of the other. \
+Your job is to verify whether each link is correct or a false positive.
+
+A pair IS a true variant (same dictionary entry) when:
+- Verb conjugation -> base verb
+- Feminine form -> masculine (same concept)
+- Broken/sound plural -> singular
+- Possessive -> base noun
+- Definite -> indefinite
+
+A pair is NOT a true variant (distinct dictionary entries) when:
+- Different core meanings despite shared root (e.g. dish vs hunter)
+- Verbal noun vs related noun (writing vs book)
+- Agent noun vs verb/noun (writer vs book)
+- Nisba adjective vs base noun (Egyptian vs Egypt)
+- Words with different roots
+- The key test: would an Arabic learner benefit from tracking these as ONE word?
+
+Respond with JSON only."""
+
+
+def build_batch_prompt(pairs: list[dict]) -> str:
+    """Build prompt for a batch of suspicious variant pairs."""
+    lines = [
+        "For each numbered pair, determine if VARIANT is truly a morphological "
+        "variant of CANONICAL (same dictionary entry) or a false positive "
+        "(distinct words that were incorrectly linked).\n"
+    ]
+    for p in pairs:
+        lines.append(
+            f"{p['idx']}. VARIANT: {p['var_ar']} \"{p['var_gloss']}\" ({p['var_pos']}) "
+            f"-> CANONICAL: {p['canon_ar']} \"{p['canon_gloss']}\" ({p['canon_pos']})"
+        )
+
+    lines.append(
+        '\nRespond with JSON: {"results": [{"id": 1, "is_variant": true/false, '
+        '"reason": "brief explanation"}, ...]}'
+    )
+    return "\n".join(lines)
+
+
+def call_llm_batch(pairs: list[dict]) -> list[dict]:
+    """Send a batch of pairs to LLM and return parsed results."""
+    from app.services.llm import generate_completion
+
+    prompt = build_batch_prompt(pairs)
+
+    for model in ["claude_haiku", "gemini"]:
+        try:
+            result = generate_completion(
+                prompt=prompt,
+                system_prompt=SYSTEM_PROMPT,
+                json_mode=True,
+                temperature=0.1,
+                model_override=model,
+                task_type="variant_audit",
+            )
+            raw = result.get("results", [])
+            if isinstance(raw, list) and len(raw) > 0:
+                return raw
+        except Exception as e:
+            logger.warning(f"LLM call failed with {model}: {e}")
+            continue
+
+    return []
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Audit variant->canonical links for false merges"
+    )
+    parser.add_argument(
+        "--fix", action="store_true",
+        help="Unmerge LLM-confirmed false positives (default: dry-run)"
+    )
+    parser.add_argument(
+        "--threshold", type=float, default=0.0,
+        help="Jaccard similarity threshold below which to flag (default: 0.0 = zero overlap only)"
+    )
+    parser.add_argument(
+        "--skip-llm", action="store_true",
+        help="Skip LLM verification, just report gloss similarity"
+    )
+    args = parser.parse_args()
+
+    dry_run = not args.fix
+    db = SessionLocal()
+
+    # Step 1: Load all variant->canonical pairs
+    variants = (
+        db.query(Lemma)
+        .filter(Lemma.canonical_lemma_id.isnot(None))
+        .all()
+    )
+
+    print(f"Found {len(variants)} variant->canonical links\n")
+
+    if not variants:
+        db.close()
+        return
+
+    # Step 2: Compute Jaccard similarity for each pair
+    all_pairs = []
+    suspicious = []
+    confirmed_by_gloss = []
+
+    for var in variants:
+        canon = db.query(Lemma).filter(Lemma.lemma_id == var.canonical_lemma_id).first()
+        if not canon:
+            logger.warning(
+                f"Variant #{var.lemma_id} points to missing canonical #{var.canonical_lemma_id}"
+            )
+            continue
+
+        jaccard = compute_jaccard_similarity(var.gloss_en or "", canon.gloss_en or "")
+        pair_info = {
+            "variant_id": var.lemma_id,
+            "variant_ar": var.lemma_ar_bare or "",
+            "variant_gloss": var.gloss_en or "",
+            "variant_pos": var.pos or "",
+            "canonical_id": canon.lemma_id,
+            "canonical_ar": canon.lemma_ar_bare or "",
+            "canonical_gloss": canon.gloss_en or "",
+            "canonical_pos": canon.pos or "",
+            "jaccard": jaccard,
+        }
+        all_pairs.append(pair_info)
+
+        if jaccard <= args.threshold:
+            suspicious.append(pair_info)
+        else:
+            confirmed_by_gloss.append(pair_info)
+
+    print(f"  {len(confirmed_by_gloss)} pairs above Jaccard threshold (OK)")
+    print(f"  {len(suspicious)} pairs at/below threshold {args.threshold} (suspicious)\n")
+
+    if not suspicious:
+        print("No suspicious pairs found.")
+        db.close()
+        return
+
+    # Step 3: Show suspicious pairs table
+    print(f"{'ID':>5}  {'Variant':>15}  {'Variant Gloss':<25}  {'Canon ID':>8}  "
+          f"{'Canonical':>15}  {'Canon Gloss':<25}  {'Jaccard':>7}")
+    print("-" * 110)
+    for p in suspicious:
+        print(f"{p['variant_id']:>5}  {p['variant_ar']:>15}  {p['variant_gloss']:<25.25}  "
+              f"{p['canonical_id']:>8}  {p['canonical_ar']:>15}  "
+              f"{p['canonical_gloss']:<25.25}  {p['jaccard']:>7.3f}")
+    print()
+
+    if args.skip_llm:
+        print("Skipping LLM verification (--skip-llm).")
+        db.close()
+        return
+
+    # Step 4: LLM verification of suspicious pairs
+    print("--- LLM verification ---")
+    to_unlink = []
+    llm_confirmed = []
+
+    for batch_start in range(0, len(suspicious), LLM_BATCH_SIZE):
+        batch = suspicious[batch_start:batch_start + LLM_BATCH_SIZE]
+        batch_num = batch_start // LLM_BATCH_SIZE + 1
+        total_batches = (len(suspicious) + LLM_BATCH_SIZE - 1) // LLM_BATCH_SIZE
+        print(f"  Batch {batch_num}/{total_batches} ({len(batch)} pairs)...")
+
+        llm_input = []
+        for i, p in enumerate(batch):
+            llm_input.append({
+                "idx": i + 1,
+                "var_ar": p["variant_ar"],
+                "var_gloss": p["variant_gloss"],
+                "var_pos": p["variant_pos"],
+                "canon_ar": p["canonical_ar"],
+                "canon_gloss": p["canonical_gloss"],
+                "canon_pos": p["canonical_pos"],
+            })
+
+        results = call_llm_batch(llm_input)
+
+        if not results:
+            print("    LLM returned no results for this batch, skipping")
+            continue
+
+        result_by_id = {}
+        for r in results:
+            if isinstance(r, dict) and "id" in r:
+                result_by_id[r["id"]] = r
+
+        for i, p in enumerate(batch):
+            r = result_by_id.get(i + 1)
+            if not r:
+                p["llm_verdict"] = "no_response"
+                continue
+
+            is_variant = bool(r.get("is_variant", False))
+            reason = r.get("reason", "")
+
+            if is_variant:
+                p["llm_verdict"] = f"YES: {reason}"
+                llm_confirmed.append(p)
+            else:
+                p["llm_verdict"] = f"NO: {reason}"
+                to_unlink.append(p)
+                print(f"    UNLINK  {p['variant_ar']} \"{p['variant_gloss']}\" -> "
+                      f"{p['canonical_ar']} \"{p['canonical_gloss']}\" -- {reason}")
+
+    # Step 5: Results table
+    print(f"\n{'='*110}")
+    print("RESULTS TABLE")
+    print(f"{'='*110}")
+    print(f"{'ID':>5}  {'Variant':>15}  {'Variant Gloss':<25}  {'Canon ID':>8}  "
+          f"{'Canonical':>15}  {'Canon Gloss':<25}  {'Jaccard':>7}  {'LLM Verdict'}")
+    print("-" * 130)
+    for p in suspicious:
+        verdict = p.get("llm_verdict", "pending")
+        print(f"{p['variant_id']:>5}  {p['variant_ar']:>15}  {p['variant_gloss']:<25.25}  "
+              f"{p['canonical_id']:>8}  {p['canonical_ar']:>15}  "
+              f"{p['canonical_gloss']:<25.25}  {p['jaccard']:>7.3f}  {verdict}")
+
+    # Step 6: Summary
+    print(f"\n=== SUMMARY ===")
+    print(f"  Total variant links:         {len(variants)}")
+    print(f"  Confirmed by gloss overlap:  {len(confirmed_by_gloss)}")
+    print(f"  Confirmed by LLM:            {len(llm_confirmed)}")
+    print(f"  FALSE POSITIVES to unlink:   {len(to_unlink)}")
+
+    if not to_unlink:
+        print("\nAll suspicious variant links verified by LLM. Nothing to fix.")
+        db.close()
+        return
+
+    if dry_run:
+        print(f"\nDry run -- no changes made. Use --fix to unmerge false positives.")
+        db.close()
+        return
+
+    # Step 7: Apply fixes
+    unlinked = 0
+    for p in to_unlink:
+        lemma = db.query(Lemma).filter(Lemma.lemma_id == p["variant_id"]).first()
+        if lemma:
+            lemma.canonical_lemma_id = None
+            unlinked += 1
+
+    db.commit()
+    print(f"\nUnmerged {unlinked} false positive variant links.")
+
+    log_activity(
+        db,
+        event_type="variant_cleanup_completed",
+        summary=f"Variant audit: unmerged {unlinked} false positives out of {len(variants)} links",
+        detail={
+            "total_links": len(variants),
+            "confirmed_by_gloss": len(confirmed_by_gloss),
+            "confirmed_by_llm": len(llm_confirmed),
+            "unlinked": len(to_unlink),
+            "unlinked_pairs": [
+                {
+                    "variant_id": p["variant_id"],
+                    "variant": p["variant_ar"],
+                    "variant_gloss": p["variant_gloss"],
+                    "canonical_id": p["canonical_id"],
+                    "canonical": p["canonical_ar"],
+                    "canonical_gloss": p["canonical_gloss"],
+                    "jaccard": p["jaccard"],
+                    "llm_verdict": p.get("llm_verdict", ""),
+                }
+                for p in to_unlink
+            ],
+        },
+        commit=True,
+    )
+
+    db.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/test_variant_detection.py
+++ b/backend/tests/test_variant_detection.py
@@ -11,7 +11,10 @@ from app.services.variant_detection import (
     _gloss_overlap,
     _has_enclitic,
     _build_llm_batch_prompt,
+    _tokenize_gloss,
+    compute_jaccard_similarity,
     evaluate_variants_llm,
+    verify_variant_pair,
 )
 
 
@@ -222,3 +225,102 @@ class TestEvaluateVariantsLlm:
         assert len(results2) == 1
         assert results2[0]["is_variant"] is True
         assert "(cached)" in results2[0]["reason"]
+
+
+class TestTokenizeGloss:
+    def test_basic(self):
+        result = _tokenize_gloss("big book")
+        assert result == {"big", "book"}
+
+    def test_strips_noise(self):
+        result = _tokenize_gloss("the big book")
+        assert "the" not in result
+        assert result == {"big", "book"}
+
+    def test_strips_gender_markers(self):
+        result = _tokenize_gloss("happy (f)")
+        assert result == {"happy"}
+
+    def test_empty(self):
+        assert _tokenize_gloss("") == set()
+        assert _tokenize_gloss(None) == set()
+
+    def test_only_noise(self):
+        result = _tokenize_gloss("a the of")
+        assert result == set()
+
+
+class TestJaccardSimilarity:
+    def test_identical(self):
+        assert compute_jaccard_similarity("book", "book") == 1.0
+
+    def test_no_overlap(self):
+        assert compute_jaccard_similarity("book", "house") == 0.0
+
+    def test_partial_overlap(self):
+        score = compute_jaccard_similarity("big book", "old book")
+        # intersection = {"book"}, union = {"big", "book", "old"} => 1/3
+        assert abs(score - 1 / 3) < 0.01
+
+    def test_noise_ignored(self):
+        score = compute_jaccard_similarity("the book", "a book")
+        assert score == 1.0
+
+    def test_both_empty(self):
+        assert compute_jaccard_similarity("", "") == 0.0
+
+    def test_one_empty(self):
+        assert compute_jaccard_similarity("book", "") == 0.0
+
+    def test_gender_markers_ignored(self):
+        score = compute_jaccard_similarity("happy (m)", "happy (f)")
+        assert score == 1.0
+
+    def test_distinct_glosses(self):
+        score = compute_jaccard_similarity("hunter", "fish dish")
+        assert score == 0.0
+
+
+class TestVerifyVariantPair:
+    def test_gloss_overlap_returns_true(self, db_session):
+        var = _seed_lemma(db_session, 1, "كتابي", "my book")
+        canon = _seed_lemma(db_session, 2, "كتاب", "book")
+        db_session.commit()
+
+        assert verify_variant_pair(db_session, var, canon) is True
+
+    def test_no_overlap_calls_llm_true(self, db_session):
+        var = _seed_lemma(db_session, 1, "صيادية", "fish dish")
+        canon = _seed_lemma(db_session, 2, "صياد", "hunter")
+        db_session.commit()
+
+        mock_response = {
+            "results": [{"id": 0, "is_variant": False, "reason": "distinct words"}]
+        }
+        with patch("app.services.llm.generate_completion",
+                    return_value=mock_response):
+            result = verify_variant_pair(db_session, var, canon)
+        assert result is False
+
+    def test_no_overlap_llm_confirms_variant(self, db_session):
+        var = _seed_lemma(db_session, 1, "ملكة", "queen")
+        canon = _seed_lemma(db_session, 2, "ملك", "king")
+        db_session.commit()
+
+        mock_response = {
+            "results": [{"id": 0, "is_variant": True, "reason": "feminine of king"}]
+        }
+        with patch("app.services.llm.generate_completion",
+                    return_value=mock_response):
+            result = verify_variant_pair(db_session, var, canon)
+        assert result is True
+
+    def test_llm_failure_returns_false(self, db_session):
+        var = _seed_lemma(db_session, 1, "صيادية", "fish dish")
+        canon = _seed_lemma(db_session, 2, "صياد", "hunter")
+        db_session.commit()
+
+        with patch("app.services.llm.generate_completion",
+                    side_effect=Exception("LLM unavailable")):
+            result = verify_variant_pair(db_session, var, canon)
+        assert result is False

--- a/docs/scripts-catalog.md
+++ b/docs/scripts-catalog.md
@@ -53,6 +53,7 @@ All scripts in `backend/scripts/`. Run from `backend/` directory.
 
 ## Cleanup & Maintenance
 - `verify_variants.py` — LLM-verified audit of all variant→canonical links. Finds pairs with no gloss overlap, sends to LLM for confirmation, unlinks false positives. `--fix` to apply (default: dry-run). `--verbose` to show all pairs.
+- `audit_variants.py` — Jaccard-scored variant audit with tabular output. Computes gloss similarity for every variant→canonical link, flags pairs below threshold (default: 0.0 = zero overlap), sends to LLM for verification. `--fix` to unmerge confirmed false positives (default: dry-run). `--threshold=N` to adjust Jaccard cutoff. `--skip-llm` for report-only mode.
 - `cleanup_bad_roots.py` — LLM-assisted bad root classification and cleanup (POS fixes, variant linking).
 - `cleanup_review_pool.py` — Reset under-learned→acquiring, suspend variant ULKs with stat merge, suspend junk, retire bad sentences, run variant detection on uncovered words.
 - `reset_ocr_cards.py` — Reset inflated OCR-imported FSRS cards to "encountered". Supports --dry-run.

--- a/research/experiment-log.md
+++ b/research/experiment-log.md
@@ -4,6 +4,18 @@ Running lab notebook for Alif's learning algorithm. Each entry documents what ch
 
 ---
 
+## 2026-03-21: Variant Verification Audit
+
+**Context**: Variant detection sometimes merges semantically-distinct words that are morphologically similar (e.g., صيادية "dish" → صياد "hunter"). These bad merges mean the variant's reviews affect the wrong canonical word.
+
+**Change**: Added `audit_variants.py` script that checks gloss coherence between variants and their canonicals. Zero-overlap pairs get LLM verification. `--fix` mode unmerges confirmed distinct words. Also added `verify_variant_pair()` for import-time checking.
+
+**Expected**: Identifies and fixes incorrectly merged variants. Prevents future bad merges via import-time verification.
+
+**Verify**: Run script, review output. Expected: 5-15 suspicious pairs out of ~100 variants.
+
+---
+
 ## 2026-03-21: Tighten LLM Pipeline Verification Across All Code Paths
 
 **Context**: Comprehensive audit of all LLM/automatic processing paths revealed 4 additional issues beyond the unverified cron (fixed earlier today).


### PR DESCRIPTION
## Summary
- Adds `compute_jaccard_similarity()` and `verify_variant_pair()` to `variant_detection.py` for detecting semantically-distinct words incorrectly merged as variants
- New `audit_variants.py` script computes gloss similarity for all variant-canonical pairs, flags zero-overlap pairs for LLM verification, and can unmerge confirmed false positives with `--fix`
- 17 new tests covering tokenization, Jaccard scoring, and pair verification (all 822 tests pass)

Generated with [Claude Code](https://claude.com/claude-code)