### PR TITLE
Phase 1 awkward-sentence prevention: corpus regex pre-filter

### DIFF
--- a/backend/app/services/sentence_quality.py
+++ b/backend/app/services/sentence_quality.py
@@ -1,0 +1,112 @@
+"""Pure-string regex helpers that flag low-quality sentences.
+
+Phase 1 awkward-sentence prevention: a regex pre-filter for corpus-import
+fragments (anaphoric continuations, dialogue-only chunks, demonstrative/
+pronoun openers without antecedent). Lifted from the simulator at
+/tmp/claude/awkward/simulate_b1.py — combined precision 79% / recall 81%
+on the hand-graded Hindawi corpus eval set.
+
+No DB access. No LLM. Just strings in, (bool, rule_name) out.
+"""
+from __future__ import annotations
+
+import re
+
+# Anaphoric multi-letter openers (single-letter و/ف are handled separately).
+_ANAPHORIC_OPENERS_BARE = {
+    "ثم", "لكن", "لكنّ", "فإذا", "فلما", "وعندما", "وفي",
+    "فقال", "فقالت", "فأخذ",
+}
+
+_TERMINAL = (".", "؟", "!", "»", "…", "؛")
+
+_DEMONSTRATIVES_BARE = {
+    "هذا", "هذه", "ذلك", "تلك", "هؤلاء", "أولئك",
+}
+
+# Standalone anaphoric pronouns. ها/ه/هم suffixes get caught attached to
+# words too, so we restrict to length>=2 to avoid matching attached ـه.
+_PRONOUN_ANAPHOR_BARE = {
+    "هو", "هي", "هم", "هن", "هما", "ها",
+}
+
+_DIACRITICS_RE = re.compile(r"[\u064b-\u065f\u0670]")
+
+
+def _strip_diacritics(s: str) -> str:
+    return _DIACRITICS_RE.sub("", s)
+
+
+def _first_word(s: str) -> str:
+    bare = _strip_diacritics(s.strip())
+    parts = bare.split()
+    return parts[0] if parts else ""
+
+
+def _r1_anaphoric_opener(text: str) -> bool:
+    """Opens with و/ف (single-letter prefix attached to next word) or
+    a multi-letter anaphoric connector (ثم/لكن/فإذا/...)."""
+    bare = _strip_diacritics(text.strip())
+    if not bare:
+        return False
+    if bare[0] in ("و", "ف"):
+        return True
+    parts = bare.split()
+    return bool(parts) and parts[0] in _ANAPHORIC_OPENERS_BARE
+
+
+def _r3_no_terminal(text: str) -> bool:
+    stripped = text.strip()
+    return bool(stripped) and not any(stripped.endswith(c) for c in _TERMINAL)
+
+
+def _r5_dialogue_only(text: str) -> bool:
+    stripped = text.strip()
+    return stripped.startswith("«") and stripped.endswith("»")
+
+
+def _r7_demonstrative_subject(text: str) -> bool:
+    """Demonstrative (hadhā/hadhihi/dhālika/tilka/...) in first 3 words —
+    almost always an anaphoric subject pointing at an unstated referent."""
+    bare = _strip_diacritics(text.strip())
+    words = bare.split()[:3]
+    return any(w in _DEMONSTRATIVES_BARE for w in words)
+
+
+def _r8_pronoun_subject(text: str) -> bool:
+    """First word is a standalone anaphoric pronoun (huwa/hiya/...)."""
+    return _first_word(text) in _PRONOUN_ANAPHOR_BARE
+
+
+# Order matters only for the rule_name returned on first match.
+_RULES: tuple[tuple[str, callable], ...] = (
+    ("R1_ANAPHORIC_OPENER", _r1_anaphoric_opener),
+    ("R3_NO_TERMINAL", _r3_no_terminal),
+    ("R5_DIALOGUE_ONLY", _r5_dialogue_only),
+    ("R7_DEMONSTRATIVE_SUBJECT", _r7_demonstrative_subject),
+    ("R8_PRONOUN_SUBJECT", _r8_pronoun_subject),
+)
+
+
+def fails_corpus_regex_filter(arabic_text: str) -> tuple[bool, str | None]:
+    """Return (fails, rule_name) — True if the sentence should be rejected.
+
+    Rules:
+    - R1_ANAPHORIC_OPENER: opens with و / ف (single-letter prefix attached to
+      next word) or ثم / لكن / لكنّ / فإذا / فلما / وعندما / وفي / فقال / ...
+    - R3_NO_TERMINAL: no terminal punctuation (. ؟ ! » … ؛)
+    - R5_DIALOGUE_ONLY: entirely inside «...» quotes
+    - R7_DEMONSTRATIVE_SUBJECT: hadhā/hadhihi/dhālika/tilka/hāʾulāʾi/ʾūlāʾika
+      in first 3 words (anaphoric subject)
+    - R8_PRONOUN_SUBJECT: first word is a standalone anaphoric pronoun
+      (huwa/hiya/hum/hunna/humā/hā)
+
+    Returns the first matching rule name. Diacritic-stripping applied
+    before matching so vowelled and bare text behave the same.
+    """
+    if not arabic_text or not arabic_text.strip():
+        return False, None
+    for name, fn in _RULES:
+        if fn(arabic_text):
+            return True, name
+    return False, None

