### PR TITLE
Lapse recovery tuning — desired_retention=0.95 + LAPSED_BOOST

### DIFF
--- a/backend/app/services/fsrs_service.py
+++ b/backend/app/services/fsrs_service.py
@@ -10,7 +10,10 @@ from app.models import Lemma, UserLemmaKnowledge, ReviewLog
 
 logger = logging.getLogger(__name__)
 
-scheduler = Scheduler()
+# desired_retention=0.95 — calibrated from optimize_fsrs.py on 21,363 reviews.
+# Default library weights are well-fit; our only deviation is the retention target,
+# which the optimizer judged optimal at 0.95 for this user's low lapse rate (~4.6%).
+scheduler = Scheduler(desired_retention=0.95)
 
 
 def parse_json_column(data, default=None):

--- a/backend/app/services/sentence_selector.py
+++ b/backend/app/services/sentence_selector.py
@@ -51,8 +51,9 @@ INTRO_RESERVE_FRACTION = 0.2  # fraction of session slots reserved for new word 
 PIPELINE_BACKLOG_THRESHOLD = 40  # suppress reserved intros when acquiring pipeline exceeds this
 SESSION_SCAFFOLD_DECAY = 0.5  # per-appearance decay for scaffold words already in session
 NEVER_REVIEWED_BOOST = 5.0  # score multiplier for sentences targeting acquiring words with 0 reviews
-OVERDUE_ESCALATION_DAYS = 3.0  # start escalating after this many days overdue
-OVERDUE_ESCALATION_MAX = 4.0  # max multiplier for severely overdue words
+LAPSED_BOOST = 3.0  # score multiplier for sentences targeting lapsed words (re-expose soon)
+OVERDUE_ESCALATION_DAYS = 0.5  # start escalating as soon as a card is past due
+OVERDUE_ESCALATION_MAX = 6.0  # max multiplier for severely overdue words
 MAX_UNKNOWN_SCAFFOLD = 2  # max unknown non-target words per sentence (prevents overwhelming density)
 MIN_SESSION_SENTENCES = 5  # minimum sentences before pulling in almost-due words
 COMPREHENSIBILITY_THRESHOLD = 0.6  # min fraction of scaffold words that must be known
