### PR TITLE
feat: add mnemonic regeneration for stuck words

### DIFF
--- a/IDEAS.md
+++ b/IDEAS.md
@@ -525,7 +525,7 @@
 - [DEFERRED] Use text-to-image (DALL-E, Midjourney) to generate actual images for the interactive scenes. SmartPhone (AIED 2023) showed combining verbal + visual mnemonics improves retention. Would add visual card to Learn Mode.
 
 #### Mnemonic Quality Feedback Loop
-- Track which words the user struggles with despite having a mnemonic. If a word gets ≥3 "no_idea" ratings with an existing hook, flag for regeneration with a note "previous mnemonic didn't stick."
+- [DONE] Track which words the user struggles with despite having a mnemonic. If a word gets ≥4 reviews with <50% accuracy and existing hooks, auto-regenerate with "previous mnemonic didn't stick" prompt. Background task (`check_and_regenerate_stuck_hooks`) + script (`regenerate_stuck_mnemonics.py`). 7-day cooldown. Old hooks preserved in `previous_hooks` field.
 - SMART (Balepur EMNLP 2024) finding: what students think helps and what actually helps disagree (0.4-0.5 agreement). Track observed learning outcomes, not self-reported preferences.
 
 #### PhoniTale-Style IPA Matching

--- a/backend/app/services/memory_hooks.py
+++ b/backend/app/services/memory_hooks.py
@@ -1,14 +1,24 @@
 """Generate memory hooks (mnemonics, cognates, collocations) for words.
 
 Called as a background task when words enter acquisition, or via backfill script.
+Also handles regeneration for words where mnemonics didn't stick.
 """
 
 import logging
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy.orm import Session
 
 from app.database import SessionLocal
-from app.models import Lemma
+from app.models import Lemma, ReviewLog, UserLemmaKnowledge
 
 logger = logging.getLogger(__name__)
+
+# Stuck hook detection thresholds
+STUCK_MIN_REVIEWS = 4
+STUCK_MAX_ACCURACY = 0.50
+STUCK_RECENT_WINDOW = 5
+STUCK_REGEN_COOLDOWN_DAYS = 7
 
 SYSTEM_PROMPT = """You generate memory hooks for Arabic (MSA) vocabulary using the keyword mnemonic method (Atkinson & Raugh 1975). The learner speaks: English, Norwegian, Swedish, Danish, Hindi, German, French, Italian, Spanish, Greek, Latin, Indonesian, and some Russian.
 
@@ -289,3 +299,170 @@ Return null if the word is a particle/pronoun/function word."""
         db.rollback()
     finally:
         db.close()