--- a/backend/scripts/import_hindawi.py
+++ b/backend/scripts/import_hindawi.py
@@ -41,6 +41,7 @@ import pandas as pd
 sys.path.insert(0, ".")
 from app.database import SessionLocal
 from app.models import Sentence, SentenceWord
+from app.services.sentence_quality import fails_corpus_regex_filter
 from app.services.sentence_validator import (
     build_lemma_lookup,
     detect_proper_names,
@@ -247,6 +248,25 @@ def run_pipeline(
             })
 
     logger.info(f"Extracted {len(all_sentences):,} candidate sentences ({min_words}-{max_words} words)")
+
+    # Phase 1 awkward-sentence pre-filter: drop fragments before they reach
+    # the lemma-mapping pass. See app.services.sentence_quality.
+    rule_counts: dict[str, int] = {}
+    kept: list[dict] = []
+    for s in all_sentences:
+        fail, rule = fails_corpus_regex_filter(s["text"])
+        if fail:
+            rule_counts[rule] = rule_counts.get(rule, 0) + 1
+            continue
+        kept.append(s)
+    n_filtered = len(all_sentences) - len(kept)
+    if n_filtered:
+        breakdown = " ".join(f"{k}={v}" for k, v in sorted(rule_counts.items()))
+        logger.info(
+            f"Filtered {n_filtered:,} sentences via regex ({breakdown}); "
+            f"{len(kept):,} remain"
+        )
+    all_sentences = kept
 
     # Build lemma lookup
     db = SessionLocal()

