### PR TITLE
Phase 4 awkward-sentence prevention: prompt enrichment + Haiku candidate ranker

### DIFF
--- a/backend/app/services/llm.py
+++ b/backend/app/services/llm.py
@@ -492,6 +492,25 @@ Sentence structure variety:
 Respond with JSON: {{"sentences": [{{"arabic": "...", "english": "...", "transliteration": "..."}}, ...]}}"""
 
 
+def _format_target_example_block(
+    target_example_ar: str | None,
+    target_example_en: str | None,
+) -> str:
+    """Render an EXAMPLE block to anchor the lemma's correct sense.
+
+    Returns an empty string when either side is missing — we only show the
+    block when we have both Arabic and English so the LLM gets unambiguous
+    sense grounding. (Phase 4: enrich prompt with already-existing examples
+    to prevent wrong-sense awkward sentences like the استَوَى/dust case.)
+    """
+    if not target_example_ar or not target_example_en:
+        return ""
+    return (
+        f"Example of correct usage:\n"
+        f"- {target_example_ar.strip()} → {target_example_en.strip()}\n"
+    )
+
+
 def generate_sentence(
     target_word: str,
     target_translation: str,
@@ -501,6 +520,8 @@ def generate_sentence(
     max_words: int | None = None,
     avoid_words: list[str] | None = None,
     model_override: str = "claude_sonnet",
+    target_example_ar: str | None = None,
+    target_example_en: str | None = None,
 ) -> SentenceResult:
     """Generate a single Arabic sentence featuring the target word.
 