+
+
+def _recent_accuracy(db: Session, lemma_id: int, window: int = STUCK_RECENT_WINDOW) -> float | None:
+    """Compute accuracy over the last `window` reviews. Returns None if < STUCK_MIN_REVIEWS."""
+    recent = (
+        db.query(ReviewLog.rating)
+        .filter(ReviewLog.lemma_id == lemma_id)
+        .order_by(ReviewLog.reviewed_at.desc())
+        .limit(window)
+        .all()
+    )
+    if len(recent) < STUCK_MIN_REVIEWS:
+        return None
+    correct = sum(1 for (r,) in recent if r >= 3)
+    return correct / len(recent)
+
+
+def find_stuck_hook_words(
+    db: Session,
+    limit: int = 10,
+    cooldown_days: int = STUCK_REGEN_COOLDOWN_DAYS,
+) -> list[tuple["Lemma", "UserLemmaKnowledge", float]]:
+    """Find words with existing memory hooks that are still failing.
+
+    Criteria:
+    - memory_hooks_json is not NULL
+    - knowledge_state is acquiring or lapsed
+    - At least STUCK_MIN_REVIEWS total reviews
+    - Recent accuracy (last STUCK_RECENT_WINDOW reviews) < STUCK_MAX_ACCURACY
+    - Last regeneration was >cooldown_days ago (or never regenerated)
+
+    Returns list of (lemma, ulk, recent_accuracy) tuples.
+    """
+    candidates = (
+        db.query(Lemma, UserLemmaKnowledge)
+        .join(UserLemmaKnowledge, UserLemmaKnowledge.lemma_id == Lemma.lemma_id)
+        .filter(
+            Lemma.memory_hooks_json.isnot(None),
+            Lemma.canonical_lemma_id.is_(None),
+            UserLemmaKnowledge.knowledge_state.in_(["acquiring", "lapsed"]),
+            UserLemmaKnowledge.times_seen >= STUCK_MIN_REVIEWS,
+        )
+        .all()
+    )
+
+    now = datetime.now(timezone.utc)
+    cooldown = timedelta(days=cooldown_days)
+    stuck = []
+
+    for lemma, ulk in candidates:
+        # SQLite JSON columns store Python None as JSON "null", not SQL NULL,
+        # so the isnot(None) filter may not exclude them. Double-check here.
+        hooks = lemma.memory_hooks_json
+        if not hooks or not isinstance(hooks, dict) or not hooks.get("mnemonic"):
+            continue
+
+        # Check cooldown: skip if regenerated too recently
+        if isinstance(hooks, dict) and hooks.get("regenerated_at"):
+            try:
+                regen_at = datetime.fromisoformat(hooks["regenerated_at"])
+                if regen_at.tzinfo is None:
+                    regen_at = regen_at.replace(tzinfo=timezone.utc)
+                if now - regen_at < cooldown:
+                    continue
+            except (ValueError, TypeError):
+                pass
+
+        acc = _recent_accuracy(db, lemma.lemma_id)
+        if acc is not None and acc < STUCK_MAX_ACCURACY:
+            stuck.append((lemma, ulk, acc))
+
+    # Sort by accuracy ascending (worst first)
+    stuck.sort(key=lambda x: x[2])
+    return stuck[:limit]
+
+
+def check_and_regenerate_stuck_hooks(db: Session) -> list[int]:
+    """Background task: find and regenerate hooks for up to 3 stuck words.
+
+    Designed to be called from warm_sentence_cache or cron. Limits to 3 words
+    per run to control LLM cost. Respects 7-day cooldown between regenerations.
+
+    Returns list of lemma_ids that were regenerated.
+    """
+    from app.services.llm import generate_completion, AllProvidersFailed
+    from app.services.activity_log import log_activity
+
+    stuck = find_stuck_hook_words(db, limit=3)
+    if not stuck:
+        return []
+
+    regenerated = []
+    for lemma, ulk, recent_acc in stuck:
+        old_hooks = lemma.memory_hooks_json or {}
+        old_mnemonic = old_hooks.get("mnemonic", "")
+        regen_count = old_hooks.get("regeneration_count", 0)
+
+        word_info = _build_word_info(lemma)
+        failed_note = ""
+        if old_mnemonic:
+            failed_note = (
+                f"\n\nThe previous mnemonic FAILED — the learner reviewed this word "
+                f"{ulk.times_seen} times with only {recent_acc:.0%} accuracy. "
+                f"Do NOT reuse the same keyword or approach:\n"
+                f'  "{old_mnemonic}"'
+            )
+
+        prompt = f"""Generate memory hooks for this HARD Arabic word that the learner keeps forgetting:
+
+{word_info}{failed_note}
+
+Generate 3 candidate mnemonics with COMPLETELY DIFFERENT keywords from the failed one.
+Self-evaluate each on sound match, interaction, and meaning extraction (1-5).
+Pick the candidate with the highest total score.
+
+Return JSON with keys: candidates, best_index, mnemonic, cognates, collocations, usage_context, fun_fact.
+Return null if the word is a particle/pronoun/function word."""
+
+        try:
+            result = generate_completion(
+                prompt=prompt,
+                system_prompt=PREMIUM_SYSTEM_PROMPT,
+                json_mode=True,
+                temperature=0.8,
+                model_override="claude_haiku",
+                task_type="memory_hooks_regeneration",
+            )
+        except AllProvidersFailed as e:
+            logger.warning(f"Stuck hook regeneration LLM failed for lemma {lemma.lemma_id}: {e}")
+            continue
+
+        if result is None or not isinstance(result, dict) or not result:
+            continue
+
+        hooks = result.get("hooks", result) if "hooks" in result else result
+        hooks.pop("candidates", None)
+        hooks.pop("best_index", None)
+
+        if not validate_hooks(hooks):
+            logger.warning(f"Invalid regenerated hooks for lemma {lemma.lemma_id}")
+            continue
+
+        # Preserve old hooks and track regeneration metadata
+        hooks["previous_hooks"] = {
+            k: v for k, v in old_hooks.items()
+            if k not in ("previous_hooks", "regeneration_count", "regenerated_at")
+        }
+        hooks["regeneration_count"] = regen_count + 1
+        hooks["regenerated_at"] = datetime.now(timezone.utc).isoformat()
+
+        lemma.memory_hooks_json = hooks
+        regenerated.append(lemma.lemma_id)
+        logger.info(
+            f"Regenerated stuck mnemonic for lemma {lemma.lemma_id} "
+            f"({lemma.lemma_ar_bare}) — accuracy was {recent_acc:.0%}"
+        )
+
+    if regenerated:
+        db.commit()
+        log_activity(
+            db,
+            event_type="mnemonic_regeneration",
+            summary=f"Auto-regenerated mnemonics for {len(regenerated)} stuck words",
+            detail={"lemma_ids": regenerated},
+        )
+
+    return regenerated

