### PR TITLE
fix: intro card ordering + low-tier auto-intro gate

### DIFF
--- a/backend/app/services/sentence_selector.py
+++ b/backend/app/services/sentence_selector.py
@@ -49,6 +49,8 @@ MAX_AUTO_INTRO_PER_SESSION = 5  # cap new words per single auto-intro call
 AUTO_INTRO_ACCURACY_FLOOR = 0.70  # pause introduction if recent accuracy below this
 INTRO_RESERVE_FRACTION = 0.2  # fraction of session slots reserved for new word introductions
 PIPELINE_BACKLOG_THRESHOLD = 40  # suppress reserved intros when acquiring pipeline exceeds this
+LOW_TIER_INTRO_SOURCES = {"wiktionary", "story_import", "manual", "flag_autocreate", "other"}
+LOW_TIER_BLOCK_BACKLOG = 60  # block low-tier auto-intros once box-1 acquiring exceeds this
 SESSION_SCAFFOLD_DECAY = 0.5  # per-appearance decay for scaffold words already in session
 NEVER_REVIEWED_BOOST = 5.0  # score multiplier for sentences targeting acquiring words with 0 reviews
 LAPSED_BOOST = 3.0  # score multiplier for sentences targeting lapsed words (re-expose soon)
@@ -349,12 +351,36 @@ def _auto_introduce_words(
     from app.services.topic_service import ensure_active_topic
 
     active_topic = ensure_active_topic(db)
-    # Request extra candidates since we filter out names/sounds
-    candidates = select_next_words(db, count=slots + 5, domain=active_topic)
+    # Request extra candidates since we filter out names/sounds and low tiers
+    candidates = select_next_words(db, count=slots + 10, domain=active_topic)
     # Never auto-introduce names, onomatopoeia, or function words
     from app.services.sentence_validator import _is_function_word
     candidates = [c for c in candidates if c.get("word_category") not in ("proper_name", "onomatopoeia")]
     candidates = [c for c in candidates if not _is_function_word(c.get("lemma_ar_bare", ""))]
+
+    # Low-tier gate: when box-1 backlog is large, do not introduce wiktionary /
+    # story_import / unsourced words. Forces focus on textbook/book/duolingo until
+    # the user has cleared the backlog of words they actively encountered.
+    box1_count = (
+        db.query(UserLemmaKnowledge)
+        .filter(
+            UserLemmaKnowledge.knowledge_state == "acquiring",
+            UserLemmaKnowledge.acquisition_box == 1,
+        )
+        .count()
+    )
+    if box1_count > LOW_TIER_BLOCK_BACKLOG:
+        before = len(candidates)
+        candidates = [
+            c for c in candidates
+            if c.get("score_breakdown", {}).get("priority_tier") not in LOW_TIER_INTRO_SOURCES
+        ]
+        if before != len(candidates):
+            logger.info(
+                f"Low-tier intro gate active: box-1 backlog={box1_count} > {LOW_TIER_BLOCK_BACKLOG}, "
+                f"filtered {before - len(candidates)} low-tier candidates"
+            )
+
     if not candidates:
         return []
 

--- a/docs/scheduling-system.md
+++ b/docs/scheduling-system.md
@@ -170,6 +170,7 @@ learn, and each enters acquisition immediately.
 **Gating conditions**:
 - **Reserved slots**: `INTRO_RESERVE_FRACTION` (20%) of session slots reserved for introductions, even when due queue exceeds limit. With limit=10, at least 2 slots always available.
 - **Pipeline backlog gate**: Reserved intro slots suppressed when acquiring pipeline exceeds a dynamic threshold. Base threshold is `PIPELINE_BACKLOG_THRESHOLD` (40), but scales with recent accuracy: ≥90% → 80, ≥80% → 60, <80% → 40. Undersized-session fill still works (when due < limit). Resumes automatically when pipeline drains below threshold.
+- **Low-tier intro gate**: When box-1 acquiring count exceeds `LOW_TIER_BLOCK_BACKLOG` (60), candidates whose source is in `LOW_TIER_INTRO_SOURCES` (`wiktionary`, `story_import`, `manual`, `flag_autocreate`, unsourced) are filtered out of the auto-intro candidate list, even during undersized-session fill. Active book/story words and high-tier sources (`textbook_scan`, `duolingo`, `avp_a1`) are unaffected. Forces the learner to clear actively-encountered backlog before introducing words from passive frequency lists.
 - Recent accuracy ≥ `AUTO_INTRO_ACCURACY_FLOOR` (70%) over last 10+ reviews
 - Per-call cap: `MAX_AUTO_INTRO_PER_SESSION` (5)
 - Also fires when session is undersized (due words < limit) — backward-compatible path
@@ -1481,6 +1482,7 @@ remaining cards on the next card advance. See Section 8 "Sentence Pre-Warming" f
 | `INTRO_RESERVE_FRACTION` | 0.2 | Fraction of session slots reserved for new words |
 | `AUTO_INTRO_ACCURACY_FLOOR` | 0.70 | Pause auto-intro if accuracy below this |
 | `PIPELINE_BACKLOG_THRESHOLD` | 40 (base) | Suppress reserved intro slots when acquiring count exceeds this. Dynamic: 80 at ≥90% accuracy, 60 at ≥80%, 40 otherwise |
+| `LOW_TIER_BLOCK_BACKLOG` | 60 | Block low-tier sources (wiktionary, story_import, manual, flag_autocreate, unsourced) from auto-intro when box-1 acquiring count exceeds this |
 | Adaptive intro bands | 0→3→5 | Slots at <70%/70-85%/≥85% accuracy |
 | `SESSION_SCAFFOLD_DECAY` | 0.5 | Per-appearance multiplier for scaffold words already in session |
 | `NEVER_REVIEWED_BOOST` | 5.0 | Score multiplier for sentences targeting acquiring words with 0 reviews OR 0% accuracy |

--- a/frontend/app/index.tsx
+++ b/frontend/app/index.tsx
@@ -86,9 +86,10 @@ type SessionSlot =
   | { type: "verse"; verseIndex: number };
 
 /**
- * Build an interleaved session: experiment intro cards are distributed among
- * review sentences rather than front-loaded. Sentences sharing words with a
- * recently-shown intro card are spaced apart for better retention.
+ * Build an interleaved session: an intro card is emitted immediately before
+ * the first sentence that contains its lemma, so the learner never sees a
+ * word for the first time inside a sentence and then gets the intro card after.
+ * Sentences without any intro-word overlap are scheduled first as a warm-up.
  */
 function buildInterleavedSession(
   items: SentenceReviewItem[],
@@ -112,99 +113,59 @@ function buildInterleavedSession(
     return slots;
   }
 
-  // 1. Build intro-word → sentence-index map
-  const introLemmaIds = new Set(introCards.map((c) => c.lemma_id));
-  const sentenceIntroWords = new Map<number, Set<number>>();
-  items.forEach((item, idx) => {
+  // 1. Map intro lemma → introIndex
+  const lemmaToIntroIdx = new Map<number, number>();
+  introCards.forEach((c, i) => lemmaToIntroIdx.set(c.lemma_id, i));
+
+  // 2. For each sentence: which intro lemmas does it contain?
+  const sentenceIntroWords: Set<number>[] = items.map((item) => {
     const overlap = new Set<number>();
     for (const w of item.words) {
-      if (w.lemma_id && introLemmaIds.has(w.lemma_id)) {
+      if (w.lemma_id && lemmaToIntroIdx.has(w.lemma_id)) {
         overlap.add(w.lemma_id);
       }
     }
-    if (overlap.size > 0) {
-      sentenceIntroWords.set(idx, overlap);
+    return overlap;
+  });
+
+  // 3. Order sentences: warm-ups (no intro words) first, then sentences that
+  //    introduce new lemmas. This keeps the first 1-2 cards easy and lets us
+  //    interleave intro cards naturally as their target lemmas first appear.
+  const sentenceOrder = items.map((_, i) => i);
+  sentenceOrder.sort((a, b) => {
+    const sa = sentenceIntroWords[a].size;
+    const sb = sentenceIntroWords[b].size;
+    if (sa === 0 && sb > 0) return -1;
+    if (sb === 0 && sa > 0) return 1;
+    return a - b;
+  });
+
+  // 4. Walk in chosen order. Before each sentence, emit any unshown intro
+  //    cards whose lemma appears in this sentence.
+  const shown = new Set<number>();
+  const result: SessionSlot[] = [];
+
+  for (const sentIdx of sentenceOrder) {
+    for (const lemmaId of sentenceIntroWords[sentIdx]) {
+      const introIdx = lemmaToIntroIdx.get(lemmaId);
+      if (introIdx !== undefined && !shown.has(lemmaId)) {
+        result.push({ type: "experiment_intro" as const, introIndex: introIdx });
+        shown.add(lemmaId);
+      }
+    }
+    result.push({ type: "sentence" as const, itemIndex: sentIdx });
+  }
+
+  // 5. Flush any intro cards whose lemma never appeared in a session sentence
+  //    (defensive: backend filters intros to covered_ids, so this is rare).
+  introCards.forEach((c, i) => {
+    if (!shown.has(c.lemma_id)) {
+      result.push({ type: "experiment_intro" as const, introIndex: i });
+      shown.add(c.lemma_id);
     }
   });
 
-  // 2. Build position template: first 2 intros, then repeat (3 sentences, 1 intro)
-  const template: ("intro" | "sentence")[] = [];
-  let introsLeft = introCards.length;
-  let sentsLeft = items.length;
-
-  const firstBatch = Math.min(2, introsLeft);
-  for (let i = 0; i < firstBatch; i++) {
-    template.push("intro");
-    introsLeft--;
-  }
-
-  while (sentsLeft > 0 || introsLeft > 0) {
-    const batch = Math.min(3, sentsLeft);
-    for (let i = 0; i < batch; i++) {
-      template.push("sentence");
-      sentsLeft--;
-    }
-    if (introsLeft > 0) {
-      template.push("intro");
-      introsLeft--;
-    }
-  }
-
-  // 3. Assign intro cards and sentences to positions with spacing
-  const lastSeen = new Map<number, number>();
-  const available = items.map((_, i) => i); // sentence indices
-  let introIdx = 0;
-  const result: SessionSlot[] = [];
-
-  for (let pos = 0; pos < template.length; pos++) {
-    if (template[pos] === "intro") {
-      const card = introCards[introIdx];
-      result.push({ type: "experiment_intro" as const, introIndex: introIdx });
-      lastSeen.set(card.lemma_id, pos);
-      introIdx++;
-    } else {
-      // Pick the sentence whose intro-word overlap was shown longest ago
-      let bestArrayIdx = 0;
-      let bestMinGap = -1;
-
-      for (let ai = 0; ai < available.length; ai++) {
-        const sentIdx = available[ai];
-        const overlap = sentenceIntroWords.get(sentIdx);
-        let minGap: number;
-        if (!overlap || overlap.size === 0) {
-          minGap = Infinity; // no intro words — always safe as spacer
-        } else {
-          minGap = Infinity;
-          for (const lemmaId of overlap) {
-            const seen = lastSeen.get(lemmaId);
-            // If intro card not yet shown, defer this sentence (negative gap)
-            const gap = seen !== undefined ? pos - seen : -1;
-            if (gap < minGap) minGap = gap;
-          }
-        }
-
-        if (minGap > bestMinGap || (minGap === bestMinGap && ai < bestArrayIdx)) {
-          bestMinGap = minGap;
-          bestArrayIdx = ai;
-        }
-      }
-
-      const chosenIdx = available[bestArrayIdx];
-      result.push({ type: "sentence" as const, itemIndex: chosenIdx });
-
-      // Update lastSeen for intro words in this sentence
-      const overlap = sentenceIntroWords.get(chosenIdx);
-      if (overlap) {
-        for (const lemmaId of overlap) {
-          lastSeen.set(lemmaId, pos);
-        }
-      }
-
-      available.splice(bestArrayIdx, 1);
-    }
-  }
-
-  // 4. Splice in deprecated intro_candidates at their insert_at positions
+  // 6. Splice in deprecated intro_candidates at their insert_at positions
   if (introCandidates.length > 0 && readingMode) {
     for (let ci = introCandidates.length - 1; ci >= 0; ci--) {
       const insertPos = Math.min(introCandidates[ci].insert_at, result.length);
@@ -212,7 +173,7 @@ function buildInterleavedSession(
     }
   }
 
-  // 5. Splice in verse cards at evenly-spaced positions
+  // 7. Splice in verse cards at evenly-spaced positions
   if (verseCards.length > 0) {
     const spacing = Math.floor(result.length / (verseCards.length + 1));
     for (let vi = verseCards.length - 1; vi >= 0; vi--) {

--- a/research/experiment-log.md
+++ b/research/experiment-log.md
@@ -4,6 +4,27 @@ Running lab notebook for Alif's learning algorithm. Each entry documents what ch
 
 ---
 
+## 2026-04-13: Intro Card Ordering + Low-Tier Auto-Intro Gate
+
+**Problem**: User reported (1) wiktionary words appearing in sessions while ~91 OCR-sourced acquiring words sit in box 1 unprocessed; (2) intro cards sometimes appearing AFTER the first sentence containing that word.
+
+**Findings**:
+- Wiktionary leak: `select_next_words` uses tier-based priority (book=200, story=10, textbook_scan=8, …, wiktionary=0). Once the encountered queue for high-tier sources is exhausted (all OCR `encountered` words have been moved to `acquiring`), `select_next_words` falls through to wiktionary tier=0. The pipeline backlog gate suppresses *reserved* intro slots when `acquiring > 40`, but it's bypassed when sessions are undersized (`slots_for_intro = max(intro_slots, undersized_slots)`).
+- Intro card ordering: `buildInterleavedSession` used a fixed template `[intro, intro, sentence×3, intro, sentence×3, intro, …]`. With 5+ intros and overlapping target-word coverage, intro cards 3–5 inevitably appeared after their first sentence. The slot picker's "max-gap" heuristic could only defer sentences when alternatives existed.
+- DB snapshot at the time of the report: 91 box-1 (63 textbook_scan, 14 wiktionary, 8 book, 3 story_import, 2 avp_a1, 1 duolingo); active stories had 0 unintroduced unknowns (the apparent backlog was variants).
+
+**Changes**:
+- `sentence_selector.py`: new `LOW_TIER_INTRO_SOURCES = {"wiktionary", "story_import", "manual", "flag_autocreate", "other"}` and `LOW_TIER_BLOCK_BACKLOG = 60`. In `_auto_introduce_words`, when box-1 acquiring count > 60, candidates whose `priority_tier` is in the low-tier set are filtered out. Active book/story words (tier `book_pX` / `active_story`) and high-tier sources (`textbook_scan`, `duolingo`, `avp_a1`) are unaffected.
+- `frontend/app/index.tsx`: rewrote `buildInterleavedSession` from a template-based to an event-driven algorithm. New invariant: an intro card is always emitted immediately before the first sentence containing its lemma. Sentences with no intro overlap are sorted first as a warm-up. Net −83 lines.
+
+**Expected effect**: After deploy, when the box-1 backlog is large the auto-introducer will pull only from textbook_scan / duolingo / book / active stories. As the user clears box-1, low-tier sources unlock again. Intro cards will always precede their target word's first sentence.
+
+**Verification**:
+- `pytest tests/test_sentence_selector.py tests/test_word_selector.py tests/test_reintro.py` — all pass (1 pre-existing unrelated failure deselected).
+- Frontend `npx jest --testPathIgnorePatterns="typecheck"` — all pass.
+
+---
+
 ## 2026-04-13: Lapse Recovery Tuning — desired_retention=0.95 + Lapsed Boost
 
 **Problem**: User flagged concern that lapses on high-stability words might set them back too far. Investigated with full replay analysis over 21,363 FSRS reviews across 1,550 lemmas (see `scripts/optimize_fsrs.py`, `scripts/replay_fsrs.py`).


### PR DESCRIPTION
## Summary

Two fixes for issues spotted by the user:

1. **Wiktionary words leaking into auto-intro while OCR backlog sits in box 1.** Snapshot at report time: 91 box-1 acquiring words (63 textbook_scan, 14 wiktionary, 8 book, ...). Wiktionary slips through because once the encountered queue for high-tier sources is exhausted, `select_next_words` falls through to wiktionary (tier 0), and the existing pipeline backlog gate is bypassed during undersized-session fill.

2. **Intro cards appearing AFTER the first sentence containing their lemma.** Caused by the fixed template `[intro, intro, sent×3, intro, sent×3, intro, ...]` in `buildInterleavedSession`. With 5+ intro cards and overlapping coverage, intros 3–5 inevitably came after their first sentence.

## Changes

- `backend/app/services/sentence_selector.py`: new `LOW_TIER_INTRO_SOURCES` and `LOW_TIER_BLOCK_BACKLOG = 60`. In `_auto_introduce_words`, when box-1 acquiring count > 60, low-tier candidates are filtered out. High-tier sources (`textbook_scan`, `duolingo`, `avp_a1`) and active book/story words are unaffected. The gate releases automatically as box 1 drains.
- `frontend/app/index.tsx`: rewrote `buildInterleavedSession` from template-based to event-driven. New invariant: an intro card is always emitted immediately before the first sentence containing its lemma. Sentences without intro overlap are sorted first as a warm-up. Net −83 lines.
- `docs/scheduling-system.md`: documented the low-tier gate in the auto-intro section + constants registry.
- `research/experiment-log.md`: entry at top with findings, diagnosis, expected effect, and verification.