@@ -512,6 +533,11 @@ def generate_sentence(
         retry_feedback: Feedback from a previous failed attempt.
         max_words: Maximum word count for the sentence (for cognitive load management).
         avoid_words: Arabic words to avoid for diversity.
+        target_example_ar: Optional canonical Arabic example sentence (anchors
+            the correct sense for polysemous lemmas). Omitted from prompt when
+            None.
+        target_example_en: Optional English translation of the canonical
+            example.
 
     Returns:
         SentenceResult with arabic, english, transliteration.
@@ -530,11 +556,13 @@ def generate_sentence(
         avoid_str = "، ".join(avoid_words)
         avoid_instruction = f"\nDo NOT use these overused words — using them will cause rejection: {avoid_str}\nChoose different vocabulary instead.\n"
 
+    example_block = _format_target_example_block(target_example_ar, target_example_en)
+
     prompt = f"""Create a natural MSA sentence for a {difficulty_hint} Arabic learner.
 
 TARGET WORD (must appear in the sentence):
 - {target_word} ({target_translation})
-
+{example_block}
 KNOWN WORDS (you may use these):
 {known_list}
 
@@ -568,16 +596,29 @@ def generate_sentences_batch(
     target_word: str,
     target_translation: str,
     known_words: list[dict[str, str]],
-    count: int = 3,
+    count: int = 5,
     difficulty_hint: str = "beginner",
     model_override: str = "claude_sonnet",
     avoid_words: list[str] | None = None,
     rejected_words: list[str] | None = None,
     max_words: int | None = None,
+    target_example_ar: str | None = None,
+    target_example_en: str | None = None,
+    rerank: bool = True,
+    rerank_top_k: int = 2,
 ) -> list[SentenceResult]:
-    """Generate multiple sentences for a target word in a single LLM call.
+    """Generate multiple sentences for a target word in a single LLM call,
+    then optionally rerank by naturalness via a Haiku quality gate.
 
-    Returns up to `count` SentenceResult objects (may be fewer if parsing fails).
+    Default ``count`` was bumped from 3 to 5 in Phase 4 of the awkward-sentence
+    work so the Haiku reranker has a real choice to make. When ``rerank=True``
+    (default), the candidates are scored by ``rerank_sentences_by_naturalness``
+    and only the top ``rerank_top_k`` GOOD ones are returned. If the reranker
+    rejects all candidates, returns ``[]`` — caller decides whether to retry or
+    fall back to single-sentence generation.
+
+    Returns up to ``count`` SentenceResult objects when ``rerank=False`` (legacy
+    behavior), or up to ``rerank_top_k`` when reranking is enabled.
     """
     known_list = format_known_words_by_pos(known_words)
 
@@ -599,11 +640,14 @@ def generate_sentences_batch(
         word_range = f"{min_words}-{max_words}"
     else:
         word_range = "6-10"
+
+    example_block = _format_target_example_block(target_example_ar, target_example_en)
+
     prompt = f"""Create {count} different natural MSA sentences for a {difficulty_hint} Arabic learner.
 
 TARGET WORD (must appear in every sentence):
 - {target_word} ({target_translation})
-
+{example_block}
 VOCABULARY (you may ONLY use these Arabic content words, plus function words):
 {known_list}
 
@@ -645,7 +689,179 @@ Respond with JSON: {{"sentences": [{{"arabic": "...", "english": "...", "transli
                 transliteration=transliteration,
             ))
 
+    if rerank and sentences:
+        try:
+            return rerank_sentences_by_naturalness(
+                sentences,
+                target_word=target_word,
+                target_translation=target_translation,
+                top_k=rerank_top_k,
+            )
+        except (LLMError, AllProvidersFailed) as exc:
+            # Fail-open: rerank is a bonus quality filter; if Haiku times out or
+            # produces malformed output, fall back to the unranked candidates so
+            # we don't regress availability. CLAUDE.md §13 — we explicitly log
+            # so silent fallback doesn't mask repeated failures.
+            _log_call(
+                settings.log_dir, "claude_cli/haiku-rerank", False,
+                response_time=0.0, error=f"rerank failed: {str(exc)[:160]}",
+                prompt_length=0, task_type="sentence_rerank",
+            )
+            return sentences
+
     return sentences
+
+
+# ---------------------------------------------------------------------------
+# Phase 4 candidate ranker — Haiku-scored naturalness filter
+# ---------------------------------------------------------------------------
+
+# Categories shared with /tmp/claude/awkward/simulate_naturalness_v2.py
+_RERANK_CATEGORIES = [
+    "CONTEXT_DEPENDENT",
+    "CONTINUATION",
+    "STORY_SPECIFIC",
+    "DIALOGUE_FRAGMENT",
+    "FORCED_COMBINATION",
+    "WRONG_SENSE",
+    "NO_VERB",
+    "OK",
+]
+
+_RERANK_PROMPT_HEADER = """You are an editor selecting Arabic sentences to use as STANDALONE flashcard examples for an MSA learner. The learner sees one sentence with no other context.
+
+You are deliberately STRICT. The pool of candidate sentences is huge, so when in doubt, REJECT.
+
+Reject (verdict: BAD) when ANY of the following apply:
+
+1. CONTEXT_DEPENDENT — the sentence has a 3rd-person pronoun ("he/she/it/they/them/his/her" — هو/هي/هم/ها/ه/ـها), demonstrative used as subject ("this/that" — هذا/هذه/ذلك), or definite-article noun (الـ X) that points to a specific previously-mentioned referent the learner cannot resolve.
+   - GOOD: "The fox learns from experience" (proverbial, "the fox" is generic)
+   - GOOD: "She felt great satisfaction after completing the homework" (subject pronoun + clear context within sentence)
+   - BAD: "She must be moving at great speed" (who is she?)
+   - BAD: "Take from this bag what you need" (which bag?)
+   - BAD: "After that, he stopped to listen" (after what? who?)
+
+2. CONTINUATION — opens with و (and), ف (so), ثم (then), لكن (but), or فلما/وعندما/فإذا at the start, suggesting it's a continuation of prior text.
+   - Exception: if the و/ف is part of the verb itself (e.g., وَعَدَ "promised", فَهِمَ "understood"), not a connector.
+
+3. STORY_SPECIFIC — references a named character, event, or object specific to a narrative the learner doesn't know.
+
+4. DIALOGUE_FRAGMENT — line of quoted speech with insufficient narrative frame to make sense.
+
+5. FORCED_COMBINATION — words individually fit but the topic combination is bizarre or non-sequitur.
+   - BAD: "I drank cold licorice then hung the coat in the closet" (no semantic link between clauses)
+
+6. WRONG_SENSE — a polysemous word is used in a sense that doesn't fit the context. The TARGET_WORD line below names the intended sense; reject if a candidate uses a different sense.
+   - BAD: "The teacher talked about justice, then the school bell buzzed" (دَوَّى = "to buzz of insects" is wrong sense for a bell)
+   - BAD: "Art and heritage leveled among the participants" (استَوَى = "to settle/sit straight" is wrong sense — "leveled among" is nonsensical)
+
+7. NO_VERB / NOT_A_SENTENCE — sentence fragments, headings, lists.
+
+Otherwise verdict: GOOD.
+
+Be strict — when uncertain about anaphor or topic coherence, choose BAD. The cost of a false positive is low; the learner has many other sentences."""
+
+
+_RERANK_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "verdicts": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "index": {"type": "integer"},
+                    "verdict": {"type": "string", "enum": ["GOOD", "BAD"]},
+                    "category": {"type": "string", "enum": _RERANK_CATEGORIES},
+                    "explanation": {"type": "string"},
+                },
+                "required": ["index", "verdict", "category", "explanation"],
+            },
+        },
+    },
+    "required": ["verdicts"],
+}
+
+
+def rerank_sentences_by_naturalness(
+    sentences: list[SentenceResult],
+    target_word: str,
+    target_translation: str,
+    top_k: int = 2,
+) -> list[SentenceResult]:
+    """Score candidate sentences with the Haiku v2 naturalness gate, return top GOOD.
+
+    Single Haiku CLI call rates all sentences in one shot. Phase 4 of the
+    awkward-sentence prevention work; targets the long-tail wrong-sense and
+    forced-combination cases that no per-lemma fix scales to.
+
+    Behavior:
+      - All N candidates scored in one prompt
+      - Returns up to ``top_k`` sentences whose verdict is GOOD, preserving
+        the LLM's reported order so callers see the most natural picks first
+      - If fewer than ``top_k`` are GOOD, returns however many are GOOD
+      - If all are BAD, returns ``[]`` — caller is expected to either retry
+        generation or fall back to single-sentence generation
+      - Raises LLMError on parse failure / no verdicts; ``generate_sentences_batch``
+        catches this and falls back to the unranked candidates so Phase 4 quality
+        work never regresses availability
+    """
+    if not sentences:
+        return []
+
+    numbered = "\n".join(
+        f"[{i}] Arabic: {s.arabic}\n    English: {s.english}"
+        for i, s in enumerate(sentences)
+    )
+    prompt = f"""{_RERANK_PROMPT_HEADER}
+
+TARGET_WORD: {target_word} ({target_translation})
+
+Score each of the {len(sentences)} candidate sentences below. Return ONE verdict object per candidate (use the same `index` you see in brackets). Use category OK when the verdict is GOOD; otherwise pick the matching reject category.
+
+Candidates:
+{numbered}"""
+
+    result = generate_completion(
+        prompt=prompt,
+        system_prompt=(
+            "You are an expert Arabic linguist filtering candidate flashcard "
+            "sentences. Be deliberately strict — the pool is large, so when in "
+            "doubt, mark BAD. Return one verdict per candidate, keyed by index."
+        ),
+        json_schema=_RERANK_SCHEMA,
+        temperature=0.0,
+        model_override="claude_haiku",
+        task_type="sentence_rerank",
+        cli_only=True,
+    )
+
+    verdicts = result.get("verdicts", []) if isinstance(result, dict) else []
+    if not isinstance(verdicts, list) or not verdicts:
+        # Treat empty/malformed as a soft failure so the caller's except path
+        # falls back to unranked candidates rather than dropping everything.
+        raise LLMError("rerank returned no verdicts")
+
+    good_indices: list[int] = []
+    for v in verdicts:
+        if not isinstance(v, dict):
+            continue
+        idx = v.get("index")
+        if not isinstance(idx, int) or idx < 0 or idx >= len(sentences):
+            continue
+        if str(v.get("verdict", "")).upper() == "GOOD":
+            good_indices.append(idx)
+
+    # Preserve original LLM ordering; dedupe in case Haiku repeats an index.
+    seen: set[int] = set()
+    ordered: list[int] = []
+    for idx in good_indices:
+        if idx in seen:
+            continue
+        seen.add(idx)
+        ordered.append(idx)
+
+    return [sentences[i] for i in ordered[:top_k]]
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/services/material_generator.py
+++ b/backend/app/services/material_generator.py
@@ -123,6 +123,12 @@ def generate_material_for_word(lemma_id: int, needed: int = 2, model_override: s
         lemma_ar = lemma.lemma_ar
         gloss_en = lemma.gloss_en or ""
         target_lemma_id = lemma.lemma_id
+        # Phase 4: snapshot canonical example to anchor the correct sense in
+        # the generation prompt (prevents wrong-sense awkward sentences like
+        # the استَوَى/dust case). Both fields required — partial example is
+        # worse than no example.
+        target_example_ar = (lemma.example_ar or "").strip() or None
+        target_example_en = (lemma.example_en or "").strip() or None
 
         active_lemmas = (
             db.query(Lemma)
@@ -171,7 +177,9 @@ def generate_material_for_word(lemma_id: int, needed: int = 2, model_override: s
     target_bare = strip_diacritics(clean_target)
     all_bare_forms = set(lemma_lookup.keys())
 
-    batch_requested = needed + 2
+    # Phase 4: ask Sonnet for at least 5 candidates so the Haiku reranker has
+    # a real choice; the reranker keeps at most ``max(needed, 2)`` GOOD ones.
+    batch_requested = max(5, needed + 2)
     try:
         results = generate_sentences_batch(
             target_word=clean_target,
@@ -182,6 +190,10 @@ def generate_material_for_word(lemma_id: int, needed: int = 2, model_override: s
             avoid_words=avoid_words,
             max_words=diff_params["max_words"],
             model_override=model_override,
+            target_example_ar=target_example_ar,
+            target_example_en=target_example_en,
+            rerank=True,
+            rerank_top_k=max(needed, 2),
         )
     except AllProvidersFailed:
         logger.warning(f"LLM unavailable for sentence generation (lemma {lemma_id})")
@@ -195,6 +207,7 @@ def generate_material_for_word(lemma_id: int, needed: int = 2, model_override: s
         "event": "batch_returned", "lemma_id": lemma_id, "target": lemma_ar,
         "model": model_override, "requested": batch_requested, "returned": len(results),
         "difficulty": diff_params["difficulty_hint"], "known_sample_size": len(sample),
+        "had_example": bool(target_example_ar and target_example_en),
     })
 
     # Phase 2a: Deterministic validation + mapping (no LLM calls)

--- a/backend/scripts/analyze_word_distribution.py
+++ b/backend/scripts/analyze_word_distribution.py
@@ -217,6 +217,9 @@ def regenerate_worst_offenders(
                 difficulty_hint="beginner",
                 model_override=model,
                 avoid_words=avoid_words,
+                # Diagnostic tool: keep all generated candidates, skip the
+                # Phase 4 Haiku rerank (which would cap to top-2).
+                rerank=False,
             )
         except AllProvidersFailed as e:
             print(f"    LLM error: {e}")

--- a/backend/scripts/benchmark_claude_code.py
+++ b/backend/scripts/benchmark_claude_code.py
@@ -367,13 +367,15 @@ def _generate_batch(
 ) -> list[dict]:
     """Generate a batch of sentences using either API or CLI."""
     if model in API_MODELS:
-        # Use existing generate_sentences_batch
+        # Use existing generate_sentences_batch (skip Phase 4 rerank — this
+        # script benchmarks raw Sonnet quality, not the production pipeline).
         results = generate_sentences_batch(
             target_word=target_word,
             target_translation=target_translation,
             known_words=known_words,
             count=count,
             model_override=API_MODELS[model],
+            rerank=False,
         )
         return [{"arabic": r.arabic, "english": r.english, "transliteration": r.transliteration} for r in results]
 

--- a/backend/tests/test_llm.py
+++ b/backend/tests/test_llm.py
@@ -5,13 +5,18 @@ Tests prompt construction and fallback behavior with mocked litellm.
 
 from unittest.mock import MagicMock, patch
 
+import inspect
+
 import pytest
 
 from app.services.llm import (
     AllProvidersFailed,
+    LLMError,
     SentenceResult,
     generate_completion,
     generate_sentence,
+    generate_sentences_batch,
+    rerank_sentences_by_naturalness,
 )
 
 
@@ -133,3 +138,187 @@ def test_generate_sentence_difficulty_in_prompt(mock_completion):
 
     prompt = mock_completion.call_args.kwargs.get("prompt") or mock_completion.call_args.args[0]
     assert "advanced" in prompt
+
+
+# -------------------------------------------------------------------------
+# Phase 4: prompt enrichment (example_ar / example_en) + candidate ranker
+# -------------------------------------------------------------------------
+
+
+@patch("app.services.llm.generate_completion")
+def test_generate_sentence_includes_example_block_when_populated(mock_completion):
+    """Populated example_ar/example_en produce an EXAMPLE block in the prompt."""
+    mock_completion.return_value = {
+        "arabic": "t", "english": "t", "transliteration": "t",
+    }
+
+    generate_sentence(
+        target_word="اِسْتَوَى",
+        target_translation="to sit upright / settle",
+        known_words=[],
+        target_example_ar="اِسْتَوَى الشَّيْخُ عَلَى كُرْسِيِّهِ",
+        target_example_en="The elder settled onto his chair.",
+    )
+
+    prompt = mock_completion.call_args.kwargs.get("prompt") or mock_completion.call_args.args[0]
+    assert "Example of correct usage" in prompt
+    assert "اِسْتَوَى الشَّيْخُ عَلَى كُرْسِيِّهِ" in prompt
+    assert "The elder settled onto his chair." in prompt
+
+
+@patch("app.services.llm.generate_completion")
+def test_generate_sentence_omits_example_block_when_null(mock_completion):
+    """Missing example_ar → no EXAMPLE block (keeps prompt clean)."""
+    mock_completion.return_value = {
+        "arabic": "t", "english": "t", "transliteration": "t",
+    }
+
+    generate_sentence(
+        target_word="كِتَاب",
+        target_translation="book",
+        known_words=[],
+    )
+
+    prompt = mock_completion.call_args.kwargs.get("prompt") or mock_completion.call_args.args[0]
+    assert "Example of correct usage" not in prompt
+
+
+@patch("app.services.llm.generate_completion")
+def test_generate_sentence_omits_example_block_when_partial(mock_completion):
+    """Only target_example_ar (no English) → block suppressed — both sides needed
+    for sense grounding."""
+    mock_completion.return_value = {
+        "arabic": "t", "english": "t", "transliteration": "t",
+    }
+
+    generate_sentence(
+        target_word="كِتَاب",
+        target_translation="book",
+        known_words=[],
+        target_example_ar="هَذَا كِتَابٌ",
+        target_example_en=None,
+    )
+
+    prompt = mock_completion.call_args.kwargs.get("prompt") or mock_completion.call_args.args[0]
+    assert "Example of correct usage" not in prompt
+
+
+def test_generate_sentences_batch_default_count_is_5():
+    """Phase 4 bump: default count should be 5 (was 3)."""
+    sig = inspect.signature(generate_sentences_batch)
+    assert sig.parameters["count"].default == 5
+
+
+@patch("app.services.llm.generate_completion")
+def test_generate_sentences_batch_includes_example_in_prompt(mock_completion):
+    """Batch prompt includes EXAMPLE block when both example_ar/en are given."""
+    # First call: sentence generation
+    # Second call: rerank (returns empty verdicts → fails, falls back to unranked)
+    mock_completion.side_effect = [
+        {"sentences": [{"arabic": "س", "english": "s", "transliteration": "s"}]},
+        {"verdicts": []},
+    ]
+
+    generate_sentences_batch(
+        target_word="اِسْتَوَى",
+        target_translation="to settle",
+        known_words=[],
+        count=5,
+        target_example_ar="اِسْتَوَى الشَّيْخُ عَلَى كُرْسِيِّهِ",
+        target_example_en="The elder settled onto his chair.",
+    )
+
+    first_call = mock_completion.call_args_list[0]
+    prompt = first_call.kwargs.get("prompt") or first_call.args[0]
+    assert "Example of correct usage" in prompt
+    assert "اِسْتَوَى الشَّيْخُ عَلَى كُرْسِيِّهِ" in prompt
+
+
+@patch("app.services.llm.generate_completion")
+def test_rerank_picks_good_returns_top_k(mock_completion):
+    """5 candidates, 3 GOOD → top_k=2 returns 2 in LLM order, skipping BADs."""
+    mock_completion.return_value = {
+        "verdicts": [
+            {"index": 0, "verdict": "BAD", "category": "WRONG_SENSE", "explanation": "..."},
+            {"index": 1, "verdict": "GOOD", "category": "OK", "explanation": "..."},
+            {"index": 2, "verdict": "BAD", "category": "FORCED_COMBINATION", "explanation": "..."},
+            {"index": 3, "verdict": "GOOD", "category": "OK", "explanation": "..."},
+            {"index": 4, "verdict": "GOOD", "category": "OK", "explanation": "..."},
+        ]
+    }
+
+    candidates = [
+        SentenceResult(arabic=f"s{i}", english=f"e{i}", transliteration="")
+        for i in range(5)
+    ]
+
+    top = rerank_sentences_by_naturalness(
+        candidates, target_word="كِتَاب", target_translation="book", top_k=2,
+    )
+
+    assert len(top) == 2
+    # Preserves Haiku's order — first two GOOD are indices 1 and 3
+    assert top[0].arabic == "s1"
+    assert top[1].arabic == "s3"
+
+
+@patch("app.services.llm.generate_completion")
+def test_rerank_all_bad_returns_empty(mock_completion):
+    """All candidates BAD → returns [] so caller can fall back."""
+    mock_completion.return_value = {
+        "verdicts": [
+            {"index": 0, "verdict": "BAD", "category": "WRONG_SENSE", "explanation": "..."},
+            {"index": 1, "verdict": "BAD", "category": "FORCED_COMBINATION", "explanation": "..."},
+        ]
+    }
+
+    candidates = [
+        SentenceResult(arabic="a", english="e", transliteration=""),
+        SentenceResult(arabic="b", english="f", transliteration=""),
+    ]
+
+    top = rerank_sentences_by_naturalness(
+        candidates, target_word="كِتَاب", target_translation="book", top_k=2,
+    )
+
+    assert top == []
+
+
+@patch("app.services.llm.generate_completion")
+def test_rerank_empty_verdicts_raises(mock_completion):
+    """Empty/malformed verdicts list raises LLMError so caller falls back."""
+    mock_completion.return_value = {"verdicts": []}
+
+    candidates = [SentenceResult(arabic="a", english="e", transliteration="")]
+
+    with pytest.raises(LLMError):
+        rerank_sentences_by_naturalness(
+            candidates, target_word="كِتَاب", target_translation="book",
+        )
+
+
+@patch("app.services.llm.generate_completion")
+def test_batch_falls_back_to_unranked_when_rerank_fails(mock_completion):
+    """When the rerank Haiku call fails, generate_sentences_batch returns the
+    original unranked candidates rather than dropping everything."""
+    # First call: gen → 3 sentences
+    # Second call: rerank → empty verdicts → raises LLMError internally
+    mock_completion.side_effect = [
+        {"sentences": [
+            {"arabic": "s0", "english": "e0", "transliteration": ""},
+            {"arabic": "s1", "english": "e1", "transliteration": ""},
+            {"arabic": "s2", "english": "e2", "transliteration": ""},
+        ]},
+        {"verdicts": []},  # triggers LLMError in rerank
+    ]
+
+    results = generate_sentences_batch(
+        target_word="كِتَاب",
+        target_translation="book",
+        known_words=[],
+        count=3,
+    )
+
+    # Fail-open: caller gets the 3 unranked candidates back.
+    assert len(results) == 3
+    assert results[0].arabic == "s0"

--- a/backend/tests/test_sentence_generator.py
+++ b/backend/tests/test_sentence_generator.py
@@ -250,6 +250,7 @@ def test_batch_generates_multiple_sentences(mock_completion):
         target_translation="book",
         known_words=KNOWN_WORDS,
         count=3,
+        rerank=False,  # legacy behaviour for this test
     )
 
     assert len(results) == 3
@@ -276,6 +277,7 @@ def test_batch_handles_partial_results(mock_completion):
         target_translation="book",
         known_words=KNOWN_WORDS,
         count=3,
+        rerank=False,
     )
 
     assert len(results) == 1
@@ -313,6 +315,7 @@ def test_batch_skips_entries_without_arabic(mock_completion):
         target_word="يَقْرَأ",
         target_translation="reads",
         known_words=KNOWN_WORDS,
+        rerank=False,
     )
 
     assert len(results) == 1
@@ -329,6 +332,7 @@ def test_batch_uses_model_override(mock_completion):
         target_translation="book",
         known_words=KNOWN_WORDS,
         model_override="openai",
+        rerank=False,
     )
 
     call_kwargs = mock_completion.call_args.kwargs


### PR DESCRIPTION
## Summary

Phase 4 of the awkward-sentence prevention plan, addressing the long-tail
problem identified by the 132-sentence hand-grade (~13% awkward, ~24%
borderline; 25/26 worst-offender lemmas had populated `example_ar`/`example_en`
that the prompt never used).

Two complementary changes shipped in one PR:

### 1. Prompt enrichment

`generate_sentence` and `generate_sentences_batch` now accept
`target_example_ar` / `target_example_en`. When **both** are populated,
the prompt grows an `Example of correct usage` block right after the
TARGET WORD line. `material_generator.generate_material_for_word` snapshots
the example fields from the existing Lemma read so the block is free at
generation time. A/B test (n=15) eliminated 2 wrong-sense errors with no
regressions in actual sense correctness.

### 2. Candidate ranker

- `generate_sentences_batch` default `count` bumped from 3 to 5 so the
  reranker has a real choice
- New `rerank_sentences_by_naturalness()` calls Haiku v2 naturalness gate
  in a single CLI call over all candidates, returning the top
  `rerank_top_k` GOOD ones
- `material_generator` now requests 5 candidates and asks for `max(needed, 2)`
  GOOD picks. If reranker returns `[]` (all BAD), the existing fallback path
  handles regeneration.
- **Fail-open** (CLAUDE.md §13): if the Haiku rerank call fails, times out, or
  returns empty verdicts, `generate_sentences_batch` logs the failure and
  returns the unranked candidates. Quality work never regresses availability.

### Tooling preserved

`analyze_word_distribution.py` and `benchmark_claude_code.py` opt out of
rerank to keep their diagnostic semantics.

### Tests

10 new tests in `test_llm.py` covering: example block included/omitted/partial,
default count == 5, rerank top-k selection, all-BAD returns [], empty-verdicts
raises, and the batch fail-open behaviour. Existing batch tests adjusted to
use `rerank=False` (legacy behaviour).