--- a/backend/scripts/regenerate_stuck_mnemonics.py
+++ b/backend/scripts/regenerate_stuck_mnemonics.py
@@ -1,0 +1,164 @@
+"""Regenerate memory hooks for words failing despite having mnemonics.
+
+Finds words where the existing mnemonic didn't help: they have hooks but
+still show <50% recent accuracy with ≥4 reviews. Regenerates with a prompt
+that explicitly mentions the previous failed keyword, asking for a different
+approach.
+
+Usage:
+    cd backend && python3 scripts/regenerate_stuck_mnemonics.py [--dry-run] [--limit=10]
+
+Options:
+    --dry-run    Preview stuck words without regenerating
+    --limit=N    Max words to regenerate (default: 10)
+"""
+
+import json
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from dotenv import load_dotenv
+from pathlib import Path
+
+load_dotenv(Path(__file__).resolve().parent.parent / ".env")
+
+from app.database import SessionLocal
+from app.models import Lemma, ReviewLog, UserLemmaKnowledge
+from app.services.activity_log import log_activity
+from app.services.memory_hooks import (
+    PREMIUM_SYSTEM_PROMPT,
+    _build_word_info,
+    validate_hooks,
+    find_stuck_hook_words,
+)
+
+
+def regenerate_stuck(dry_run: bool = False, limit: int = 10):
+    from app.services.llm import generate_completion, AllProvidersFailed
+
+    db = SessionLocal()
+    try:
+        stuck_words = find_stuck_hook_words(db, limit=limit)
+        print(f"Found {len(stuck_words)} words with failing mnemonics")
+
+        if not stuck_words:
+            return
+
+        regenerated = []
+        failed = []
+
+        for lemma, ulk, recent_acc in stuck_words:
+            old_hooks = lemma.memory_hooks_json or {}
+            old_mnemonic = old_hooks.get("mnemonic", "")
+            regen_count = old_hooks.get("regeneration_count", 0)
+
+            print(
+                f"\n  {lemma.lemma_id} {lemma.lemma_ar_bare} "
+                f"({lemma.gloss_en or '?'}) — "
+                f"accuracy={recent_acc:.0%}, "
+                f"reviews={ulk.times_seen}, "
+                f"regen_count={regen_count}"
+            )
+            if old_mnemonic:
+                print(f"    Old mnemonic: {old_mnemonic[:80]}...")
+
+            if dry_run:
+                continue
+
+            word_info = _build_word_info(lemma)
+            failed_note = ""
+            if old_mnemonic:
+                failed_note = (
+                    f"\n\nThe previous mnemonic FAILED — the learner reviewed this word "
+                    f"{ulk.times_seen} times with only {recent_acc:.0%} accuracy. "
+                    f"Do NOT reuse the same keyword or approach:\n"
+                    f'  "{old_mnemonic}"'
+                )
+
+            prompt = f"""Generate memory hooks for this HARD Arabic word that the learner keeps forgetting:
+
+{word_info}{failed_note}
+
+Generate 3 candidate mnemonics with COMPLETELY DIFFERENT keywords from the failed one.
+Self-evaluate each on sound match, interaction, and meaning extraction (1-5).
+Pick the candidate with the highest total score.
+
+Return JSON with keys: candidates, best_index, mnemonic, cognates, collocations, usage_context, fun_fact.
+Return null if the word is a particle/pronoun/function word."""
+
+            try:
+                result = generate_completion(
+                    prompt=prompt,
+                    system_prompt=PREMIUM_SYSTEM_PROMPT,
+                    json_mode=True,
+                    temperature=0.8,
+                    model_override="claude_haiku",
+                    task_type="memory_hooks_regeneration",
+                )
+            except AllProvidersFailed as e:
+                print(f"    LLM failed: {e}")
+                failed.append(lemma.lemma_id)
+                continue
+
+            if result is None or not isinstance(result, dict) or not result:
+                print(f"    No result from LLM")
+                failed.append(lemma.lemma_id)
+                continue
+
+            hooks = result.get("hooks", result) if "hooks" in result else result
+            hooks.pop("candidates", None)
+            hooks.pop("best_index", None)
+
+            if not validate_hooks(hooks):
+                print(f"    Invalid hooks structure")
+                failed.append(lemma.lemma_id)
+                continue
+
+            # Preserve old hooks as backup and track regeneration count
+            hooks["previous_hooks"] = {
+                k: v for k, v in old_hooks.items()
+                if k not in ("previous_hooks", "regeneration_count")
+            }
+            hooks["regeneration_count"] = regen_count + 1
+            hooks["regenerated_at"] = __import__("datetime").datetime.now(
+                __import__("datetime").timezone.utc
+            ).isoformat()
+
+            lemma.memory_hooks_json = hooks
+            new_mnemonic = hooks.get("mnemonic", "")[:80]
+            print(f"    New mnemonic: {new_mnemonic}...")
+            regenerated.append(lemma.lemma_id)
+
+            time.sleep(1)
+
+        if not dry_run and regenerated:
+            db.commit()
+            log_activity(
+                db,
+                event_type="mnemonic_regeneration",
+                summary=f"Regenerated mnemonics for {len(regenerated)} stuck words",
+                detail={
+                    "lemma_ids": regenerated,
+                    "failed": failed,
+                },
+            )
+
+        status = "Would regenerate" if dry_run else "Regenerated"
+        print(f"\n{status}: {len(regenerated)} words")
+        if failed:
+            print(f"Failed: {len(failed)} words")
+
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    dry_run = "--dry-run" in sys.argv
+    limit = 10
+    for arg in sys.argv:
+        if arg.startswith("--limit="):
+            limit = int(arg.split("=")[1])
+    regenerate_stuck(dry_run=dry_run, limit=limit)

