### PR TITLE
Tighten R1: only fire on connective وَ/فَ (fatha required)

### DIFF
--- a/backend/app/services/sentence_quality.py
+++ b/backend/app/services/sentence_quality.py
@@ -12,11 +12,16 @@ from __future__ import annotations
 
 import re
 
-# Anaphoric multi-letter openers (single-letter و/ف are handled separately).
+# Anaphoric multi-letter openers (single-letter و/ف are handled separately
+# below — only when the connective fatha is present, to spare lexical words
+# like فِي / وُجِدَ).
 _ANAPHORIC_OPENERS_BARE = {
     "ثم", "لكن", "لكنّ", "فإذا", "فلما", "وعندما", "وفي",
     "فقال", "فقالت", "فأخذ",
 }
+
+# Diacritic codepoint we use for the و/ف disambiguation.
+_FATHA = "\u064E"  # ـَ — marks the connective particle (فَ / وَ)
 
 _TERMINAL = (".", "؟", "!", "»", "…", "؛")
 
@@ -44,13 +49,27 @@ def _first_word(s: str) -> str:
 
 
 def _r1_anaphoric_opener(text: str) -> bool:
-    """Opens with و/ف (single-letter prefix attached to next word) or
-    a multi-letter anaphoric connector (ثم/لكن/فإذا/...)."""
-    bare = _strip_diacritics(text.strip())
-    if not bare:
+    """Opens with the connective particle و/ف (only when explicitly
+    diacritized as fatha — `وَ` / `فَ` — to spare lexical words like
+    فِي / وُجِدَ) or with a multi-letter anaphoric connector
+    (ثم/لكن/فإذا/...).
+
+    Heuristic: look at the *raw* first word (no diacritic stripping).
+    If it starts with و or ف and the next codepoint is fatha (ـَ),
+    it's connective. Anything else (kasra, damma, sukun, no mark,
+    shadda) is treated as lexical and does not trip R1.
+    """
+    raw = text.strip()
+    if not raw:
         return False
-    if bare[0] in ("و", "ف"):
-        return True
+    raw_first = raw.split()[0] if raw.split() else ""
+    if raw_first and raw_first[0] in ("و", "ف"):
+        # Need at least one diacritic mark on the first letter to call it
+        # connective; bare-letter prefixes are ambiguous and we err on
+        # the side of keeping them.
+        if len(raw_first) >= 2 and raw_first[1] == _FATHA:
+            return True
+    bare = _strip_diacritics(raw)
     parts = bare.split()
     return bool(parts) and parts[0] in _ANAPHORIC_OPENERS_BARE
 