@@ -818,6 +819,7 @@ def build_session(
     # words (seen but never correct) — these fall through the cracks when they
     # lose the times_seen==0 boost after their first failed review.
     boosted_acquiring_ids: set[int] = set()
+    lapsed_lemma_ids: set[int] = set()
     for lid in due_lemma_ids:
         k = knowledge_by_id.get(lid)
         if k and k.knowledge_state == "acquiring":
@@ -825,8 +827,12 @@ def build_session(
                 boosted_acquiring_ids.add(lid)
             elif (k.times_correct or 0) == 0:
                 boosted_acquiring_ids.add(lid)
+        elif k and k.knowledge_state == "lapsed":
+            lapsed_lemma_ids.add(lid)
     if boosted_acquiring_ids:
         logger.info(f"Boosted acquiring words due: {len(boosted_acquiring_ids)}")
+    if lapsed_lemma_ids:
+        logger.info(f"Lapsed words due (boosted for re-exposure): {len(lapsed_lemma_ids)}")
 
     # Build candidates
     candidates: list[SentenceCandidate] = []
@@ -930,8 +936,9 @@ def build_session(
         # Boost sentences targeting never-reviewed acquiring words so they can
         # compete with multi-word FSRS sentences in the greedy selection.
         nr_boost = NEVER_REVIEWED_BOOST if (due_covered & boosted_acquiring_ids) else 1.0
+        lapsed_boost = LAPSED_BOOST if (due_covered & lapsed_lemma_ids) else 1.0
         overdue_boost = _overdue_escalation(due_covered, overdue_days_map)
-        score = (len(due_covered) ** 1.5) * dmq * gfit * diversity * freshness * source_bonus * rescue_penalty * nr_boost * overdue_boost
+        score = (len(due_covered) ** 1.5) * dmq * gfit * diversity * freshness * source_bonus * rescue_penalty * nr_boost * lapsed_boost * overdue_boost
 
         candidates.append(SentenceCandidate(
             sentence_id=sent.id,
@@ -972,8 +979,9 @@ def build_session(
 
             rescue_penalty = 0.3 if c.sentence_id in rescue_sentence_ids else 1.0
             nr_boost = NEVER_REVIEWED_BOOST if (overlap & boosted_acquiring_ids) else 1.0
+            lapsed_boost = LAPSED_BOOST if (overlap & lapsed_lemma_ids) else 1.0
             overdue_boost = _overdue_escalation(overlap, overdue_days_map)
-            c.score = (len(overlap) ** 1.5) * dmq * gfit * diversity * freshness * source_bonus * session_diversity * rescue_penalty * nr_boost * overdue_boost
+            c.score = (len(overlap) ** 1.5) * dmq * gfit * diversity * freshness * source_bonus * session_diversity * rescue_penalty * nr_boost * lapsed_boost * overdue_boost
             c.score_components = {
                 "due_coverage": len(overlap),
                 "difficulty_match": round(dmq, 2),
@@ -984,6 +992,7 @@ def build_session(
                 "session_diversity": round(session_diversity, 2),
                 "rescue": rescue_penalty < 1.0,
                 "never_reviewed_boost": nr_boost,
+                "lapsed_boost": lapsed_boost,
                 "overdue_boost": round(overdue_boost, 2),
             }
 

--- a/backend/scripts/optimize_fsrs.py
+++ b/backend/scripts/optimize_fsrs.py
@@ -1,0 +1,147 @@
+"""Run the FSRS-6 optimizer on the review_log table and report personalized weights.
+
+Usage:
+    python3 scripts/optimize_fsrs.py [--db PATH]
+
+Only non-acquisition reviews (is_acquisition=0) are used, since acquisition reviews
+are Leitner-box transitions, not FSRS card updates.
+"""
+from __future__ import annotations
+
+import argparse
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+
+from fsrs import Optimizer, ReviewLog as FsrsReviewLog, Rating, Scheduler, Card
+
+
+RATING_MAP = {1: Rating.Again, 2: Rating.Hard, 3: Rating.Good, 4: Rating.Easy}
+
+
+def load_reviews(db_path: Path) -> list[FsrsReviewLog]:
+    conn = sqlite3.connect(str(db_path))
+    cur = conn.cursor()
+    rows = cur.execute(
+        """
+        SELECT lemma_id, rating, reviewed_at, response_ms
+        FROM review_log
+        WHERE is_acquisition = 0 OR is_acquisition IS NULL
+        ORDER BY lemma_id, reviewed_at
+        """
+    ).fetchall()
+    conn.close()
+
+    logs: list[FsrsReviewLog] = []
+    skipped = 0
+    for lemma_id, rating_int, ts_str, response_ms in rows:
+        if rating_int not in RATING_MAP:
+            skipped += 1
+            continue
+        dt = datetime.fromisoformat(ts_str)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        logs.append(
+            FsrsReviewLog(
+                card_id=int(lemma_id),
+                rating=RATING_MAP[rating_int],
+                review_datetime=dt,
+                review_duration=int(response_ms) if response_ms else None,
+            )
+        )
+    if skipped:
+        print(f"Skipped {skipped} reviews with unrecognized rating")
+    return logs
+
+
+# FSRS-6 default weights (what the library ships with; what we're running in production)
+DEFAULT_W = [
+    0.2172, 1.1771, 3.2602, 16.1507, 7.0114, 0.57, 2.0966, 0.0069,
+    1.5261, 0.112, 1.0178, 1.849, 0.1133, 0.3127, 2.2934, 0.2191,
+    3.0004, 0.7536, 0.3332, 0.1437, 0.2,
+]
+W_LABELS = [
+    "w0  init stability (Again)",
+    "w1  init stability (Hard)",
+    "w2  init stability (Good)",
+    "w3  init stability (Easy)",
+    "w4  init difficulty base",
+    "w5  init difficulty modifier",
+    "w6  difficulty decay",
+    "w7  difficulty mean-reversion",
+    "w8  stability growth (success)",
+    "w9  stability diminish (hard penalty)",
+    "w10 stability-retrievability coupling",
+    "w11 POST-LAPSE stability base",
+    "w12 post-lapse stability (difficulty)",
+    "w13 post-lapse stability (stability)",
+    "w14 post-lapse stability (retrievability)",
+    "w15 hard-rating stability multiplier",
+    "w16 easy-rating stability multiplier",
+    "w17 short-term stability (same-day)",
+    "w18 short-term stability modifier",
+    "w19 initial retrievability ceiling",
+    "w20 (unused/reserved)",
+]
+
+
+def pct(a: float, b: float) -> str:
+    if b == 0:
+        return " inf%"
+    diff = (a - b) / b * 100
+    sign = "+" if diff >= 0 else ""
+    return f"{sign}{diff:6.1f}%"
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--db", default="/tmp/claude/alif_fresh.db")
+    args = ap.parse_args()
+
+    db_path = Path(args.db)
+    if not db_path.exists():
+        raise SystemExit(f"DB not found: {db_path}")
+
+    print(f"Loading review logs from {db_path}…")
+    logs = load_reviews(db_path)
+    print(f"Loaded {len(logs)} FSRS reviews across "
+          f"{len({l.card_id for l in logs})} lemmas")
+
+    print("\nRunning optimizer (this takes a minute)…\n")
+    opt = Optimizer(logs)
+    new_w = opt.compute_optimal_parameters(verbose=False)
+
+    print(f"\nOptimal retention (given these weights): ", end="")
+    try:
+        optimal_retention = opt.compute_optimal_retention(new_w)
+        print(optimal_retention)
+    except Exception as e:
+        print(f"(failed: {e})")
+
+    print("\n== Weight comparison (default → optimized) ==")
+    print(f"{'weight':<42} {'default':>10} {'optimized':>10} {'change':>9}")
+    print("-" * 75)
+    for i, (label, d, n) in enumerate(zip(W_LABELS, DEFAULT_W, new_w)):
+        marker = "  <-- LAPSE" if i in (11, 12, 13, 14) else ""
+        print(f"{label:<42} {d:>10.4f} {n:>10.4f} {pct(n, d):>9}{marker}")
+
+    # Sanity: what post-lapse stability does each parameter set predict
+    # for a well-learned word (stability=30, difficulty=5, retrievability=0.9)?
+    def post_lapse_stability(w, S=30.0, D=5.0, R=0.9):
+        # FSRS-6 post-lapse stability formula
+        return w[11] * (D ** -w[12]) * ((S + 1) ** w[13] - 1) * (2.718281828 ** ((1 - R) * w[14]))
+
+    print("\n== Predicted post-lapse stability for S=30d, D=5, R=0.9 ==")
+    d_lapse = post_lapse_stability(DEFAULT_W)
+    n_lapse = post_lapse_stability(new_w)
+    print(f"  default params:   {d_lapse:7.2f} days")
+    print(f"  optimized params: {n_lapse:7.2f} days  ({pct(n_lapse, d_lapse).strip()})")
+    print()
+    print("Higher post-lapse stability = gentler recovery path after a lapse.")
+    print()
+    print("To deploy: copy the optimized weights into Scheduler(parameters=...) "
+          "in backend/app/services/fsrs_service.py and restart alif-backend.")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/replay_fsrs.py
+++ b/backend/scripts/replay_fsrs.py
@@ -1,0 +1,313 @@
+"""Counterfactual replay: feed actual rating sequences through both default and optimized
+FSRS schedulers and compare outcomes.
+
+Answers:
+  1. What stability would each card have ended at under each scheduler?
+  2. After each lapse, what intervals would each scheduler have recommended?
+  3. What's the aggregate distribution of scheduler-intended intervals?
+  4. How much calendar time would recovery take after a lapse under each scheduler?
+"""
+from __future__ import annotations
+
+import sqlite3
+from collections import defaultdict, Counter
+from datetime import datetime, timedelta, timezone
+from statistics import mean, median
+
+import argparse
+from fsrs import Scheduler, Card, Rating, State
+
+
+DEFAULT_W = (0.2172, 1.1771, 3.2602, 16.1507, 7.0114, 0.57, 2.0966, 0.0069,
+             1.5261, 0.112, 1.0178, 1.849, 0.1133, 0.3127, 2.2934, 0.2191,
+             3.0004, 0.7536, 0.3332, 0.1437, 0.2)
+
+# Weights produced by optimize_fsrs.py on 21,363-review dataset (2026-02-08..04-12).
+# Kept here for reproducibility of the replay comparison. Not deployed — see
+# research/experiment-log.md entry 2026-04-13 for why.
+OPT_W = (0.4561, 0.8986, 3.3274, 8.2956, 6.7088, 0.6613, 2.3324, 0.1555,
+         1.8420, 0.3975, 0.7796, 1.2168, 0.2500, 0.1249, 1.2062, 0.4289,
+         1.8729, 0.5514, 0.6694, 0.5113, 0.1259)
+
+RATING_MAP = {1: Rating.Again, 2: Rating.Hard, 3: Rating.Good, 4: Rating.Easy}
+
+
+def load_histories(db_path):
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    rows = cur.execute("""
+        SELECT lemma_id, rating, reviewed_at
+        FROM review_log
+        WHERE is_acquisition=0 OR is_acquisition IS NULL
+        ORDER BY lemma_id, reviewed_at
+    """).fetchall()
+    conn.close()
+    histories: dict[int, list[tuple[Rating, datetime]]] = defaultdict(list)
+    for lid, r, ts in rows:
+        if r not in RATING_MAP:
+            continue
+        dt = datetime.fromisoformat(ts)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        histories[lid].append((RATING_MAP[r], dt))
+    return histories
+
+
+def replay(history, weights, desired_retention=0.9):
+    """Replay a single card's history through a scheduler.
+    Returns list of (rating, timestamp, state_after, stability_after, intended_next_due).
+    Uses ACTUAL review timestamps (not scheduler-chosen ones)."""
+    sched = Scheduler(parameters=weights, desired_retention=desired_retention)
+    card = Card()
+    out = []
+    for rating, ts in history:
+        # Use ACTUAL timestamp, regardless of what scheduler wanted
+        card, _ = sched.review_card(card, rating, ts)
+        out.append({
+            "rating": rating,
+            "ts": ts,
+            "state": card.state,
+            "stability": card.stability,
+            "difficulty": card.difficulty,
+            "intended_due": card.due.replace(tzinfo=timezone.utc) if card.due else None,
+        })
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--db", default="/tmp/claude/alif_fresh.db",
+                    help="Path to SQLite database (default: /tmp/claude/alif_fresh.db)")
+    args = ap.parse_args()
+    histories = load_histories(args.db)
+    print(f"Loaded {len(histories)} card histories, "
+          f"total {sum(len(h) for h in histories.values())} reviews")
+
+    default_results = {}
+    opt_results = {}
+    print("Replaying under DEFAULT weights (ret=0.90)…")
+    for lid, h in histories.items():
+        default_results[lid] = replay(h, DEFAULT_W, 0.90)
+    print("Replaying under OPTIMIZED weights (ret=0.90)…")
+    for lid, h in histories.items():
+        opt_results[lid] = replay(h, OPT_W, 0.90)
+
+    # ===== Analysis 1: End-of-history stability distribution =====
+    print("\n=== End-of-history stability distribution ===")
+    def_final = [r[-1]["stability"] for r in default_results.values() if r]
+    opt_final = [r[-1]["stability"] for r in opt_results.values() if r]
+
+    def pct(vals, p):
+        v = sorted(vals)
+        return v[int(len(v) * p / 100)]
+
+    print(f"{'metric':<25}{'default':>12}{'optimized':>12}")
+    print("-" * 50)
+    print(f"{'mean stability':<25}{mean(def_final):>12.2f}{mean(opt_final):>12.2f}")
+    print(f"{'median':<25}{pct(def_final, 50):>12.2f}{pct(opt_final, 50):>12.2f}")
+    print(f"{'p25':<25}{pct(def_final, 25):>12.2f}{pct(opt_final, 25):>12.2f}")
+    print(f"{'p75':<25}{pct(def_final, 75):>12.2f}{pct(opt_final, 75):>12.2f}")
+    print(f"{'p90':<25}{pct(def_final, 90):>12.2f}{pct(opt_final, 90):>12.2f}")
+
+    # ===== Analysis 2: Post-lapse recovery — intervals recommended =====
+    print("\n=== Post-lapse recovery analysis ===")
+    print("For each lapse in history, compare: if the user had followed the scheduler's")
+    print("recommendation, how long to recover to pre-lapse stability?")
+    print()
+
+    def lapse_recovery(results, history):
+        """For each lapse event, track: pre-S, recommended post-lapse interval,
+        stability trajectory in the actual next reviews."""
+        out = []
+        for i, step in enumerate(results):
+            if step["rating"] not in (Rating.Again, Rating.Hard):
+                continue
+            if i == 0:
+                continue  # first review can't be a "lapse"
+            pre_step = results[i - 1]
+            pre_stab = pre_step["stability"]
+            if pre_stab < 7:  # only look at lapses of well-learned cards
+                continue
+            post_stab = step["stability"]
+            # Intended next interval
+            intended = (step["intended_due"] - step["ts"]).total_seconds() / 86400
+            # How many subsequent reviews to reach pre-lapse stability again?
+            reviews_to_recover = None
+            days_to_recover = None
+            for j in range(i + 1, len(results)):
+                if results[j]["stability"] >= pre_stab:
+                    reviews_to_recover = j - i
+                    days_to_recover = (results[j]["ts"] - step["ts"]).total_seconds() / 86400
+                    break
+            out.append({
+                "pre_stab": pre_stab,
+                "post_stab": post_stab,
+                "intended_interval_days": intended,
+                "reviews_to_recover": reviews_to_recover,
+                "days_to_recover": days_to_recover,
+            })
+        return out
+
+    lapse_stats_def = []
+    lapse_stats_opt = []
+    for lid in histories:
+        lapse_stats_def.extend(lapse_recovery(default_results[lid], histories[lid]))
+        lapse_stats_opt.extend(lapse_recovery(opt_results[lid], histories[lid]))
+
+    print(f"Lapses of S>=7d cards under DEFAULT:  {len(lapse_stats_def)}")
+    print(f"Lapses of S>=7d cards under OPTIMIZED: {len(lapse_stats_opt)}")
+    print()
+
+    def summarize(stats, label):
+        print(f"--- {label} ---")
+        print(f"  Mean pre-lapse stability:       {mean(s['pre_stab'] for s in stats):6.2f}d")
+        print(f"  Mean post-lapse stability:      {mean(s['post_stab'] for s in stats):6.2f}d")
+        print(f"  Mean intended next interval:    {mean(s['intended_interval_days'] for s in stats):6.2f}d")
+        print(f"  Median intended next interval:  {median(s['intended_interval_days'] for s in stats):6.2f}d")
+        recov = [s for s in stats if s['reviews_to_recover'] is not None]
+        print(f"  Cards that recovered in dataset: {len(recov)}/{len(stats)}")
+        if recov:
+            print(f"  Mean reviews to recover:        {mean(s['reviews_to_recover'] for s in recov):6.2f}")
+            print(f"  Mean days to recover:           {mean(s['days_to_recover'] for s in recov):6.2f}")
+        print()
+
+    summarize(lapse_stats_def, "DEFAULT weights")
+    summarize(lapse_stats_opt, "OPTIMIZED weights")
+
+    # ===== Analysis 3: Aggregate interval distribution =====
+    print("=== Scheduler-intended interval distribution (all reviews) ===")
+    def get_intervals(results_dict):
+        intervals = []
+        for lid, steps in results_dict.items():
+            for s in steps:
+                if s["intended_due"] is None:
+                    continue
+                interval = (s["intended_due"] - s["ts"]).total_seconds() / 86400
+                intervals.append(interval)
+        return intervals
+
+    def_intervals = get_intervals(default_results)
+    opt_intervals = get_intervals(opt_results)
+
+    print(f"{'bucket':<15}{'default':>10}{'optimized':>12}")
+    print("-" * 37)
+    buckets = [
+        ("< 6h", 0, 0.25),
+        ("6h-1d", 0.25, 1),
+        ("1-3d", 1, 3),
+        ("3-7d", 3, 7),
+        ("7-30d", 7, 30),
+        ("30-90d", 30, 90),
+        (">=90d", 90, 999999),
+    ]
+    for label, lo, hi in buckets:
+        dc = sum(1 for x in def_intervals if lo <= x < hi)
+        oc = sum(1 for x in opt_intervals if lo <= x < hi)
+        print(f"{label:<15}{dc:>10}{oc:>12}")
+    print(f"{'TOTAL':<15}{len(def_intervals):>10}{len(opt_intervals):>12}")
+
+    # ===== Analysis 4: "Would have been due" over past 30 days =====
+    print("\n=== Counterfactual due queue over past 30 days ===")
+    print("At end of each day, how many cards did each scheduler think should be due?")
+
+    # Collect all (card_id, last_review_ts, intended_due) from each scheduler
+    def get_due_timeline(results_dict, start, end):
+        """For each day, count cards whose intended due date falls at or before that day
+        AND whose last review is before that day (i.e., currently due)."""
+        day_counts = []
+        cur_day = start
+        # For each card, pick its last replay step; simulate the due evolution
+        while cur_day <= end:
+            cur_due = 0
+            for lid, steps in results_dict.items():
+                # Find latest step before cur_day
+                latest = None
+                for s in steps:
+                    if s["ts"] <= cur_day:
+                        latest = s
+                    else:
+                        break
+                if latest and latest["intended_due"] and latest["intended_due"] <= cur_day:
+                    cur_due += 1
+            day_counts.append((cur_day, cur_due))
+            cur_day += timedelta(days=1)
+        return day_counts
+
+    end_date = datetime(2026, 4, 13, 0, 0, tzinfo=timezone.utc)
+    start_date = end_date - timedelta(days=30)
+    def_timeline = get_due_timeline(default_results, start_date, end_date)
+    opt_timeline = get_due_timeline(opt_results, start_date, end_date)
+
+    print(f"{'date':<12}{'default due':>12}{'optimized due':>14}")
+    print("-" * 38)
+    for (d1, c1), (d2, c2) in zip(def_timeline, opt_timeline):
+        print(f"{d1.strftime('%Y-%m-%d'):<12}{c1:>12}{c2:>14}")
+
+    # ===== Analysis 5: What fraction of time do schedulers produce intervals
+    #       within 1.5x of the actual next-review gap? =====
+    print("\n=== Alignment with actual user behavior ===")
+    print("How often does each scheduler's suggested interval match what the user actually did?")
+
+    def alignment(results, hist):
+        matches_tight = 0  # within 0.67x - 1.5x
+        matches_loose = 0  # within 0.33x - 3x
+        total = 0
+        over_scheduled = 0  # scheduler said sooner than user came back
+        under_scheduled = 0  # scheduler said later than user came back
+        for i, step in enumerate(results):
+            if i + 1 >= len(results):
+                continue
+            intended = (step["intended_due"] - step["ts"]).total_seconds() / 86400
+            actual = (results[i + 1]["ts"] - step["ts"]).total_seconds() / 86400
+            if intended <= 0 or actual <= 0:
+                continue
+            ratio = actual / intended
+            total += 1
+            if 0.67 <= ratio <= 1.5:
+                matches_tight += 1
+            if 0.33 <= ratio <= 3:
+                matches_loose += 1
+            if ratio > 1.5:
+                under_scheduled += 1  # user came back later — scheduler wanted sooner
+            if ratio < 0.67:
+                over_scheduled += 1  # user came back sooner — scheduler wanted later
+        return {
+            "total": total,
+            "tight_match_pct": matches_tight / total * 100 if total else 0,
+            "loose_match_pct": matches_loose / total * 100 if total else 0,
+            "over_scheduled_pct": over_scheduled / total * 100 if total else 0,
+            "under_scheduled_pct": under_scheduled / total * 100 if total else 0,
+        }
+
+    def_align = {"total": 0, "tight_match_pct": 0, "loose_match_pct": 0,
+                 "over_scheduled_pct": 0, "under_scheduled_pct": 0}
+    opt_align = {"total": 0, "tight_match_pct": 0, "loose_match_pct": 0,
+                 "over_scheduled_pct": 0, "under_scheduled_pct": 0}
+    # accumulate
+    for lid in histories:
+        d = alignment(default_results[lid], histories[lid])
+        o = alignment(opt_results[lid], histories[lid])
+        for k in def_align:
+            if k == "total":
+                def_align[k] += d[k]
+                opt_align[k] += o[k]
+            else:
+                def_align[k] += d[k] * d["total"]
+                opt_align[k] += o[k] * o["total"]
+    # normalize
+    for k in def_align:
+        if k != "total":
+            def_align[k] /= def_align["total"] or 1
+            opt_align[k] /= opt_align["total"] or 1
+
+    print(f"{'metric':<30}{'default':>12}{'optimized':>12}")
+    print("-" * 54)
+    print(f"{'tight match (0.67-1.5x)':<30}{def_align['tight_match_pct']:>11.1f}%{opt_align['tight_match_pct']:>11.1f}%")
+    print(f"{'loose match (0.33-3x)':<30}{def_align['loose_match_pct']:>11.1f}%{opt_align['loose_match_pct']:>11.1f}%")
+    print(f"{'scheduler wanted later':<30}{def_align['under_scheduled_pct']:>11.1f}%{opt_align['under_scheduled_pct']:>11.1f}%")
+    print(f"{'scheduler wanted sooner':<30}{def_align['over_scheduled_pct']:>11.1f}%{opt_align['over_scheduled_pct']:>11.1f}%")
+    print(f"total evaluated: {def_align['total']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/scheduling-system.md
+++ b/docs/scheduling-system.md
@@ -1484,8 +1484,10 @@ remaining cards on the next card advance. See Section 8 "Sentence Pre-Warming" f
 | Adaptive intro bands | 0→3→5 | Slots at <70%/70-85%/≥85% accuracy |
 | `SESSION_SCAFFOLD_DECAY` | 0.5 | Per-appearance multiplier for scaffold words already in session |
 | `NEVER_REVIEWED_BOOST` | 5.0 | Score multiplier for sentences targeting acquiring words with 0 reviews OR 0% accuracy |
-| `OVERDUE_ESCALATION_DAYS` | 3.0 | Start boosting score after this many days overdue |
-| `OVERDUE_ESCALATION_MAX` | 4.0 | Max score multiplier for severely overdue words (linear ramp over 14 days) |
+| `LAPSED_BOOST` | 3.0 | Score multiplier for sentences targeting any due word in `lapsed` state — drives aggressive re-exposure after a miss |
+| `OVERDUE_ESCALATION_DAYS` | 0.5 | Start boosting score after this many days overdue |
+| `OVERDUE_ESCALATION_MAX` | 6.0 | Max score multiplier for severely overdue words (linear ramp over 14 days) |
+| FSRS `desired_retention` | 0.95 | Target retention — calibrated from 21k reviews via `optimize_fsrs.py`. Tighter than library default of 0.90, matches this user's low (~4.6%) lapse rate |
 | `MAX_UNKNOWN_SCAFFOLD` | 2 | Max unknown non-target words per sentence (prevents overwhelming density) |
 | `FRESHNESS_BASELINE` | 5 | Reviews before scaffold freshness penalty kicks in (floor 0.1) |
 | `MAX_ON_DEMAND_PER_SESSION` | 10 | Reference constant (callers control actual cap via remaining session capacity) |

--- a/docs/scripts-catalog.md
+++ b/docs/scripts-catalog.md
@@ -97,6 +97,8 @@ All scripts in `backend/scripts/`. Run from `backend/` directory.
 - `learning_analysis.py` — Comprehensive production learning metrics: vocabulary states, graduation rates, retention, FSRS stability, session patterns, frequency coverage, tashkeel readiness. Raw sqlite3, outputs JSON to stdout + console summary to stderr.
 - `deep_word_diagnostic.py` — Outlier and grey-zone hunter: state integrity violations, stuck acquirers, FSRS anomalies, accuracy paradoxes, review pattern outliers, leech escape traps, rating oscillation, variant split scheduling. Function-word-aware, uses sentence_words for coverage checks. `--json path` for machine output.
 - `analyze_intro_experiment.py` — A/B experiment analysis: intro card vs sentence-first acquisition. Compares reviews-to-graduation, first-review accuracy, time-to-graduation by experiment group. `--db path/to/alif.db`.
+- `optimize_fsrs.py` — Run the FSRS-6 optimizer on `review_log` to produce personalized weights. Reports weight comparison vs. library defaults, predicted post-lapse stability, and optimal `desired_retention`. `--db path/to/alif.db` (defaults to `/tmp/claude/alif_fresh.db`). Read-only; prints to stdout.
+- `replay_fsrs.py` — Counterfactual: feed actual rating sequences through default vs. optimized schedulers at the user's real review timestamps. Reports end-stability distribution, post-lapse recovery metrics (reviews/days to recover pre-lapse stability), interval distribution shifts, daily due-queue size, and alignment with actual user behavior. Read-only; stdout only.
 
 ## Utilities
 - `log_activity.py` — CLI tool for manual ActivityLog entries.

--- a/research/experiment-log.md
+++ b/research/experiment-log.md
@@ -4,6 +4,42 @@ Running lab notebook for Alif's learning algorithm. Each entry documents what ch
 
 ---
 
+## 2026-04-13: Lapse Recovery Tuning — desired_retention=0.95 + Lapsed Boost
+
+**Problem**: User flagged concern that lapses on high-stability words might set them back too far. Investigated with full replay analysis over 21,363 FSRS reviews across 1,550 lemmas (see `scripts/optimize_fsrs.py`, `scripts/replay_fsrs.py`).
+
+**Findings**:
+- Well-known lapses (S≥30d) recover well: 91% Good on first follow-up, 96% never re-lapse.
+- BUT coverage gap: **85 of 176 lapses (48%) in past 7 days had zero follow-up reviews**. Of those, ~37 are due + in cohort + have sentences — they just lose the sentence-scoring competition.
+- FSRS optimizer suggested aggressive new weights, but replay analysis showed minimal practical effect — user reviews ~2-3x more often than either scheduler wants (84% of reviews happen before scheduled due), likely driven by incidental co-occurrence reviews. So weights matter less than selector scoring.
+- Optimizer DID confirm `desired_retention=0.95` is the right target with library default weights (user's 95.4% Good rate fits that target better than default 0.90).
+- `OVERDUE_ESCALATION_DAYS=3.0` meant lapses under 3d overdue got no priority boost, losing to multi-word sentences covering other words.
+
+**Changes**:
+- `fsrs_service.py`: `Scheduler(desired_retention=0.95)` — shortens all intervals ~15-20% to match this user's low lapse rate.
+- `sentence_selector.py`:
+  - New `LAPSED_BOOST = 3.0`, applied multiplicatively to sentence score when covering any due word in `lapsed` state (similar pattern to `NEVER_REVIEWED_BOOST`).
+  - `OVERDUE_ESCALATION_DAYS`: 3.0 → **0.5** (escalation starts immediately after due date).
+  - `OVERDUE_ESCALATION_MAX`: 4.0 → **6.0** (steeper ramp for badly overdue).
+- `score_components["lapsed_boost"]` exposed for debugging.
+
+**Expected effect**:
+- Lapsed words re-surface in next 1-2 sessions instead of waiting out FSRS interval alone.
+- Composite boost example: a 2-day-overdue lapsed word on a fresh sentence gets `3.0 × ~1.3 = ~3.9×` score boost vs. `1.0 ×` before.
+- `desired_retention=0.95` doesn't affect already-scheduled cards; takes effect on next review.
+
+**Verification plan**:
+- Re-run `replay_fsrs.py` in 1 week. Expect no-follow-up count to drop from 85 → <40.
+- Monitor lapse rate: should stay ~4-5% (not spike from over-scheduling).
+- Check `recent_accuracy` stays ≥85% — if drops, back off desired_retention.
+
+**Considered but not deployed**:
+- Fully optimized FSRS-6 weights (`optimize_fsrs.py` output). Replay showed nearly identical post-lapse recovery time (4.98 vs 5.12 reviews) and the optimizer was fit on user's incidental-review signal, not clean scheduler-driven signal. Risk/reward didn't favor a weights change.
+
+**Files**: `backend/app/services/fsrs_service.py`, `backend/app/services/sentence_selector.py`, `backend/scripts/optimize_fsrs.py` (new), `backend/scripts/replay_fsrs.py` (new), `docs/scheduling-system.md`
+
+---
+
 ## 2026-04-12: Hindawi Corpus Import + Enrichment Pipeline
 
 **Goal**: Increase sentence diversity by importing authentic Arabic sentences from published children's books, instead of relying solely on LLM-generated sentences (307 active at time of change).


### PR DESCRIPTION
## Summary
- FSRS `desired_retention`: 0.90 → **0.95** (optimizer-calibrated on 21k reviews)
- New `LAPSED_BOOST = 3.0` multiplier in sentence selector — lapsed words win scoring competition against multi-word sentences
- `OVERDUE_ESCALATION_DAYS`: 3.0 → **0.5** (escalation kicks in immediately after due date)
- `OVERDUE_ESCALATION_MAX`: 4.0 → **6.0** (steeper ramp for stuck cards)
- New analysis scripts `optimize_fsrs.py` + `replay_fsrs.py` for reproducibility

## Why
Investigating user concern about lapses on well-known words. Replay analysis of 21,363 reviews showed:
- Recovery dynamics for high-stability lapses are good (91% Good on first follow-up)
- But **85 of 176 recent lapses had ZERO follow-up reviews** — half the lapsed words weren't being re-shown
- ~37 of those are stuck in scoring (due, in cohort, have sentences, but lose to other words)
- Deploying fully-optimized FSRS weights was considered but replay showed near-identical recovery (4.98 vs 5.12 reviews), and the weights were fit to user's incidental-review signal rather than clean scheduler-driven signal

See `research/experiment-log.md` 2026-04-13 entry for full analysis.

## Verification
- 102 tests pass (`test_fsrs.py`, `test_fsrs_realistic.py`, `test_sentence_selector.py`, `test_acquisition.py`)
- Replay script reproducible: `python3 scripts/replay_fsrs.py --db path/to/alif.db`
- 1-week check: re-run `replay_fsrs.py` on fresh DB, expect no-follow-up count to drop from 85 → <40