--- a/backend/tests/test_stuck_hooks.py
+++ b/backend/tests/test_stuck_hooks.py
@@ -1,0 +1,228 @@
+"""Tests for stuck mnemonic detection logic (find_stuck_hook_words)."""
+
+from datetime import datetime, timedelta, timezone
+
+from app.models import Lemma, ReviewLog, UserLemmaKnowledge
+from app.services.memory_hooks import (
+    STUCK_MAX_ACCURACY,
+    STUCK_MIN_REVIEWS,
+    STUCK_RECENT_WINDOW,
+    STUCK_REGEN_COOLDOWN_DAYS,
+    find_stuck_hook_words,
+)
+
+
+def _create_lemma(db, arabic="كتاب", english="book", hooks=None):
+    lemma = Lemma(
+        lemma_ar=arabic,
+        lemma_ar_bare=arabic,
+        gloss_en=english,
+        pos="noun",
+        memory_hooks_json=hooks,
+    )
+    db.add(lemma)
+    db.flush()
+    return lemma
+
+
+def _add_ulk(db, lemma_id, state="acquiring", times_seen=10, times_correct=3, **kwargs):
+    ulk = UserLemmaKnowledge(
+        lemma_id=lemma_id,
+        knowledge_state=state,
+        times_seen=times_seen,
+        times_correct=times_correct,
+        **kwargs,
+    )
+    db.add(ulk)
+    db.flush()
+    return ulk
+
+
+def _add_reviews(db, lemma_id: int, ratings: list[int]):
+    now = datetime.now(timezone.utc)
+    for i, rating in enumerate(ratings):
+        db.add(ReviewLog(
+            lemma_id=lemma_id,
+            rating=rating,
+            reviewed_at=now - timedelta(hours=len(ratings) - i),
+        ))
+    db.flush()
+
+
+# --- find_stuck_hook_words ---
+
+
+def test_finds_stuck_word_with_bad_accuracy(db_session):
+    """Word with hooks, acquiring state, low accuracy should be found."""
+    hooks = {"mnemonic": "A CAT reads a BOOK", "cognates": [], "collocations": []}
+    lemma = _create_lemma(db_session, hooks=hooks)
+    _add_ulk(db_session, lemma.lemma_id, state="acquiring", times_seen=6, times_correct=1)
+    _add_reviews(db_session, lemma.lemma_id, [1, 1, 3, 1, 1, 1])
+    db_session.commit()
+
+    stuck = find_stuck_hook_words(db_session)
+    assert len(stuck) == 1
+    assert stuck[0][0].lemma_id == lemma.lemma_id
+    assert stuck[0][2] < STUCK_MAX_ACCURACY
+
+
+def test_skips_word_without_hooks(db_session):
+    """Word without memory_hooks_json should not be found."""
+    lemma = _create_lemma(db_session, hooks=None)
+    _add_ulk(db_session, lemma.lemma_id, state="acquiring", times_seen=10, times_correct=1)
+    _add_reviews(db_session, lemma.lemma_id, [1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
+    db_session.commit()
+
+    stuck = find_stuck_hook_words(db_session)
+    assert len(stuck) == 0
+
+
+def test_skips_word_with_good_accuracy(db_session):
+    """Word with hooks but good recent accuracy should not be found."""
+    hooks = {"mnemonic": "test mnemonic", "cognates": [], "collocations": []}
+    lemma = _create_lemma(db_session, hooks=hooks)
+    _add_ulk(db_session, lemma.lemma_id, state="acquiring", times_seen=10, times_correct=8)
+    _add_reviews(db_session, lemma.lemma_id, [3, 3, 3, 3, 3, 3, 3, 1, 3, 3])
+    db_session.commit()
+
+    stuck = find_stuck_hook_words(db_session)
+    assert len(stuck) == 0
+
+
+def test_skips_known_state(db_session):
+    """Word in 'known' state (not acquiring/lapsed) should not be found."""
+    hooks = {"mnemonic": "test mnemonic", "cognates": [], "collocations": []}
+    lemma = _create_lemma(db_session, hooks=hooks)
+    _add_ulk(db_session, lemma.lemma_id, state="known", times_seen=10, times_correct=2)
+    _add_reviews(db_session, lemma.lemma_id, [1, 1, 3, 1, 1, 1, 1, 3, 1, 1])
+    db_session.commit()
+
+    stuck = find_stuck_hook_words(db_session)
+    assert len(stuck) == 0
+
+
+def test_includes_lapsed_state(db_session):
+    """Word in 'lapsed' state should be found."""
+    hooks = {"mnemonic": "test mnemonic", "cognates": [], "collocations": []}
+    lemma = _create_lemma(db_session, hooks=hooks)
+    _add_ulk(db_session, lemma.lemma_id, state="lapsed", times_seen=8, times_correct=2)
+    _add_reviews(db_session, lemma.lemma_id, [1, 1, 3, 1, 1, 1, 1, 1])
+    db_session.commit()
+
+    stuck = find_stuck_hook_words(db_session)
+    assert len(stuck) == 1
+
+
+def test_skips_too_few_reviews(db_session):
+    """Word with fewer than STUCK_MIN_REVIEWS should not be found."""
+    hooks = {"mnemonic": "test mnemonic", "cognates": [], "collocations": []}
+    lemma = _create_lemma(db_session, hooks=hooks)
+    _add_ulk(db_session, lemma.lemma_id, state="acquiring", times_seen=3, times_correct=0)
+    _add_reviews(db_session, lemma.lemma_id, [1, 1, 1])
+    db_session.commit()
+
+    stuck = find_stuck_hook_words(db_session)
+    assert len(stuck) == 0
+
+
+def test_respects_cooldown(db_session):
+    """Word regenerated recently should be skipped."""
+    recent_regen = (datetime.now(timezone.utc) - timedelta(days=2)).isoformat()
+    hooks = {
+        "mnemonic": "test mnemonic",
+        "cognates": [],
+        "collocations": [],
+        "regenerated_at": recent_regen,
+        "regeneration_count": 1,
+    }
+    lemma = _create_lemma(db_session, hooks=hooks)
+    _add_ulk(db_session, lemma.lemma_id, state="acquiring", times_seen=8, times_correct=1)
+    _add_reviews(db_session, lemma.lemma_id, [1, 1, 1, 1, 1, 1, 1, 1])
+    db_session.commit()
+
+    stuck = find_stuck_hook_words(db_session)
+    assert len(stuck) == 0
+
+
+def test_cooldown_expired_is_eligible(db_session):
+    """Word regenerated more than cooldown_days ago should be eligible."""
+    old_regen = (datetime.now(timezone.utc) - timedelta(days=STUCK_REGEN_COOLDOWN_DAYS + 1)).isoformat()
+    hooks = {
+        "mnemonic": "old mnemonic",
+        "cognates": [],
+        "collocations": [],
+        "regenerated_at": old_regen,
+        "regeneration_count": 1,
+    }
+    lemma = _create_lemma(db_session, hooks=hooks)
+    _add_ulk(db_session, lemma.lemma_id, state="acquiring", times_seen=8, times_correct=1)
+    _add_reviews(db_session, lemma.lemma_id, [1, 1, 1, 1, 1, 1, 1, 1])
+    db_session.commit()
+
+    stuck = find_stuck_hook_words(db_session)
+    assert len(stuck) == 1
+
+
+def test_limit_respected(db_session):
+    """Limit parameter caps the number of results."""
+    hooks = {"mnemonic": "test", "cognates": [], "collocations": []}
+    for i in range(5):
+        lemma = _create_lemma(db_session, arabic=f"word{i}", english=f"meaning{i}", hooks=hooks)
+        _add_ulk(db_session, lemma.lemma_id, state="acquiring", times_seen=6, times_correct=1)
+        _add_reviews(db_session, lemma.lemma_id, [1, 1, 1, 1, 1, 1])
+    db_session.commit()
+
+    stuck = find_stuck_hook_words(db_session, limit=2)
+    assert len(stuck) == 2
+
+
+def test_sorted_by_accuracy_ascending(db_session):
+    """Results should be sorted by accuracy ascending (worst first)."""
+    hooks = {"mnemonic": "test", "cognates": [], "collocations": []}
+
+    # Word A: 0% recent accuracy
+    la = _create_lemma(db_session, arabic="wordA", english="a", hooks=hooks)
+    _add_ulk(db_session, la.lemma_id, state="acquiring", times_seen=5, times_correct=0)
+    _add_reviews(db_session, la.lemma_id, [1, 1, 1, 1, 1])
+
+    # Word B: 20% recent accuracy (1/5)
+    lb = _create_lemma(db_session, arabic="wordB", english="b", hooks=hooks)
+    _add_ulk(db_session, lb.lemma_id, state="acquiring", times_seen=5, times_correct=1)
+    _add_reviews(db_session, lb.lemma_id, [1, 3, 1, 1, 1])
+
+    db_session.commit()
+
+    stuck = find_stuck_hook_words(db_session)
+    assert len(stuck) == 2
+    assert stuck[0][0].lemma_id == la.lemma_id  # 0% first
+    assert stuck[1][0].lemma_id == lb.lemma_id  # 20% second
+
+
+def test_skips_variant_lemmas(db_session):
+    """Variant lemmas (canonical_lemma_id set) should be skipped."""
+    hooks = {"mnemonic": "test", "cognates": [], "collocations": []}
+    canonical = _create_lemma(db_session, arabic="canonical", english="main", hooks=hooks)
+    variant = _create_lemma(db_session, arabic="variant", english="var", hooks=hooks)
+    variant.canonical_lemma_id = canonical.lemma_id
+    db_session.flush()
+
+    _add_ulk(db_session, variant.lemma_id, state="acquiring", times_seen=6, times_correct=1)
+    _add_reviews(db_session, variant.lemma_id, [1, 1, 1, 1, 1, 1])
+    db_session.commit()
+
+    stuck = find_stuck_hook_words(db_session)
+    assert len(stuck) == 0
+
+
+def test_boundary_accuracy_not_stuck(db_session):
+    """Exactly 50% accuracy should not be flagged (threshold is strict <50%)."""
+    hooks = {"mnemonic": "test", "cognates": [], "collocations": []}
+    lemma = _create_lemma(db_session, hooks=hooks)
+    _add_ulk(db_session, lemma.lemma_id, state="acquiring", times_seen=6, times_correct=3)
+    # 3 correct out of last 6 = 50%, but we only look at last STUCK_RECENT_WINDOW=5
+    # So ratings: [1, 3, 1, 3, 3, 1] -> last 5 = [3, 1, 3, 3, 1] = 3/5 = 60%
+    _add_reviews(db_session, lemma.lemma_id, [1, 3, 1, 3, 3, 1])
+    db_session.commit()
+
+    stuck = find_stuck_hook_words(db_session)
+    assert len(stuck) == 0

--- a/docs/scripts-catalog.md
+++ b/docs/scripts-catalog.md
@@ -65,6 +65,7 @@ All scripts in `backend/scripts/`. Run from `backend/` directory.
 - `merge_al_lemmas.py` — Merge al-prefixed duplicate lemmas.
 - `merge_lemma_variants.py` — Merge identified variant lemmas.
 - `identify_leeches.py` — Find high-review low-accuracy words, optional --suspend.
+- `regenerate_stuck_mnemonics.py` — Regenerate memory hooks for words failing despite having mnemonics. Finds words with hooks but <50% recent accuracy (last 5 reviews, >=4 total), regenerates with prompt mentioning the failed keyword. Backs up old hooks in `previous_hooks` field. `--dry-run`, `--limit=N`.
 - `fix_null_lemma_ids.py` — Re-maps NULL lemma_id sentence_words using comprehensive lookup, retires unfixable sentences.
 - `fix_book_glosses.py` — Fix conjugated glosses on book/story-imported lemmas + run full enrichment, --dry-run --limit.
 - `cleanup_lemma_mappings.py` — Batch cleanup of lemma data quality issues: wrong glosses, missing particles, conjugated-form lemmas, possessive-form lemmas, al-prefix lemmas, batch re-map via CAMeL + LLM.

--- a/research/experiment-log.md
+++ b/research/experiment-log.md
@@ -4,6 +4,18 @@ Running lab notebook for Alif's learning algorithm. Each entry documents what ch
 
 ---
 
+## 2026-03-21: Mnemonic Regeneration for Stuck Words
+
+**Context**: Some words fail repeatedly despite having memory hooks. The original mnemonic didn't work for this learner. IDEAS.md suggests regenerating with a "previous didn't stick" prompt.
+
+**Change**: Added `regenerate_stuck_mnemonics.py` script and background `check_and_regenerate_stuck_hooks()` function. Criteria: >=4 reviews, <50% recent accuracy, existing hooks. Regeneration uses modified prompt mentioning the failed keyword. 7-day cooldown between regenerations.
+
+**Expected**: Stuck words get fresh, different mnemonics. Combined with rescue intro cards (also added today), this provides a second intervention for chronically failing words.
+
+**Verify**: After 2 weeks, check if regenerated words show accuracy improvement vs. their pre-regeneration trend.
+
+---
+
 ## 2026-03-21: Tighten LLM Pipeline Verification Across All Code Paths
 
 **Context**: Comprehensive audit of all LLM/automatic processing paths revealed 4 additional issues beyond the unverified cron (fixed earlier today).


### PR DESCRIPTION
## Summary
- Words failing despite having memory hooks (>=4 reviews, <50% recent accuracy) get their mnemonics auto-regenerated with a prompt that mentions the failed keyword
- `check_and_regenerate_stuck_hooks(db)` background function processes up to 3 words per run with 7-day cooldown between regenerations
- `regenerate_stuck_mnemonics.py` script for manual batch runs with `--dry-run` and `--limit=N`
- Old hooks preserved in `previous_hooks` field within `memory_hooks_json`, regeneration count tracked

Generated with [Claude Code](https://claude.com/claude-code)