### PR TITLE
feat: rasm-based confusable pair session exclusion

### DIFF
--- a/IDEAS.md
+++ b/IDEAS.md
@@ -64,15 +64,16 @@
 
 ## Confusable Words / Visual Similarity
 
-### Rasm-Based Confusable Pair Detection
-- Compute rasm (dotless skeleton) for all vocabulary; words sharing a rasm are maximal confusables (e.g., بنت/بيت, حبر/خبر)
-- Use `rasmipy` library or custom rasm extraction (prototype at `/tmp/claude/arabic_similarity.py`)
-- Store in `confusable_pairs` table: `(lemma_id_a, lemma_id_b, similarity_score, similarity_type)`
+### Rasm-Based Confusable Pair Detection [DONE]
+- [DONE] Compute rasm (dotless skeleton) for all vocabulary; words sharing a rasm are maximal confusables (e.g., بنت/بيت, حبر/خبر)
+- [DONE] Custom rasm extraction via `compute_rasm()` and `build_confusable_index()` in `confusion_service.py`
+- Computed on-the-fly per session (no persistence needed — fast enough via single DB query + dict grouping)
 - Research: `research/confusable-words-research-2026-03-03.md`
 
-### Session Builder: No Same-Rasm Pairs in Same Session
-- Prevents interference — AnnA (Anki) and research (Carvalho & Goldstone 2014) show spacing similar items reduces confusion
-- Constraint: if word A's rasm matches word B's rasm, don't put both in the same session
+### Session Builder: No Same-Rasm Pairs in Same Session [DONE]
+- [DONE] Prevents interference — AnnA (Anki) and research (Carvalho & Goldstone 2014) show spacing similar items reduces confusion
+- [DONE] Constraint: if word A's rasm matches word B's rasm, don't put both in the same session
+- Toggle: `ENABLE_CONFUSABLE_EXCLUSION` constant in `sentence_selector.py`
 
 ### Confusable Word Info Display [DONE]
 - [DONE] In WordInfoCard, show visually similar words when marking yellow ("did not recognize")

--- a/backend/app/services/confusion_service.py
+++ b/backend/app/services/confusion_service.py
@@ -2,7 +2,14 @@
 
 Analyzes WHY the user was confused — morphological complexity (clitics/conjugation)
 or visual similarity to other known words. All rule-based, no LLM calls, <50ms.