@@ -92,8 +111,10 @@ def fails_corpus_regex_filter(arabic_text: str) -> tuple[bool, str | None]:
     """Return (fails, rule_name) — True if the sentence should be rejected.
 
     Rules:
-    - R1_ANAPHORIC_OPENER: opens with و / ف (single-letter prefix attached to
-      next word) or ثم / لكن / لكنّ / فإذا / فلما / وعندما / وفي / فقال / ...
+    - R1_ANAPHORIC_OPENER: opens with the connective particle وَ / فَ
+      (single-letter prefix with explicit fatha — bare letters and
+      kasra/damma vocalizations are spared, so فِي and وُجِدَ pass) or
+      ثم / لكن / لكنّ / فإذا / فلما / وعندما / وفي / فقال / ...
     - R3_NO_TERMINAL: no terminal punctuation (. ؟ ! » … ؛)
     - R5_DIALOGUE_ONLY: entirely inside «...» quotes
     - R7_DEMONSTRATIVE_SUBJECT: hadhā/hadhihi/dhālika/tilka/hāʾulāʾi/ʾūlāʾika

--- a/backend/tests/test_sentence_quality.py
+++ b/backend/tests/test_sentence_quality.py
@@ -30,6 +30,27 @@ class TestFailingCases:
         assert fails is True
         assert rule == "R1_ANAPHORIC_OPENER"
 
+    def test_r1_opens_with_fa_kana(self):
+        # "So it was..." — connective فَ + kāna verb. Fatha on the ف.
+        text = "فَكَانَ الْأَمْرُ كَذَلِكَ."
+        fails, rule = fails_corpus_regex_filter(text)
+        assert fails is True
+        assert rule == "R1_ANAPHORIC_OPENER"
+
+    def test_r1_opens_with_wa_lamma(self):
+        # "And when..." — connective وَ + lammā.
+        text = "وَلَمَّا وَصَلْنَا إِلَى الْبَيْتِ."
+        fails, rule = fails_corpus_regex_filter(text)
+        assert fails is True
+        assert rule == "R1_ANAPHORIC_OPENER"
+
+    def test_r1_opens_with_thumma(self):
+        # "Then..." — multi-letter connective.
+        text = "ثُمَّ ذَهَبَ إِلَى السُّوقِ."
+        fails, rule = fails_corpus_regex_filter(text)
+        assert fails is True
+        assert rule == "R1_ANAPHORIC_OPENER"
+
     def test_r3_no_terminal_punctuation(self):
         # Bare fragment with no .؟!»…؛ — Hindawi lifts these as chunks.
         text = "جَعَلَ ذَلِكَ سِيَّا الْأَكْبَرَ حَزِينًا جِدًّا"
@@ -83,6 +104,31 @@ class TestPassingCases:
 
     def test_simple_declarative(self):
         text = "الْكِتَابُ عَلَىٰ الطَّاوِلَةِ."
+        fails, _ = fails_corpus_regex_filter(text)
+        assert fails is False
+
+    def test_fi_kasra_is_lexical(self):
+        # `فِي` ("in") starts with ف+kasra, NOT the connective فَ. Must pass.
+        text = "فِي الْحَدِيقَةِ أَرْنَبٌ نَحِيفٌ."
+        fails, rule = fails_corpus_regex_filter(text)
+        assert fails is False, f"R1 false-positive on فِي ({rule})"
+
+    def test_fi_almustashfa_passes(self):
+        # Same family — `فِي الْمَاضِي ...` was a high-volume false positive
+        # in the prod dry-run that prompted this tighten.
+        text = "فِي الْمَاضِي كَانَ الْجَدَرِيُّ مَرَضًا خَطِيرًا."
+        fails, _ = fails_corpus_regex_filter(text)
+        assert fails is False
+
+    def test_wujida_damma_is_lexical(self):
+        # `وُجِدَ` ("was found") — first letter و with damma, lexical verb.
+        text = "وُجِدَ الْكِتَابُ عَلَى الطَّاوِلَةِ."
+        fails, _ = fails_corpus_regex_filter(text)
+        assert fails is False
+
+    def test_wiladah_kasra_is_lexical(self):
+        # `وِلَادَة` ("birth") — و + kasra, lexical noun.
+        text = "وِلَادَةُ الطِّفْلِ كَانَتْ سَهْلَةً."
         fails, _ = fails_corpus_regex_filter(text)
         assert fails is False
 


### PR DESCRIPTION
## Summary

- Tightens R1_ANAPHORIC_OPENER so the single-letter و/ف rule only fires when the next codepoint is fatha (\u064E). Bare letters and kasra/damma vocalizations are spared, so `فِي` ("in") and `وُجِدَ` ("was found") no longer trip the filter.
- Multi-letter connectives (ثُمَّ, لَكِنَّ, فَإِذَا, …) still match via the bare set after diacritic stripping.
- Adds 7 new test cases: positive (`فَكَانَ`, `وَلَمَّا`, `ثُمَّ`) and negative (`فِي`, `فِي الْمَاضِي`, `وُجِدَ`, `وِلَادَة`).

Motivation: the prod dry-run from PR #39 flagged 110 LLM cards as R1 false positives, mostly `فِي ...` sentences.