--- a/backend/scripts/retire_corpus_fragments.py
+++ b/backend/scripts/retire_corpus_fragments.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Phase 1 awkward-sentence sweep — retire sentences that fail the
+corpus regex pre-filter (anaphoric openers, missing terminal
+punctuation, dialogue-only, demonstrative/pronoun subject).
+
+Scans ALL is_active=True sentences regardless of source: regex catches
+fragment-shaped sentences whether the LLM, a textbook OCR, or the
+Hindawi import produced them. Retired sentences are flipped to
+is_active=False; we leave the rows in place so existing review-log
+references stay intact.
+
+Usage:
+    # Dry run (no writes), shows per-source breakdown
+    python3 scripts/retire_corpus_fragments.py
+
+    # Apply (sets is_active=False, writes ContentFlag + ActivityLog)
+    python3 scripts/retire_corpus_fragments.py --apply
+"""
+import argparse
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from dotenv import load_dotenv
+
+load_dotenv(Path(__file__).resolve().parent.parent / ".env")
+
+from app.database import SessionLocal
+from app.models import ContentFlag, Sentence
+from app.services.activity_log import log_activity
+from app.services.sentence_quality import fails_corpus_regex_filter
+
+BATCH_SIZE = 500
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Retire awkward sentences via regex sweep")
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually retire sentences. Default is dry-run (no writes).",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Cap how many sentences are scanned (debug aid).",
+    )
+    args = parser.parse_args()
+
+    db = SessionLocal()
+    try:
+        q = db.query(Sentence.id, Sentence.arabic_text, Sentence.source).filter(
+            Sentence.is_active == True  # noqa: E712
+        )
+        if args.limit:
+            q = q.limit(args.limit)
+        rows = q.all()
+        print(f"Scanning {len(rows):,} active sentences...")
+
+        # Bucket by (rule, source) and collect ids to retire.
+        per_rule: dict[str, int] = {}
+        per_source: dict[str, int] = {}
+        per_source_rule: dict[tuple[str, str], int] = {}
+        to_retire: list[tuple[int, str, str, str]] = []  # (id, rule, source, text)
+
+        for sid, arabic, source in rows:
+            fail, rule = fails_corpus_regex_filter(arabic or "")
+            if not fail:
+                continue
+            src = source or "(none)"
+            per_rule[rule] = per_rule.get(rule, 0) + 1
+            per_source[src] = per_source.get(src, 0) + 1
+            per_source_rule[(src, rule)] = per_source_rule.get((src, rule), 0) + 1
+            to_retire.append((sid, rule, src, arabic or ""))
+
+        # ── Reporting ────────────────────────────────────────────────
+        print(f"\nFlagged {len(to_retire):,} sentences "
+              f"({100*len(to_retire)/max(len(rows),1):.1f}% of active)")
+
+        print("\nPer-rule:")
+        for rule, n in sorted(per_rule.items(), key=lambda x: -x[1]):
+            print(f"  {rule:30s} {n:>6,}")
+
+        print("\nPer-source:")
+        for src, n in sorted(per_source.items(), key=lambda x: -x[1]):
+            print(f"  {src:30s} {n:>6,}")
+
+        print("\nPer-source x rule:")
+        for (src, rule), n in sorted(per_source_rule.items(), key=lambda x: -x[1]):
+            print(f"  {src:15s} {rule:30s} {n:>6,}")
+
+        print("\nFirst 30 flagged:")
+        for sid, rule, src, text in to_retire[:30]:
+            preview = text.replace("\n", " ")[:60]
+            print(f"  [{sid:>6}] [{src:8s}] [{rule:25s}] {preview}")
+
+        if not args.apply:
+            print("\n[DRY RUN] No writes. Re-run with --apply to retire.")
+            return
+
+        # ── Apply ────────────────────────────────────────────────────
+        print(f"\nApplying retirement to {len(to_retire):,} sentences in batches of {BATCH_SIZE}...")
+        now = datetime.now(timezone.utc)
+        retired = 0
+        for batch_start in range(0, len(to_retire), BATCH_SIZE):
+            batch = to_retire[batch_start : batch_start + BATCH_SIZE]
+            ids = [sid for sid, _, _, _ in batch]
+            # Flip is_active in one UPDATE per batch.
+            db.query(Sentence).filter(Sentence.id.in_(ids)).update(
+                {Sentence.is_active: False},
+                synchronize_session=False,
+            )
+            # Drop a ContentFlag breadcrumb so the retirement reason is
+            # visible from the in-app flags surface.
+            for sid, rule, _src, _text in batch:
+                db.add(
+                    ContentFlag(
+                        content_type="sentence_arabic",
+                        sentence_id=sid,
+                        status="dismissed",
+                        resolution_note=f"auto-retired by regex: {rule}",
+                        created_at=now,
+                        resolved_at=now,
+                    )
+                )
+            db.commit()
+            retired += len(batch)
+            print(f"  ... committed {retired:,}/{len(to_retire):,}")
+
+        # Activity log summary.
+        per_source_str = " ".join(f"{src}={n}" for src, n in sorted(per_source.items()))
+        log_activity(
+            db,
+            event_type="sentences_retired",
+            summary=f"Phase 1 regex sweep: retired {retired} sentences ({per_source_str})",
+            detail={
+                "phase": "1_corpus_regex",
+                "retired": retired,
+                "scanned": len(rows),
+                "per_rule": per_rule,
+                "per_source": per_source,
+            },
+        )
+        print(f"\nDone. Retired {retired:,} sentences.")
+
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/test_sentence_quality.py
+++ b/backend/tests/test_sentence_quality.py
@@ -31,9 +31,7 @@ class TestFailingCases:
         assert rule == "R1_ANAPHORIC_OPENER"
 
     def test_r3_no_terminal_punctuation(self):
-        # Chapter-title fragment: "On the way to the palace" (no period).
-        # Note: starts with "في" (ف-prefixed) which also trips R1; R1 wins
-        # by rule order. We assert it fails — either rule is acceptable.
+        # Bare fragment with no .؟!»…؛ — Hindawi lifts these as chunks.
         text = "جَعَلَ ذَلِكَ سِيَّا الْأَكْبَرَ حَزِينًا جِدًّا"
         fails, rule = fails_corpus_regex_filter(text)
         assert fails is True

--- a/backend/tests/test_sentence_quality.py
+++ b/backend/tests/test_sentence_quality.py
@@ -1,0 +1,108 @@
+"""Tests for the corpus-import regex pre-filter.
+
+Hand-graded representative cases from the Hindawi corpus eval set
+(see /tmp/claude/awkward/grades_corpus.csv on the dev box). These
+locked-in expectations protect against rule drift.
+"""
+from app.services.sentence_quality import fails_corpus_regex_filter
+
+
+class TestFailingCases:
+    """Sentences that the regex filter SHOULD reject."""
+
+    def test_r1_opens_with_waw(self):
+        # "And it remained like that for a whole week."
+        text = "وَمَا زَالَتْ هَكَذَا أُسْبُوعًا كَامِلًا."
+        fails, rule = fails_corpus_regex_filter(text)
+        assert fails is True
+        assert rule == "R1_ANAPHORIC_OPENER"
+
+    def test_r1_opens_with_fa(self):
+        # "So she asked him: 'What are you thinking about, my son?'"
+        text = "فَسَأَلَتْهُ: «فِيمَ تُفَكِّرُ، يَا وَلَدِي؟»"
+        fails, rule = fails_corpus_regex_filter(text)
+        assert fails is True
+        assert rule == "R1_ANAPHORIC_OPENER"
+
+    def test_r1_opens_with_wa_indama(self):
+        text = "وَعِنْدَمَا شَاهَدَ النَّاسُ هَٰذَا اعْتَرَفُوا."
+        fails, rule = fails_corpus_regex_filter(text)
+        assert fails is True
+        assert rule == "R1_ANAPHORIC_OPENER"
+
+    def test_r3_no_terminal_punctuation(self):
+        # Chapter-title fragment: "On the way to the palace" (no period).
+        # Note: starts with "في" (ف-prefixed) which also trips R1; R1 wins
+        # by rule order. We assert it fails — either rule is acceptable.
+        text = "جَعَلَ ذَلِكَ سِيَّا الْأَكْبَرَ حَزِينًا جِدًّا"
+        fails, rule = fails_corpus_regex_filter(text)
+        assert fails is True
+        assert rule == "R3_NO_TERMINAL"
+
+    def test_r5_dialogue_only(self):
+        text = "«قَرِيبٌ. قَرِيبٌ. قَرِيبٌ.»"
+        fails, rule = fails_corpus_regex_filter(text)
+        assert fails is True
+        assert rule == "R5_DIALOGUE_ONLY"
+
+    def test_r7_demonstrative_subject(self):
+        text = "هَذَا رَجُلٌ طَيِّبٌ."
+        fails, rule = fails_corpus_regex_filter(text)
+        assert fails is True
+        assert rule == "R7_DEMONSTRATIVE_SUBJECT"
+
+    def test_r7_demonstrative_with_diacritics(self):
+        # "He told her that he had bought all THESE things from the market."
+        # هَٰذِهِ in position 4 — outside the first 3 words, so R7 should NOT
+        # fire here. But the sentence has no anaphor opener and ends with a
+        # period. This sentence should pass (the simulator graded it as F
+        # for anaphors but our regex doesn't catch every fragment — this is
+        # the recall gap we accept in Phase 1).
+        text = "أَخْبَرَهَا أَنَّهُ اشْتَرَىٰ كُلَّ هَٰذِهِ الْأَشْيَاءِ مِنَ السُّوقِ."
+        fails, _ = fails_corpus_regex_filter(text)
+        assert fails is False
+
+    def test_r8_pronoun_subject(self):
+        text = "هُوَ يَعْمَلُ فِي الْمَصْنَعِ."
+        fails, rule = fails_corpus_regex_filter(text)
+        assert fails is True
+        assert rule == "R8_PRONOUN_SUBJECT"
+
+
+class TestPassingCases:
+    """Sentences that should NOT be flagged."""
+
+    def test_proper_noun_subject(self):
+        text = "يَاسَمِينُ سَيِّدَةٌ كَرِيمَةٌ، بِنْتُ نَاسٍ طَيِّبِينَ."
+        fails, rule = fails_corpus_regex_filter(text)
+        assert fails is False
+        assert rule is None
+
+    def test_proverbial_with_terminal(self):
+        text = "الثَّعْلَبُ يَتَعَلَّمُ مِنَ التَّجْرِبَةِ."
+        fails, _ = fails_corpus_regex_filter(text)
+        assert fails is False
+
+    def test_simple_declarative(self):
+        text = "الْكِتَابُ عَلَىٰ الطَّاوِلَةِ."
+        fails, _ = fails_corpus_regex_filter(text)
+        assert fails is False
+
+
+class TestEdgeCases:
+    def test_empty_string(self):
+        fails, rule = fails_corpus_regex_filter("")
+        assert fails is False
+        assert rule is None
+
+    def test_whitespace_only(self):
+        fails, rule = fails_corpus_regex_filter("   \n  ")
+        assert fails is False
+        assert rule is None
+
+    def test_question_mark_is_terminal(self):
+        text = "هَلْ دَبَّ الْخَوْفُ إِلَى قَلْبِهِ؟"
+        fails, _ = fails_corpus_regex_filter(text)
+        # Doesn't start with و/ف, has terminal ؟, no demonstrative/pronoun
+        # in first 3 words — should pass.
+        assert fails is False


### PR DESCRIPTION
## Summary

- New `app/services/sentence_quality.py` exposes `fails_corpus_regex_filter(text)` returning `(bool, rule_name)`. Five rules (R1 anaphoric opener, R3 no terminal punct, R5 dialogue-only, R7 demonstrative subject in first 3 words, R8 anaphoric pronoun subject) lifted from `/tmp/claude/awkward/simulate_b1.py` — combined precision 79% / recall 81% on the hand-graded Hindawi eval set.
- `import_hindawi.py` now drops fragments before the lemma-mapping pass and logs per-rule counts.
- New `scripts/retire_corpus_fragments.py` retroactively sweeps ALL `is_active=True` sentences (regardless of source). Dry-run by default; with `--apply` it flips `is_active=False`, drops a `ContentFlag` breadcrumb (`status='dismissed'`, `resolution_note='auto-retired by regex: <rule>'`), and writes an `ActivityLog` (`event_type='sentences_retired'`).