+
+Also provides proactive confusable pair detection for session building:
+- compute_rasm(): strips dots from Arabic text to produce the dotless skeleton
+- build_confusable_index(): maps each active lemma to its rasm-confusable siblings
 """
+
+import logging
+from collections import defaultdict
 
 from sqlalchemy.orm import Session
 
@@ -11,12 +18,14 @@ from app.services.sentence_validator import (
     PROCLITICS, ENCLITICS, strip_diacritics,
 )
 
+logger = logging.getLogger(__name__)
+
 # --- Rasm skeleton mapping ---
 # Letters that share the same skeletal shape (differ only by dots) map to the same group.
 RASM_MAP: dict[str, str] = {}
 _RASM_GROUPS = [
     ("ا", "اأإآ"),
-    ("ب", "بتثنی"),  # ba/ta/tha/nun/ya share base shape
+    ("ب", "بتثنيیى"),  # ba/ta/tha/nun/ya/alef-maqsura share base shape
     ("ج", "جحخ"),
     ("د", "دذ"),
     ("ر", "رز"),
@@ -39,6 +48,66 @@ for _base, _letters in _RASM_GROUPS:
 def to_rasm(text: str) -> str:
     """Convert Arabic text to rasm skeleton (dots removed)."""
     return "".join(RASM_MAP.get(ch, ch) for ch in text)
+
+
+def compute_rasm(arabic_text: str) -> str:
+    """Compute the dotless skeleton (rasm) of Arabic text.
+
+    Strips diacritics first, then maps each letter to its dot-free base form.
+    Use this on lemma_ar_bare or any undiacritized Arabic string.
+    """
+    bare = strip_diacritics(arabic_text)
+    return to_rasm(bare)
+
+
+# Active vocabulary states for confusable pair detection
+_ACTIVE_STATES = {"acquiring", "known", "lapsed", "learning"}
+
+
+def build_confusable_index(db: Session) -> dict[int, set[int]]:
+    """Build a mapping of lemma_id -> set of confusable lemma_ids.
+
+    Two lemmas are confusable if they share the same rasm (dotless skeleton)
+    and both are in the user's active vocabulary. Only non-variant lemmas
+    are included.
+
+    Returns an empty dict if no confusable pairs exist.
+    """
+    # Query active, non-variant lemmas with their bare forms
+    rows = (
+        db.query(Lemma.lemma_id, Lemma.lemma_ar_bare)
+        .join(UserLemmaKnowledge, UserLemmaKnowledge.lemma_id == Lemma.lemma_id)
+        .filter(
+            Lemma.canonical_lemma_id.is_(None),
+            UserLemmaKnowledge.knowledge_state.in_(_ACTIVE_STATES),
+        )
+        .all()
+    )
+
+    # Group lemma IDs by rasm
+    rasm_groups: dict[str, list[int]] = defaultdict(list)
+    for lemma_id, bare in rows:
+        if not bare:
+            continue
+        rasm = to_rasm(bare)
+        rasm_groups[rasm].append(lemma_id)
+
+    # Build the index: only groups with 2+ members are confusable pairs
+    index: dict[int, set[int]] = {}
+    for rasm, ids in rasm_groups.items():
+        if len(ids) < 2:
+            continue
+        id_set = set(ids)
+        for lid in ids:
+            index[lid] = id_set - {lid}
+
+    if index:
+        logger.debug(
+            f"Confusable index: {len(index)} lemmas in "
+            f"{sum(1 for ids in rasm_groups.values() if len(ids) >= 2)} rasm groups"
+        )
+
+    return index
 
 
 def edit_distance(a: str, b: str) -> int:

--- a/backend/app/services/sentence_selector.py
+++ b/backend/app/services/sentence_selector.py
@@ -52,6 +52,7 @@ PIPELINE_BACKLOG_THRESHOLD = 40  # suppress reserved intros when acquiring pipel
 SESSION_SCAFFOLD_DECAY = 0.5  # per-appearance decay for scaffold words already in session
 NEVER_REVIEWED_BOOST = 5.0  # score multiplier for sentences targeting acquiring words with 0 reviews
 MAX_UNKNOWN_SCAFFOLD = 2  # max unknown non-target words per sentence (prevents overwhelming density)
+ENABLE_CONFUSABLE_EXCLUSION = True  # drop sentences whose target words share a rasm with already-selected targets
 
 
 def _intro_slots_for_accuracy(accuracy: float) -> int:
@@ -1023,6 +1024,37 @@ def build_session(
                 selected_ids.add(extra.sentence_id)
                 candidates.remove(extra)
                 acquiring_word_counts[acq_lid] = count + 1
+
+    # 3c. Confusable pair exclusion: drop sentences whose target words
+    # share a rasm (dotless skeleton) with targets in already-selected sentences.
+    # This prevents interference between visually similar words (e.g. بنت/بيت).
+    if ENABLE_CONFUSABLE_EXCLUSION and len(selected) > 1:
+        from app.services.confusion_service import build_confusable_index
+        confusable_index = build_confusable_index(db)
+        if confusable_index:
+            kept: list[SentenceCandidate] = []
+            session_target_ids: set[int] = set()
+            dropped = 0
+            for c in selected:
+                target_ids = c.due_words_covered
+                # Check if any target word is confusable with an already-selected target
+                has_conflict = False
+                for tid in target_ids:
+                    confusables = confusable_index.get(tid, set())
+                    if confusables & session_target_ids:
+                        has_conflict = True
+                        break
+                if has_conflict:
+                    dropped += 1
+                else:
+                    kept.append(c)
+                    session_target_ids |= target_ids
+            if dropped:
+                logger.info(
+                    f"Confusable exclusion: dropped {dropped} sentences "
+                    f"to prevent rasm-similar interference"
+                )
+                selected = kept
 
     # 4. Order: easy bookends, hard in middle
     ordered = _order_session(selected, stability_map)

--- a/backend/tests/test_confusion_service.py
+++ b/backend/tests/test_confusion_service.py
@@ -4,6 +4,7 @@ import pytest
 from unittest.mock import MagicMock
 
 from app.services.confusion_service import (
+    compute_rasm,
     edit_distance,
     to_rasm,
     to_phonetic,
@@ -11,6 +12,7 @@ from app.services.confusion_service import (
     find_similar_words,
     find_phonetically_similar,
     analyze_confusion,
+    build_confusable_index,
     _build_prefix_hint,
     RASM_MAP,
 )
@@ -369,3 +371,134 @@ class TestPhonetic:
             db, 1, "كلب", {10}, candidates=[(word, "known")],
         )
         assert len(results) == 0
+
+
+class TestComputeRasm:
+    def test_strips_diacritics_and_dots(self):
+        """compute_rasm handles diacritized input."""
+        # بِنْت with diacritics → same rasm as بيت
+        assert compute_rasm("بِنْت") == compute_rasm("بَيْت")
+
+    def test_bint_bayt_confusable(self):
+        """بنت (girl) and بيت (house) share the same rasm."""
+        assert compute_rasm("بنت") == compute_rasm("بيت")
+
+    def test_hibr_khibr_confusable(self):
+        """حبر (ink) and خبر (news) share the same rasm (ج group)."""
+        assert compute_rasm("حبر") == compute_rasm("خبر")
+
+    def test_jimal_himal(self):
+        """جمل (camel) and حمل (to carry) share the same rasm."""
+        assert compute_rasm("جمل") == compute_rasm("حمل")
+
+    def test_non_confusable_different_rasm(self):
+        """كتب (write) and درس (study) have different rasm."""
+        assert compute_rasm("كتب") != compute_rasm("درس")
+
+    def test_sin_shin_same_rasm(self):
+        """سمع and شمع share same rasm (س/ش group)."""
+        assert compute_rasm("سمع") == compute_rasm("شمع")
+
+    def test_dal_dhal_same_rasm(self):
+        """دكر and ذكر share same rasm (د/ذ group)."""
+        assert compute_rasm("دكر") == compute_rasm("ذكر")
+
+    def test_empty_string(self):
+        assert compute_rasm("") == ""
+
+    def test_non_arabic(self):
+        """Non-Arabic characters pass through unchanged."""
+        assert compute_rasm("abc") == "abc"
+
+
+class TestBuildConfusableIndex:
+    def test_with_real_db(self, db_session):
+        """Test confusable index with actual DB objects."""
+        from app.models import Lemma, UserLemmaKnowledge
+
+        # Create two lemmas that share a rasm: بنت and بيت
+        l1 = Lemma(lemma_id=1, lemma_ar="بِنْت", lemma_ar_bare="بنت", gloss_en="girl")
+        l2 = Lemma(lemma_id=2, lemma_ar="بَيْت", lemma_ar_bare="بيت", gloss_en="house")
+        # Non-confusable lemma
+        l3 = Lemma(lemma_id=3, lemma_ar="كِتَاب", lemma_ar_bare="كتاب", gloss_en="book")
+        db_session.add_all([l1, l2, l3])
+
+        # All three are active
+        db_session.add(UserLemmaKnowledge(lemma_id=1, knowledge_state="acquiring"))
+        db_session.add(UserLemmaKnowledge(lemma_id=2, knowledge_state="known"))
+        db_session.add(UserLemmaKnowledge(lemma_id=3, knowledge_state="known"))
+        db_session.commit()
+
+        index = build_confusable_index(db_session)
+
+        # بنت and بيت should be confusable
+        assert 1 in index
+        assert 2 in index[1]
+        assert 2 in index
+        assert 1 in index[2]
+        # كتاب should not be in the index (no confusable partner)
+        assert 3 not in index
+
+    def test_excludes_encountered(self, db_session):
+        """Encountered words are not in the confusable index."""
+        from app.models import Lemma, UserLemmaKnowledge
+
+        l1 = Lemma(lemma_id=1, lemma_ar="بنت", lemma_ar_bare="بنت", gloss_en="girl")
+        l2 = Lemma(lemma_id=2, lemma_ar="بيت", lemma_ar_bare="بيت", gloss_en="house")
+        db_session.add_all([l1, l2])
+
+        # l1 is active, l2 is only encountered
+        db_session.add(UserLemmaKnowledge(lemma_id=1, knowledge_state="acquiring"))
+        db_session.add(UserLemmaKnowledge(lemma_id=2, knowledge_state="encountered"))
+        db_session.commit()
+
+        index = build_confusable_index(db_session)
+        # No confusable pairs since l2 is not active
+        assert len(index) == 0
+
+    def test_excludes_variants(self, db_session):
+        """Variant lemmas are excluded from the confusable index."""
+        from app.models import Lemma, UserLemmaKnowledge
+
+        l1 = Lemma(lemma_id=1, lemma_ar="بنت", lemma_ar_bare="بنت", gloss_en="girl")
+        l2 = Lemma(lemma_id=2, lemma_ar="بيت", lemma_ar_bare="بيت", gloss_en="house",
+                   canonical_lemma_id=1)  # variant of l1
+        db_session.add_all([l1, l2])
+
+        db_session.add(UserLemmaKnowledge(lemma_id=1, knowledge_state="known"))
+        db_session.add(UserLemmaKnowledge(lemma_id=2, knowledge_state="known"))
+        db_session.commit()
+
+        index = build_confusable_index(db_session)
+        assert len(index) == 0
+
+    def test_empty_vocabulary(self, db_session):
+        """Empty vocabulary returns empty index."""
+        index = build_confusable_index(db_session)
+        assert index == {}
+
+    def test_three_way_confusable(self, db_session):
+        """Three words sharing the same rasm form a 3-way confusable group."""
+        from app.models import Lemma, UserLemmaKnowledge
+
+        # ب, ت, ن all map to the same rasm base
+        # بنت, بيت, نيت would all share the same rasm
+        l1 = Lemma(lemma_id=1, lemma_ar="بنت", lemma_ar_bare="بنت", gloss_en="girl")
+        l2 = Lemma(lemma_id=2, lemma_ar="بيت", lemma_ar_bare="بيت", gloss_en="house")
+        l3 = Lemma(lemma_id=3, lemma_ar="نيت", lemma_ar_bare="نيت", gloss_en="intent")
+        db_session.add_all([l1, l2, l3])
+
+        db_session.add(UserLemmaKnowledge(lemma_id=1, knowledge_state="known"))
+        db_session.add(UserLemmaKnowledge(lemma_id=2, knowledge_state="acquiring"))
+        db_session.add(UserLemmaKnowledge(lemma_id=3, knowledge_state="known"))
+        db_session.commit()
+
+        index = build_confusable_index(db_session)
+
+        assert 1 in index
+        assert 2 in index
+        assert 3 in index
+        # Each should have the other two
+        assert index[1] == {2, 3}
+        assert index[2] == {1, 3}
+        assert index[3] == {1, 2}

--- a/backend/tests/test_sentence_selector.py
+++ b/backend/tests/test_sentence_selector.py
@@ -7,6 +7,7 @@ import pytest
 from app.models import Lemma, ReviewLog, UserLemmaKnowledge, Sentence, SentenceWord
 from app.services.fsrs_service import create_new_card
 from app.services.sentence_selector import (
+    ENABLE_CONFUSABLE_EXCLUSION,
     FRESHNESS_BASELINE,
     INTRO_RESERVE_FRACTION,
     MAX_AUTO_INTRO_PER_SESSION,
@@ -821,5 +822,82 @@ class TestSelectionInfo:
         assert "due_coverage" in components
         assert "diversity" in components
         assert "session_diversity" in components
+
+
+class TestConfusableExclusion:
+    """Rasm-based confusable pair exclusion prevents visually similar words
+    (same dotless skeleton) from appearing in the same session."""
+
+    def test_confusable_constant_exists(self):
+        assert ENABLE_CONFUSABLE_EXCLUSION is True
+
+    def test_confusable_pair_excluded_from_session(self, db_session):
+        """Two words sharing the same rasm should not both appear in a session."""
+        # بنت (girl) and بيت (house) share the same rasm
+        _seed_word(db_session, 1, "بنت", "girl", due_hours=-1)
+        _seed_word(db_session, 2, "بيت", "house", due_hours=-1)
+        # Non-confusable word
+        _seed_word(db_session, 3, "كتاب", "book", due_hours=-1)
+
+        _seed_sentence(db_session, 1, "بنت", "girl", 1, [("بنت", 1)])
+        _seed_sentence(db_session, 2, "بيت", "house", 2, [("بيت", 2)])
+        _seed_sentence(db_session, 3, "كتاب", "book", 3, [("كتاب", 3)])
+        db_session.commit()
+
+        result = build_session(db_session, limit=10)
+        items = result["items"]
+        target_ids = {item["primary_lemma_id"] for item in items}
+
+        # Both should NOT be in the same session
+        assert not ({1, 2} <= target_ids), \
+            "Confusable pair بنت/بيت should not both appear in the same session"
+        # At least one should be present, plus the non-confusable word
+        assert 3 in target_ids, "Non-confusable word كتاب should appear"
+        assert len(items) >= 2
+
+    def test_non_confusable_pair_both_appear(self, db_session):
+        """Words with different rasm should both appear in the session."""
+        # كتب (write) and درس (study) have different rasm
+        _seed_word(db_session, 1, "كتب", "write", due_hours=-1)
+        _seed_word(db_session, 2, "درس", "study", due_hours=-1)
+
+        _seed_sentence(db_session, 1, "كتب", "write", 1, [("كتب", 1)])
+        _seed_sentence(db_session, 2, "درس", "study", 2, [("درس", 2)])
+        db_session.commit()
+
+        result = build_session(db_session, limit=10)
+        target_ids = {item["primary_lemma_id"] for item in result["items"]}
+
+        # Both should appear — they are not confusable
+        assert {1, 2} <= target_ids
+
+    def test_confusable_exclusion_only_active_vocabulary(self, db_session):
+        """Confusable pairs are only detected for active vocabulary words."""
+        # بنت (active/due) and بيت (encountered only)
+        _seed_word(db_session, 1, "بنت", "girl", due_hours=-1)
+        # بيت is encountered, not active
+        lemma2 = Lemma(lemma_id=2, lemma_ar="بيت", lemma_ar_bare="بيت",
+                       pos="noun", gloss_en="house")
+        db_session.add(lemma2)
+        db_session.flush()
+        ulk2 = UserLemmaKnowledge(
+            lemma_id=2, knowledge_state="encountered",
+            times_seen=0, times_correct=0, source="book",
+        )
+        db_session.add(ulk2)
+
+        # A third word that IS active and due
+        _seed_word(db_session, 3, "كتاب", "book", due_hours=-1)
+
+        _seed_sentence(db_session, 1, "بنت", "girl", 1, [("بنت", 1)])
+        _seed_sentence(db_session, 3, "كتاب", "book", 3, [("كتاب", 3)])
+        db_session.commit()
+
+        result = build_session(db_session, limit=10)
+        target_ids = {item["primary_lemma_id"] for item in result["items"]}
+
+        # بنت should appear since بيت is only encountered (no conflict)
+        assert 1 in target_ids
+        assert 3 in target_ids
 
 

--- a/docs/scheduling-system.md
+++ b/docs/scheduling-system.md
@@ -651,6 +651,22 @@ build_session(db, limit=10, mode="reading")
                    │
                    ▼
 ┌─────────────────────────────────────────────┐
+│ STAGE 7b: Confusable Pair Exclusion          │
+│                                              │
+│ If ENABLE_CONFUSABLE_EXCLUSION (default on): │
+│   Build rasm (dotless skeleton) index of     │
+│   active vocabulary via confusion_service    │
+│   For each selected sentence (in order):     │
+│     Check if target words share rasm with    │
+│     targets of already-kept sentences        │
+│     If conflict → drop the later sentence    │
+│   Dropped sentences appear next session      │
+│   Prevents interference between visually     │
+│   similar words (e.g. بنت/بيت, حبر/خبر)     │
+└──────────────────┬──────────────────────────┘
+                   │
+                   ▼
+┌─────────────────────────────────────────────┐
 │ STAGE 8: Ordering (Easy Bookends)            │
 │                                              │
 │ Easiest sentence (highest stability) → first │
@@ -1828,6 +1844,7 @@ the codebase that filter on `knowledge_state`, `stability`, or `canonical_lemma_
 | Intro card filter | `sentence_selector.py` | times_seen, experiment_group |
 | Listening readiness | `sentence_selector.py` | listening_ready set |
 | Function word exclusion | `sentence_selector.py` | lemma_ar_bare |
+| Confusable pair exclusion | `sentence_selector.py` | rasm skeleton (via `confusion_service`) |
 
 **Checklist for any lifecycle/state change**:
 1. List all gates that reference the affected state field

--- a/research/experiment-log.md
+++ b/research/experiment-log.md
@@ -4,6 +4,18 @@ Running lab notebook for Alif's learning algorithm. Each entry documents what ch
 
 ---
 
+## 2026-03-21: Rasm-Based Confusable Pair Session Exclusion
+
+**Context**: Visually similar Arabic words (same dotless skeleton, e.g., بنت/بيت) interfere when presented in the same session. Research (Carvalho & Goldstone 2014) shows spacing similar items reduces confusion.
+
+**Change**: Added rasm-based confusable pair detection. `build_session()` now drops sentences whose target word is confusable with another target word already in the session. Dropped sentences appear in the next session instead. Also fixed rasm mapping to include standard Arabic yeh (ي, U+064A) and alef maqsura (ى) in the ba/ta/tha/nun group.
+
+**Expected**: Reduced interference between visually similar words. May slightly reduce session diversity but improves learning quality.
+
+**Verify**: After 2 weeks, check confusion (yellow) rate for known confusable pairs. Compare to pre-change baseline.
+
+---
+
 ## 2026-03-21: Tighten LLM Pipeline Verification Across All Code Paths
 
 **Context**: Comprehensive audit of all LLM/automatic processing paths revealed 4 additional issues beyond the unverified cron (fixed earlier today).


### PR DESCRIPTION
## Summary

- Added `compute_rasm()` and `build_confusable_index()` to `confusion_service.py` for proactive detection of visually similar Arabic word pairs (same dotless skeleton)
- `build_session()` now drops sentences whose target words are rasm-confusable with already-selected targets, preventing interference between pairs like بنت/بيت or حبر/خبر
- Fixed rasm mapping to include standard Arabic yeh (U+064A) and alef maqsura in the skeletal group -- previously only Farsi yeh (U+06CC) was mapped
- Toggle: `ENABLE_CONFUSABLE_EXCLUSION` constant (default True)

Generated with [Claude Code](https://claude.com/claude-code)