### PR TITLE
feat: dynamic session sizing based on accuracy

### DIFF
--- a/backend/app/routers/review.py
+++ b/backend/app/routers/review.py
@@ -57,7 +57,7 @@ def next_listening_cards(
 
 @router.get("/next-sentences", response_model=SentenceSessionOut)
 def next_sentences(
-    limit: int = Query(10, ge=1, le=20),
+    limit: int | None = Query(None, ge=1, le=30),
     mode: str = Query("reading"),
     prefetch: bool = Query(False),
     exclude: list[int] = Query(default=[]),
@@ -66,6 +66,7 @@ def next_sentences(
 ):
     """Get a sentence-based review session.
 
+    When limit is omitted, session size adapts to 2-day accuracy (10/14/18).
     No LLM calls — session builds from pre-generated sentences (<1s).
     Background warm_sentence_cache generates for uncovered words after.
     """

--- a/backend/app/services/sentence_selector.py
+++ b/backend/app/services/sentence_selector.py
@@ -52,6 +52,42 @@ PIPELINE_BACKLOG_THRESHOLD = 40  # suppress reserved intros when acquiring pipel
 SESSION_SCAFFOLD_DECAY = 0.5  # per-appearance decay for scaffold words already in session
 NEVER_REVIEWED_BOOST = 5.0  # score multiplier for sentences targeting acquiring words with 0 reviews
 MAX_UNKNOWN_SCAFFOLD = 2  # max unknown non-target words per sentence (prevents overwhelming density)
+DEFAULT_SESSION_LIMIT = 10  # base session size
+ACCURACY_TIER_1 = 0.90  # 2-day accuracy threshold for +4 sentences
+ACCURACY_TIER_2 = 0.95  # 2-day accuracy threshold for +8 sentences
+SESSION_LIMIT_BUMP_1 = 4  # extra sentences at tier 1
+SESSION_LIMIT_BUMP_2 = 8  # extra sentences at tier 2
+
+
+def _get_2day_accuracy(db: Session, now: datetime) -> float | None:
+    """Compute 2-day review accuracy. Returns None if insufficient data (<10 reviews)."""
+    recent_reviews = (
+        db.query(ReviewLog)
+        .filter(ReviewLog.reviewed_at >= (now - timedelta(days=2)).replace(tzinfo=None))
+        .all()
+    )
+    if len(recent_reviews) < 10:
+        return None
+    correct = sum(1 for r in recent_reviews if r.rating >= 3)
+    return correct / len(recent_reviews)
+
+
+def _dynamic_session_limit(db: Session, now: datetime, base_limit: int = DEFAULT_SESSION_LIMIT) -> int:
+    """Compute session limit based on 2-day accuracy.
+
+    Strong learners get longer sessions so they aren't bottlenecked by a fixed cap:
+    - <90% accuracy (or insufficient data): base_limit (10)
+    - >=90% accuracy: base_limit + 4 (14)
+    - >=95% accuracy: base_limit + 8 (18)
+    """
+    accuracy = _get_2day_accuracy(db, now)
+    if accuracy is None:
+        return base_limit
+    if accuracy >= ACCURACY_TIER_2:
+        return base_limit + SESSION_LIMIT_BUMP_2
+    if accuracy >= ACCURACY_TIER_1:
+        return base_limit + SESSION_LIMIT_BUMP_1
+    return base_limit
 
 
 def _intro_slots_for_accuracy(accuracy: float) -> int:
@@ -71,14 +107,8 @@ def _intro_slots_for_accuracy(accuracy: float) -> int:
 
 def _get_accuracy_intro_slots(db: Session, now: datetime) -> int:
     """Compute how many intro slots the learner's accuracy allows."""
-    recent_reviews = (
-        db.query(ReviewLog)
-        .filter(ReviewLog.reviewed_at >= (now - timedelta(days=2)).replace(tzinfo=None))
-        .all()
-    )
-    if len(recent_reviews) >= 10:
-        correct = sum(1 for r in recent_reviews if r.rating >= 3)
-        accuracy = correct / len(recent_reviews)
+    accuracy = _get_2day_accuracy(db, now)
+    if accuracy is not None:
         return _intro_slots_for_accuracy(accuracy)
     return 4  # conservative default with insufficient data
 
@@ -385,12 +415,15 @@ def _auto_introduce_words(
 
 def build_session(
     db: Session,
-    limit: int = 10,
+    limit: int | None = None,
     mode: str = "reading",
     log_events: bool = True,
     exclude_sentence_ids: set[int] | None = None,
 ) -> dict:
     """Assemble a sentence-based review session.
+
+    When limit is None (default), uses dynamic sizing based on 2-day accuracy.
+    Pass an explicit limit to override (for tests, simulations, etc.).
 
     Returns a dict matching SentenceSessionOut schema:
     {session_id, items, total_due_words, covered_due_words}
@@ -399,6 +432,10 @@ def build_session(
     logger = logging.getLogger(__name__)
     session_id = str(uuid.uuid4())
     now = datetime.now(timezone.utc)
+
+    if limit is None:
+        limit = _dynamic_session_limit(db, now)
+        logger.info(f"Dynamic session limit: {limit}")
 
     # Load tashkeel settings
     tashkeel_settings = db.query(LearnerSettings).first()

--- a/backend/tests/test_sentence_selector.py
+++ b/backend/tests/test_sentence_selector.py
@@ -7,12 +7,19 @@ import pytest
 from app.models import Lemma, ReviewLog, UserLemmaKnowledge, Sentence, SentenceWord
 from app.services.fsrs_service import create_new_card
 from app.services.sentence_selector import (
+    ACCURACY_TIER_1,
+    ACCURACY_TIER_2,
+    DEFAULT_SESSION_LIMIT,
     FRESHNESS_BASELINE,
     INTRO_RESERVE_FRACTION,
     MAX_AUTO_INTRO_PER_SESSION,
+    SESSION_LIMIT_BUMP_1,
+    SESSION_LIMIT_BUMP_2,
     SESSION_SCAFFOLD_DECAY,
     WordMeta,
     _difficulty_match_quality,
+    _dynamic_session_limit,
+    _get_2day_accuracy,
     _intro_slots_for_accuracy,
     _scaffold_freshness,
     build_session,
@@ -821,5 +828,150 @@ class TestSelectionInfo:
         assert "due_coverage" in components
         assert "diversity" in components
         assert "session_diversity" in components
+
+
+class TestDynamicSessionLimit:
+    """Dynamic session sizing based on 2-day accuracy."""
+
+    def _seed_reviews(self, db_session, count, rating, hours_spread=48):
+        """Create review logs spread over the last N hours."""
+        now = datetime.now(timezone.utc)
+        for i in range(count):
+            db_session.add(ReviewLog(
+                lemma_id=1,
+                rating=rating,
+                reviewed_at=now - timedelta(hours=i * hours_spread / max(count, 1)),
+                review_mode="reading",
+            ))
+        db_session.flush()
+
+    def test_get_2day_accuracy_insufficient_data(self, db_session):
+        now = datetime.now(timezone.utc)
+        # Fewer than 10 reviews → None
+        self._seed_reviews(db_session, 5, rating=4)
+        assert _get_2day_accuracy(db_session, now) is None
+
+    def test_get_2day_accuracy_all_correct(self, db_session):
+        now = datetime.now(timezone.utc)
+        self._seed_reviews(db_session, 20, rating=4)
+        assert _get_2day_accuracy(db_session, now) == 1.0
+
+    def test_get_2day_accuracy_mixed(self, db_session):
+        now = datetime.now(timezone.utc)
+        # 15 correct + 5 incorrect = 75%
+        for i in range(15):
+            db_session.add(ReviewLog(
+                lemma_id=1, rating=4,
+                reviewed_at=now - timedelta(hours=i),
+                review_mode="reading",
+            ))
+        for i in range(5):
+            db_session.add(ReviewLog(
+                lemma_id=1, rating=1,
+                reviewed_at=now - timedelta(hours=15 + i),
+                review_mode="reading",
+            ))
+        db_session.flush()
+        accuracy = _get_2day_accuracy(db_session, now)
+        assert accuracy == pytest.approx(0.75)
+
+    def test_dynamic_limit_no_data(self, db_session):
+        now = datetime.now(timezone.utc)
+        assert _dynamic_session_limit(db_session, now) == DEFAULT_SESSION_LIMIT
+
+    def test_dynamic_limit_low_accuracy(self, db_session):
+        now = datetime.now(timezone.utc)
+        # 14 correct + 6 incorrect = 70%
+        for i in range(14):
+            db_session.add(ReviewLog(
+                lemma_id=1, rating=4,
+                reviewed_at=now - timedelta(hours=i),
+                review_mode="reading",
+            ))
+        for i in range(6):
+            db_session.add(ReviewLog(
+                lemma_id=1, rating=1,
+                reviewed_at=now - timedelta(hours=14 + i),
+                review_mode="reading",
+            ))
+        db_session.flush()
+        assert _dynamic_session_limit(db_session, now) == DEFAULT_SESSION_LIMIT
+
+    def test_dynamic_limit_tier1(self, db_session):
+        now = datetime.now(timezone.utc)
+        # 91 correct + 9 incorrect = 91% (>= 90%, < 95%)
+        for i in range(91):
+            db_session.add(ReviewLog(
+                lemma_id=1, rating=4,
+                reviewed_at=now - timedelta(minutes=i * 30),
+                review_mode="reading",
+            ))
+        for i in range(9):
+            db_session.add(ReviewLog(
+                lemma_id=1, rating=1,
+                reviewed_at=now - timedelta(minutes=(91 + i) * 30),
+                review_mode="reading",
+            ))
+        db_session.flush()
+        assert _dynamic_session_limit(db_session, now) == DEFAULT_SESSION_LIMIT + SESSION_LIMIT_BUMP_1
+
+    def test_dynamic_limit_tier2(self, db_session):
+        now = datetime.now(timezone.utc)
+        # 96 correct + 4 incorrect = 96% (>= 95%)
+        for i in range(96):
+            db_session.add(ReviewLog(
+                lemma_id=1, rating=4,
+                reviewed_at=now - timedelta(minutes=i * 30),
+                review_mode="reading",
+            ))
+        for i in range(4):
+            db_session.add(ReviewLog(
+                lemma_id=1, rating=1,
+                reviewed_at=now - timedelta(minutes=(96 + i) * 30),
+                review_mode="reading",
+            ))
+        db_session.flush()
+        assert _dynamic_session_limit(db_session, now) == DEFAULT_SESSION_LIMIT + SESSION_LIMIT_BUMP_2
+
+    def test_dynamic_limit_explicit_override(self, db_session):
+        now = datetime.now(timezone.utc)
+        assert _dynamic_session_limit(db_session, now, base_limit=20) == 20
+
+    def test_build_session_uses_dynamic_limit_by_default(self, db_session):
+        """When limit=None, build_session uses dynamic sizing."""
+        # Create a word and sentence
+        _seed_word(db_session, 1, "كتاب", "book", due_hours=-1)
+        _seed_sentence(db_session, 1, "الكتاب", "the book", 1, [("الكتاب", 1)])
+
+        # High accuracy reviews → should get tier 2 limit (18)
+        now = datetime.now(timezone.utc)
+        for i in range(20):
+            db_session.add(ReviewLog(
+                lemma_id=1, rating=4,
+                reviewed_at=now - timedelta(hours=i),
+                review_mode="reading",
+            ))
+        db_session.commit()
+
+        # With default limit=None, should use dynamic sizing
+        result = build_session(db_session)
+        assert result is not None
+        # Session should build without errors
+
+    def test_build_session_explicit_limit_overrides(self, db_session):
+        """When limit is explicitly passed, dynamic sizing is bypassed."""
+        _seed_word(db_session, 1, "كتاب", "book", due_hours=-1)
+        _seed_sentence(db_session, 1, "الكتاب", "the book", 1, [("الكتاب", 1)])
+        db_session.commit()
+
+        result = build_session(db_session, limit=5)
+        assert result is not None
+
+    def test_constants_are_sane(self):
+        assert DEFAULT_SESSION_LIMIT == 10
+        assert ACCURACY_TIER_1 == 0.90
+        assert ACCURACY_TIER_2 == 0.95
+        assert SESSION_LIMIT_BUMP_1 == 4
+        assert SESSION_LIMIT_BUMP_2 == 8
 
 

--- a/docs/scheduling-system.md
+++ b/docs/scheduling-system.md
@@ -168,7 +168,7 @@ learn, and each enters acquisition immediately.
 **Code**: `sentence_selector.py:_auto_introduce_words()`
 
 **Gating conditions**:
-- **Reserved slots**: `INTRO_RESERVE_FRACTION` (20%) of session slots reserved for introductions, even when due queue exceeds limit. With limit=10, at least 2 slots always available.
+- **Reserved slots**: `INTRO_RESERVE_FRACTION` (20%) of session slots reserved for introductions, even when due queue exceeds limit. With base limit=10, at least 2 slots; with dynamic limit=18, up to 3 slots.
 - **Pipeline backlog gate**: Reserved intro slots suppressed when acquiring pipeline exceeds a dynamic threshold. Base threshold is `PIPELINE_BACKLOG_THRESHOLD` (40), but scales with recent accuracy: ≥90% → 80, ≥80% → 60, <80% → 40. Undersized-session fill still works (when due < limit). Resumes automatically when pipeline drains below threshold.
 - Recent accuracy ≥ `AUTO_INTRO_ACCURACY_FLOOR` (70%) over last 10+ reviews
 - Per-call cap: `MAX_AUTO_INTRO_PER_SESSION` (5)
@@ -545,16 +545,30 @@ the cohort. Words due but outside the cohort are ignored for this session.
 ## 8. Session Building — The Core Algorithm
 
 **Code**: `backend/app/services/sentence_selector.py:build_session()`
-**Endpoint**: `GET /api/review/next-sentences?limit=10&mode=reading`
+**Endpoint**: `GET /api/review/next-sentences?mode=reading`
 
 This is the most complex piece of the system. It assembles a session of sentence-based
 review cards, optimizing for due-word coverage, comprehensibility, and difficulty
 progression.
 
+### Dynamic Session Sizing
+
+Session limit adapts to 2-day review accuracy via `_dynamic_session_limit()`:
+
+| 2-Day Accuracy | Session Limit | Intro Slots (20%) |
+|---------------|---------------|-------------------|
+| < 90% (or insufficient data) | 10 (base) | 2 |
+| >= 90% | 14 (+4) | 2 |
+| >= 95% | 18 (+8) | 3 |
+
+Constants: `DEFAULT_SESSION_LIMIT=10`, `ACCURACY_TIER_1=0.90`, `ACCURACY_TIER_2=0.95`, `SESSION_LIMIT_BUMP_1=4`, `SESSION_LIMIT_BUMP_2=8`.
+
+Callers can pass an explicit `limit` to override (for tests, simulations, etc.). The API endpoint omits `limit` by default so dynamic sizing takes effect; passing `?limit=N` overrides.
+
 ### Complete Pipeline
 
 ```
-build_session(db, limit=10, mode="reading")
+build_session(db, limit=None, mode="reading")  # None → dynamic sizing
     │
     ▼
 ┌─────────────────────────────────────────────┐
@@ -1451,6 +1465,11 @@ remaining cards on the next card advance. See Section 8 "Sentence Pre-Warming" f
 
 | Constant | Value | Purpose |
 |----------|-------|---------|
+| `DEFAULT_SESSION_LIMIT` | 10 | Base session size (sentences) |
+| `ACCURACY_TIER_1` | 0.90 | 2-day accuracy threshold for +4 sentences |
+| `ACCURACY_TIER_2` | 0.95 | 2-day accuracy threshold for +8 sentences |
+| `SESSION_LIMIT_BUMP_1` | 4 | Extra sentences at tier 1 (limit=14) |
+| `SESSION_LIMIT_BUMP_2` | 8 | Extra sentences at tier 2 (limit=18) |
 | `MIN_ACQUISITION_EXPOSURES` | 4 | Min times an acquiring word should appear per session |
 | `MAX_ACQUISITION_EXTRA_SLOTS` | 15 | Max extra cards for acquisition repetition |
 | `MAX_AUTO_INTRO_PER_SESSION` | 5 | Per-call cap on auto-intro words |
@@ -1591,22 +1610,22 @@ motivation suffers. Above 95%, learning stalls.
 Default: 4 slots when <10 reviews available (conservative for new/returning users).
 Accuracy and computed slots are logged in interaction events for analysis.
 
-### 19.2 Session Length Adaptation — Not Implemented
+### 19.2 Session Length Adaptation — Partially Implemented
 
 **Research says**: Sessions should be 10-20 items, 10-20 minutes. After 3 consecutive
 "Again" ratings, insert 5 easy review items as a "cognitive rest stop." If session
 extends beyond 20 minutes, show only review items (no new introductions in overtime).
 
-**Original plan said**: "Track rolling accuracy over the last 10 items during a
-session; if it drops below 75%, automatically pause new word introductions."
+**Implemented (2026-03-21)**: Dynamic session sizing based on 2-day accuracy. Session
+limit scales from 10 (base) to 14 (>=90% accuracy) to 18 (>=95% accuracy) via
+`_dynamic_session_limit()`. This is inter-session adaptation — strong learners get
+more practice volume. `INTRO_RESERVE_FRACTION` scales naturally (0.2 * 18 = 3.6 → 3
+intro slots instead of 2).
 
-**Current implementation**: Sessions are built as a fixed batch based on `limit`
-parameter. There is no intra-session adaptation. The session is assembled once and
-delivered to the frontend — the backend doesn't know if the user is struggling
-mid-session.
-
-**Gap**: Sessions are pre-built, not adaptive. The frontend could implement
-client-side adaptation but currently does not.
+**Not implemented**: Intra-session adaptation (reacting to mid-session struggles).
+Sessions are pre-built and delivered to the frontend — the backend doesn't know if
+the user is struggling mid-session. The frontend could implement client-side
+adaptation but currently does not.
 
 ### 19.3 ~~Batch Sentence Generation for Word Sets~~ — RESOLVED
 
@@ -1931,7 +1950,7 @@ Frontend                          Backend
 
 ### B.2 Established Learner — Typical Day
 
-1. Open app → `build_session(limit=10)` runs:
+1. Open app → `build_session()` runs (dynamic limit=14 at 92% accuracy):
    - 5 acquiring words due (boxes 1-3)
    - Cohort has 100 words; 30 FSRS words are due
    - Cohort filter keeps 25 lowest-stability FSRS words + 5 acquiring

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -411,7 +411,7 @@ export async function fetchFreshSession(
   mode: ReviewMode = "reading"
 ): Promise<SentenceReviewSession> {
   const data = await fetchApi<SentenceReviewSession>(
-    `/api/review/next-sentences?limit=10&mode=${mode}`,
+    `/api/review/next-sentences?mode=${mode}`,
     { timeoutMs: 12_000 }
   );
   const session = { ...data, session_id: data.session_id || generateSessionId() };
@@ -440,7 +440,7 @@ export async function getSentenceReviewSession(
 
   try {
     const data = await fetchApi<SentenceReviewSession>(
-      `/api/review/next-sentences?limit=10&mode=${mode}`,
+      `/api/review/next-sentences?mode=${mode}`,
       { timeoutMs: 12_000 }
     );
     const session = { ...data, session_id: data.session_id || generateSessionId() };
@@ -518,7 +518,7 @@ export async function undoSentenceReview(
 export async function prefetchSessions(mode: ReviewMode): Promise<void> {
   try {
     const data = await fetchApi<SentenceReviewSession>(
-      `/api/review/next-sentences?limit=10&mode=${mode}&prefetch=true`
+      `/api/review/next-sentences?mode=${mode}&prefetch=true`
     );
     const session = { ...data, session_id: data.session_id || generateSessionId() };
     await cacheSessions(mode, [session]);
@@ -548,7 +548,7 @@ export async function deepPrefetchSessions(
         ? `&${Array.from(excludeIds).map(id => `exclude=${id}`).join('&')}`
         : '';
       const data = await fetchApi<SentenceReviewSession>(
-        `/api/review/next-sentences?limit=10&mode=${mode}&prefetch=true${excludeParam}`
+        `/api/review/next-sentences?mode=${mode}&prefetch=true${excludeParam}`
       );
       if (!data.items || data.items.length === 0) break;
       const session = { ...data, session_id: data.session_id || generateSessionId() };

--- a/research/experiment-log.md
+++ b/research/experiment-log.md
@@ -4,6 +4,18 @@ Running lab notebook for Alif's learning algorithm. Each entry documents what ch
 
 ---
 
+## 2026-03-21: Dynamic Session Sizing Based on Accuracy
+
+**Context**: Fixed 10-sentence limit was too few for a learner at 96% accuracy. Sessions complete too quickly.
+
+**Change**: Session limit now adapts to 2-day accuracy: <90% → 10, ≥90% → 14, ≥95% → 18. Explicit `limit` parameter still overrides. Frontend no longer sends `limit=10` hardcoded — omits the parameter so the backend computes dynamically. API `le` constraint raised from 20 to 30 to accommodate dynamic max of 18 + acquisition repetition headroom.
+
+**Expected**: More practice volume for strong learners. INTRO_RESERVE_FRACTION scales naturally (0.2 * 18 = 3.6 → 3 intro slots instead of 2).
+
+**Verify**: After 1 week, check session completion rate and time-per-session. If sessions feel too long, reduce to 12/16.
+
+---
+
 ## 2026-03-21: Tighten LLM Pipeline Verification Across All Code Paths
 
 **Context**: Comprehensive audit of all LLM/automatic processing paths revealed 4 additional issues beyond the unverified cron (fixed earlier today).


### PR DESCRIPTION
## Summary

- Session limit now adapts to 2-day review accuracy: 10 (base), 14 (>=90%), 18 (>=95%)
- Extracted `_get_2day_accuracy()` and `_dynamic_session_limit()` in `sentence_selector.py`
- `build_session()` default changed from `limit=10` to `limit=None` (dynamic); explicit limit still overrides
- Frontend no longer hardcodes `limit=10` in API calls
- API endpoint `le` constraint raised from 20 to 30

🤖 Generated with [Claude Code](https://claude.com/claude-code)