### PR TITLE
chore: import backlog of untracked work + broaden .gitignore

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -120,6 +120,9 @@ Prefer focused sessions. If a task has 4+ distinct parts, suggest breaking into 
 ## 🟡 Lemma Decomposition Audit — Phase 1 + Phase 2 step 1 done, steps 2-8 open
 - [Details](project_lemma_decomposition_audit.md) — Phase 1 (2026-04-24) classified all 2,905 prod lemmas via CAMeL MLE: 144 HIGH-tier compounds (593 reviews), 102 orphans (385 reviews), 1,271 total review impact (4.5× the prior estimate). Phase 2 step 1 (2026-04-24) patched `quran_service.py:732` and `backfill_function_word_lemmas.py` to call `resolve_existing_lemma()` (clitic-aware dedup) — bleed stopped. Reports: `research/decomposition-audit-2026-04-24.md` + `decomposition-classification-2026-04-24.json`. Steps 2-8 (backup → backfill 102 orphan canonicals → spot-check + migrate 144 HIGH-tier → manual MEDIUM/LOW → re-enrich Hindawi corpus → verify) still open.
 
+## gh CLI / Go binaries TLS error in sandbox (2026-04-24)
+- [Details](feedback_gh_sandbox_tls.md) — `OSStatus -26276` from gh/terraform/tofu = Claude Code sandbox blocking `com.apple.trustd` Mach IPC. Retry the same command with `dangerouslyDisableSandbox: true` immediately. Don't waste time on auth, GODEBUG, or `brew upgrade gh`.
+
 ## Architecture Notes (not in CLAUDE.md)
 - FSRS stability floor: "known" with stability < 1.0 -> "lapsed"
 - Interaction logger: skipped when TESTING=1 (set in conftest.py)

--- a/.claude/memory/feedback_gh_sandbox_tls.md
+++ b/.claude/memory/feedback_gh_sandbox_tls.md
@@ -1,0 +1,11 @@
+---
+name: gh CLI (and other Go binaries) TLS fails in Claude Code sandbox
+description: When gh, terraform, or any Go binary returns "tls: failed to verify certificate: x509: OSStatus -26276" on macOS, it's a Claude Code sandbox issue blocking com.apple.trustd Mach IPC — not a real cert problem. Immediately retry the same command with dangerouslyDisableSandbox: true. Don't waste time on auth, GODEBUG flags, or `brew upgrade gh`.
+type: feedback
+originSessionId: 03a9a728-7f46-47ff-97f2-59ed15db373e
+---
+When a Go binary on macOS (`gh`, `terraform`, `tofu`, etc.) errors with `tls: failed to verify certificate: x509: OSStatus -26276`, retry the exact same command with `dangerouslyDisableSandbox: true`.
+
+**Why:** Go's `crypto/x509` on macOS verifies TLS certs via `com.apple.trustd` Mach IPC. The Claude Code sandbox blocks this IPC channel, so trustd is unreachable and every TLS handshake fails with `errSecCertificateExpired` (-26276). It is NOT a real cert expiry, NOT an auth problem, NOT a gh-version issue. `curl` works because it uses its own bundled CA list, not the system Security framework — that's the giveaway. Wasted ~30 minutes on 2026-04-24 trying `gh auth login`, `brew upgrade gh` to 2.91.0, `GODEBUG=x509usefallbackroots=1`, and macOS keychain token extraction before web-searching the error and finding it's a known Claude Code sandbox issue (cli/cli#8199, anthropics/claude-code#23416/#26466/#29533/#34876/#48058).
+
+**How to apply:** First sight of `OSStatus -26276` in a Go binary's TLS error → retry with `dangerouslyDisableSandbox: true`. Don't ask the user, don't try GODEBUG flags, don't try to extract tokens from the macOS keychain (that path is also flaky in the sandbox). One sandbox-bypass invocation per call — same care as any other sandbox-bypass per the system rules.

--- a/.claude/memory/feedback_pr_self_review_merge.md
+++ b/.claude/memory/feedback_pr_self_review_merge.md
@@ -1,0 +1,16 @@
+---
+name: PR self-review and merge without user approval
+description: User never reviews PRs — Claude must self-review thoroughly and merge without pausing to ask
+type: feedback
+originSessionId: 21cab0f0-2b3d-40c3-8d16-69b5be5e565f
+---
+Claude owns the entire PR lifecycle for non-trivial changes: create branch, commit, open PR, self-review, merge. Do NOT pause after opening a PR to ask whether to merge; do NOT ask for approval after self-review passes.
+
+**Why:** User explicitly told me this (2026-04-17) after I paused and asked for merge approval on PR #36 (write-lock refactor). User's exact phrasing: "I never want to review, but you should always self-review." Pausing to ask is friction the user doesn't want. The self-review IS the gate.
+
+**How to apply:**
+- For Alif specifically, the rule is now in CLAUDE.md §7 (non-trivial branch workflow).
+- For any codebase: when the user says to do work, and the work involves opening a PR as a self-review mechanism, merge immediately after self-review passes. Only pause if self-review surfaces a real issue that needs user input.
+- Self-review means reading the actual diff (`gh pr diff <N>`), not just stats — trace through logic equivalence in refactors, check for silent deletions in append-only files, verify no schema drift.
+- Deploy is a separate decision. Merging does NOT imply deploying. Wait for explicit "deploy" from user before running the deploy command.
+- If in doubt (the change genuinely has risk the user should weigh in on), ask once, and remember the answer — but default to merge-after-self-review.

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ venv/
 
 # Database
 *.db
+*.db-shm
+*.db-wal
+*.db.pre-*
 
 # Environment
 .env
@@ -35,8 +38,33 @@ Thumbs.db
 # Large data files
 backend/data/MSA_freq_lists.tsv
 
+# Resumable-script progress files
+backend/data/decomposition_backfill_progress.json
+
 # Test artifacts
 backend/pytest-of-*/
 
 # Alembic
 alembic/versions/__pycache__/
+
+# Local virtualenvs (any name)
+.review-venv/
+
+# Tiktoken cache
+data-gym-cache/
+
+# Local uv lock (project does not use uv)
+backend/uv.lock
+
+# Generated runtime data
+backend/data/podcasts/
+backend/data/story-gen-tmp/
+backend/data/textbook-uploads/
+backend/data/corpora/
+backend/data/benchmarks/benchmark_*.json
+
+# Local experiment outputs (results.tsv is the tracked ground truth)
+backend/experiments/results/*.json
+
+# Stray top-level data dir (canonical path is backend/data/)
+/data/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,3 +231,10 @@ See `.claude/skills/server-ops.md` for full details. Summary of hard-won rules:
 7. **`limbic` install on server** — `pyproject.toml` specifies `limbic @ git+https://...` which tries GitHub clone. On server, install from local: `.venv/bin/pip install -e /opt/limbic` first, then `pip install -e . --no-deps` for alif, then remaining deps separately. CPU-only PyTorch: `pip install torch --index-url https://download.pytorch.org/whl/cpu`.
 8. **Long-running remote scripts: use nohup** — SSH drops after ~60s idle, causing exit code 255 with no output. Use `nohup ... > /tmp/script.log 2>&1 &` then check the log file later. See `server-ops.md` for pattern.
 9. **Backup DB before manual data changes** — `ssh alif "cp /opt/alif/backend/data/alif.db /opt/alif-backups/alif_pre_fix_$(date +%Y%m%d_%H%M%S).db"` then log the action via `scripts/log_activity.py`.
+
+## Periodic Maintenance Checks
+
+Run these every month or two when working on alif. Append a date + result line to each checklist entry below after running.
+
+- **Check forks for upstream-worthy work** — `gh api repos/houshuang/alif/forks --jq '.[] | {full_name, pushed_at, created_at}'` then for each fork: `gh api repos/houshuang/alif/compare/main...OWNER:main --jq '{ahead_by, behind_by}'`. Only forks with `ahead_by > 0` are worth inspecting. A fork where `pushed_at < created_at` has zero new commits. Note: `gh` in the Claude Code sandbox hits TLS error `OSStatus -26276`; use sandbox-disabled bash.
+  - 2026-04-24 — 1 fork (`eurunuela/alif`), 0 ahead, 119 behind. Nothing to merge.

--- a/backend/app/services/soniox_service.py
+++ b/backend/app/services/soniox_service.py
@@ -1,0 +1,135 @@
+"""Soniox Speech-to-Text API wrapper for async file transcription.
+
+Uses the REST API directly (not the archived Python SDK).
+Supports Arabic + English code-switching with speaker diarization.
+"""
+
+import logging
+import time
+from pathlib import Path
+
+import requests
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+SONIOX_BASE_URL = "https://api.soniox.com/v1"
+DEFAULT_MODEL = "stt-async-v4"
+POLL_INTERVAL = 3.0  # seconds
+POLL_TIMEOUT = 600.0  # 10 minutes max
+
+
+class SonioxError(Exception):
+    pass
+
+
+class SonioxService:
+    def __init__(self, api_key: str | None = None):
+        self.api_key = api_key or settings.soniox_api_key
+        if not self.api_key:
+            raise SonioxError("SONIOX_API_KEY not configured")
+        self.session = requests.Session()
+        self.session.headers["Authorization"] = f"Bearer {self.api_key}"
+
+    def upload_file(self, audio_path: Path) -> str:
+        """Upload an audio file, return file_id."""
+        logger.info(f"Uploading {audio_path.name} ({audio_path.stat().st_size / 1024 / 1024:.1f} MB)")
+        with open(audio_path, "rb") as f:
+            resp = self.session.post(
+                f"{SONIOX_BASE_URL}/files",
+                files={"file": (audio_path.name, f)},
+            )
+        resp.raise_for_status()
+        file_id = resp.json()["id"]
+        logger.info(f"Uploaded → file_id={file_id}")
+        return file_id
+
+    def create_transcription(
+        self,
+        file_id: str,
+        language_hints: list[str] | None = None,
+        enable_diarization: bool = True,
+        enable_language_id: bool = True,
+    ) -> str:
+        """Create an async transcription job, return transcription_id."""
+        payload = {
+            "model": DEFAULT_MODEL,
+            "file_id": file_id,
+            "enable_speaker_diarization": enable_diarization,
+            "enable_language_identification": enable_language_id,
+        }
+        if language_hints:
+            payload["language_hints"] = language_hints
+        resp = self.session.post(f"{SONIOX_BASE_URL}/transcriptions", json=payload)
+        resp.raise_for_status()
+        txn_id = resp.json()["id"]
+        logger.info(f"Created transcription {txn_id}")
+        return txn_id
+
+    def wait_for_completion(self, transcription_id: str) -> dict:
+        """Poll until transcription completes or errors. Returns status dict."""
+        start = time.time()
+        while True:
+            resp = self.session.get(f"{SONIOX_BASE_URL}/transcriptions/{transcription_id}")
+            resp.raise_for_status()
+            data = resp.json()
+            status = data["status"]
+
+            if status == "completed":
+                duration_ms = data.get("audio_duration_ms", 0)
+                logger.info(f"Transcription {transcription_id} completed ({duration_ms / 1000:.0f}s audio)")
+                return data
+
+            if status == "error":
+                raise SonioxError(f"Transcription failed: {data.get('error_message', 'unknown')}")
+
+            elapsed = time.time() - start
+            if elapsed > POLL_TIMEOUT:
+                raise SonioxError(f"Transcription {transcription_id} timed out after {POLL_TIMEOUT}s")
+
+            logger.debug(f"Status: {status}, elapsed {elapsed:.0f}s, polling again in {POLL_INTERVAL}s")
+            time.sleep(POLL_INTERVAL)
+
+    def get_transcript(self, transcription_id: str) -> dict:
+        """Get full transcript with tokens (timestamps, speaker, language)."""
+        resp = self.session.get(f"{SONIOX_BASE_URL}/transcriptions/{transcription_id}/transcript")
+        resp.raise_for_status()
+        return resp.json()
+
+    def delete_file(self, file_id: str) -> None:
+        """Clean up uploaded file."""
+        resp = self.session.delete(f"{SONIOX_BASE_URL}/files/{file_id}")
+        if resp.status_code != 204:
+            logger.warning(f"Failed to delete file {file_id}: {resp.status_code}")
+
+    def delete_transcription(self, transcription_id: str) -> None:
+        """Clean up transcription."""
+        resp = self.session.delete(f"{SONIOX_BASE_URL}/transcriptions/{transcription_id}")
+        if resp.status_code != 204:
+            logger.warning(f"Failed to delete transcription {transcription_id}: {resp.status_code}")
+
+    def transcribe_file(
+        self,
+        audio_path: Path,
+        language_hints: list[str] | None = None,
+    ) -> dict:
+        """Convenience: upload → transcribe → wait → get transcript → cleanup.
+
+        Returns the full transcript dict with tokens.
+        """
+        if language_hints is None:
+            language_hints = ["ar", "en"]
+
+        file_id = self.upload_file(audio_path)
+        try:
+            txn_id = self.create_transcription(
+                file_id=file_id,
+                language_hints=language_hints,
+            )
+            self.wait_for_completion(txn_id)
+            transcript = self.get_transcript(txn_id)
+            self.delete_transcription(txn_id)
+            return transcript
+        finally:
+            self.delete_file(file_id)

--- a/backend/app/simulation/db_setup.py
+++ b/backend/app/simulation/db_setup.py
@@ -1,0 +1,73 @@
+"""Database setup for simulation — copy production DB to temp file."""
+
+import atexit
+import os
+import shutil
+import tempfile
+from pathlib import Path
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+
+def find_latest_backup(backup_dir: str | None = None) -> Path:
+    """Find the most recent alif_*.db file in the backup directory."""
+    backup_dir = Path(backup_dir or os.path.expanduser("~/alif-backups"))
+    backups = sorted(backup_dir.glob("alif_*.db"), key=lambda p: p.stat().st_mtime)
+    if not backups:
+        raise FileNotFoundError(f"No backups found in {backup_dir}")
+    return backups[-1]
+
+
+def create_simulation_db(source_path: str | Path) -> tuple:
+    """Copy source DB to temp file, return (engine, SessionFactory, tmp_path).
+
+    The temp file is cleaned up on process exit.
+    """
+    source_path = Path(source_path)
+    if not source_path.exists():
+        raise FileNotFoundError(f"Source DB not found: {source_path}")
+
+    tmp_fd, tmp_path = tempfile.mkstemp(suffix=".db", prefix="alif_sim_")
+    os.close(tmp_fd)
+    shutil.copy2(source_path, tmp_path)
+
+    atexit.register(lambda: os.unlink(tmp_path) if os.path.exists(tmp_path) else None)
+
+    engine = create_engine(
+        f"sqlite:///{tmp_path}",
+        connect_args={"check_same_thread": False},
+        echo=False,
+    )
+
+    # Ensure all model columns exist (backup may predate schema changes)
+    _apply_missing_columns(engine)
+
+    SessionFactory = sessionmaker(bind=engine)
+    return engine, SessionFactory, tmp_path
+
+
+def _apply_missing_columns(engine):
+    """Add any columns from the current model that are missing in the DB.
+
+    This handles running simulations against older backups that predate
+    recent migrations.
+    """
+    from sqlalchemy import text, inspect
+    insp = inspect(engine)
+    with engine.connect() as conn:
+        for table_name, expected_cols in [
+            ("learner_settings", {
+                "tashkeel_mode": "VARCHAR(10) DEFAULT 'always'",
+                "tashkeel_stability_threshold": "FLOAT DEFAULT 30.0",
+            }),
+        ]:
+            if table_name not in insp.get_table_names():
+                continue
+            existing = {col["name"] for col in insp.get_columns(table_name)}
+            for col_name, col_def in expected_cols.items():
+                if col_name not in existing:
+                    conn.execute(text(
+                        f"ALTER TABLE {table_name} ADD COLUMN {col_name} {col_def}"
+                    ))
+        conn.commit()

--- a/backend/app/simulation/reporter.py
+++ b/backend/app/simulation/reporter.py
@@ -1,0 +1,137 @@
+"""Output formatting for simulation results."""
+
+import csv
+from dataclasses import asdict
+
+from app.simulation.runner import DaySnapshot
+from app.simulation.student import StudentProfile
+
+
+def print_console_report(snapshots: list[DaySnapshot], profile_name: str = "") -> None:
+    """Print an ASCII table of day-by-day simulation results."""
+    print()
+    print("=" * 90)
+    title = "SIMULATION RESULTS"
+    if profile_name:
+        title += f" — {profile_name}"
+    print(title)
+    print("=" * 90)
+
+    # Summary
+    active_days = [s for s in snapshots if not s.skipped]
+    total_reviews = sum(s.reviews_submitted for s in snapshots)
+    total_sessions = sum(s.num_sessions for s in snapshots)
+    total_graduated = sum(s.graduated_today for s in snapshots)
+    total_leeches = sum(s.leeches_detected for s in snapshots)
+    total_introduced = sum(s.auto_introduced for s in snapshots)
+
+    print(f"\nDuration: {len(snapshots)} days ({len(active_days)} active, "
+          f"{len(snapshots) - len(active_days)} skipped)")
+    print(f"Total sessions: {total_sessions}")
+    print(f"Total reviews: {total_reviews}")
+    print(f"Total auto-introduced: {total_introduced}")
+    print(f"Total graduated (acq->FSRS): {total_graduated}")
+    print(f"Total leeches detected: {total_leeches}")
+    if active_days:
+        print(f"Avg sessions/active day: {total_sessions / len(active_days):.1f}")
+        print(f"Avg reviews/active day: {total_reviews / len(active_days):.1f}")
+
+    # Final state
+    final = snapshots[-1]
+    print(f"\nFinal word states:")
+    for label, count in [
+        ("Encountered", final.encountered),
+        ("Acquiring", final.acquiring),
+        ("Learning", final.learning),
+        ("Known", final.known),
+        ("Lapsed", final.lapsed),
+        ("Suspended", final.suspended),
+    ]:
+        if count > 0:
+            bar = "#" * min(count, 50)
+            print(f"  {label:12s} {count:4d} {bar}")
+
+    if final.acquiring > 0:
+        print(f"\n  Acquisition boxes: B1={final.box_1} B2={final.box_2} B3={final.box_3}")
+
+    # Day-by-day table
+    print()
+    print("-" * 90)
+    header = f"{'Day':>4} {'Date':>12} {'Ses':>3} {'Due':>4} {'Rev':>4} {'New':>3} {'Und':>3} {'Par':>3} {'Nid':>3} {'Acq':>4} {'Lrn':>4} {'Knw':>4} {'Lap':>4}"
+    print(header)
+    print("-" * 95)
+
+    for s in snapshots:
+        if s.skipped:
+            print(f"{s.day:4d} {s.date:>12}  SKIP"
+                  f"{'':>30}{s.acquiring:4d} {s.learning:4d} {s.known:4d} {s.lapsed:4d}")
+        else:
+            print(
+                f"{s.day:4d} {s.date:>12} {s.num_sessions:3d} {s.total_due:4d} {s.reviews_submitted:4d} "
+                f"{s.auto_introduced:3d} {s.understood:3d} {s.partial:3d} {s.no_idea:3d} "
+                f"{s.acquiring:4d} {s.learning:4d} {s.known:4d} {s.lapsed:4d}"
+            )
+
+    # Issue detection
+    issues = detect_issues(snapshots)
+    if issues:
+        print()
+        print("-" * 90)
+        print("DETECTED ISSUES")
+        print("-" * 90)
+        for issue in issues:
+            print(f"  * {issue}")
+    else:
+        print("\n  No issues detected.")
+
+    print()
+
+
+def detect_issues(snapshots: list[DaySnapshot]) -> list[str]:
+    """Flag potential algorithm problems."""
+    issues = []
+
+    for s in snapshots:
+        if s.total_due > 60 and not s.skipped:
+            issues.append(f"Day {s.day}: Review avalanche — {s.total_due} words due")
+
+    for s in snapshots:
+        if s.acquiring > 40:
+            issues.append(
+                f"Day {s.day}: Acquisition bottleneck — {s.acquiring} words stuck in acquisition"
+            )
+            break
+
+    total_leeches = sum(s.leeches_detected for s in snapshots)
+    if total_leeches > 10:
+        issues.append(f"High leech rate: {total_leeches} words became leeches")
+
+    # Check for stagnation: no graduation for 10+ active days
+    active_streak_no_grad = 0
+    for s in snapshots:
+        if s.skipped:
+            continue
+        if s.graduated_today == 0:
+            active_streak_no_grad += 1
+        else:
+            active_streak_no_grad = 0
+        if active_streak_no_grad >= 10:
+            issues.append(
+                f"Day {s.day}: Stagnation — no graduations in 10+ active days"
+            )
+            break
+
+    return issues
+
+
+def write_csv_report(snapshots: list[DaySnapshot], path: str) -> None:
+    """Write all snapshot fields to a CSV file."""
+    if not snapshots:
+        return
+    fieldnames = list(asdict(snapshots[0]).keys())
+    with open(path, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        for snap in snapshots:
+            writer.writerow(asdict(snap))
+    print(f"CSV written to {path}")

--- a/backend/app/simulation/runner.py
+++ b/backend/app/simulation/runner.py
@@ -1,0 +1,252 @@
+"""Core simulation loop — drives real services over simulated time.
+
+Models realistic multi-session-per-day usage patterns:
+- Multiple short sessions spread throughout the day (matching real user data)
+- Time gaps between sessions enable same-day acquisition box progression (4h interval)
+- Each session is a fresh build_session() + submit_sentence_review() cycle
+"""
+
+import logging
+import os
+import random
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+from freezegun import freeze_time
+from sqlalchemy.orm import Session
+
+from app.models import UserLemmaKnowledge
+from app.simulation.student import StudentProfile
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class DaySnapshot:
+    day: int
+    date: str
+    skipped: bool = False
+    # Word state counts
+    encountered: int = 0
+    acquiring: int = 0
+    learning: int = 0
+    known: int = 0
+    lapsed: int = 0
+    suspended: int = 0
+    # Acquisition box breakdown
+    box_1: int = 0
+    box_2: int = 0
+    box_3: int = 0
+    graduated_today: int = 0
+    # Session metrics (aggregated across all sessions in the day)
+    num_sessions: int = 0
+    session_limit: int = 0  # total sentence slots across all sessions
+    items_received: int = 0
+    reviews_submitted: int = 0
+    auto_introduced: int = 0
+    # Comprehension distribution
+    understood: int = 0
+    partial: int = 0
+    no_idea: int = 0
+    # Review load
+    total_due: int = 0
+    covered_due: int = 0
+    # Events
+    leeches_detected: int = 0
+    leeches_reintroduced: int = 0
+    # Cohort
+    cohort_size: int = 0
+
+
+def _fill_state_counts(db: Session, snap: DaySnapshot) -> None:
+    """Fill word state counts on a snapshot from current DB state."""
+    all_ulk = db.query(UserLemmaKnowledge).all()
+    for ulk in all_ulk:
+        state = ulk.knowledge_state
+        if state == "encountered":
+            snap.encountered += 1
+        elif state == "acquiring":
+            snap.acquiring += 1
+        elif state == "learning":
+            snap.learning += 1
+        elif state == "known":
+            snap.known += 1
+        elif state == "lapsed":
+            snap.lapsed += 1
+        elif state == "suspended":
+            snap.suspended += 1
+
+    acquiring = [u for u in all_ulk if u.knowledge_state == "acquiring"]
+    for u in acquiring:
+        box = u.acquisition_box or 1
+        if box == 1:
+            snap.box_1 += 1
+        elif box == 2:
+            snap.box_2 += 1
+        elif box >= 3:
+            snap.box_3 += 1
+
+
+def _count_state(db: Session, state: str) -> int:
+    return (
+        db.query(UserLemmaKnowledge)
+        .filter(UserLemmaKnowledge.knowledge_state == state)
+        .count()
+    )
+
+
+def _session_times(num_sessions: int, base_morning: datetime) -> list[datetime]:
+    """Generate realistic session start times spread throughout the day.
+
+    Real user pattern: sessions at ~7am, 10am, 1pm, 3pm, 6pm etc.
+    We spread sessions evenly across a 7am-9pm window (14 hours).
+    """
+    if num_sessions == 1:
+        return [base_morning]
+
+    start_hour = 7
+    end_hour = 21
+    window_minutes = (end_hour - start_hour) * 60
+    gap = window_minutes // (num_sessions - 1) if num_sessions > 1 else 0
+    # Add some jitter
+    times = []
+    for i in range(num_sessions):
+        offset_minutes = i * gap + random.randint(-15, 15)
+        offset_minutes = max(0, min(offset_minutes, window_minutes))
+        t = base_morning.replace(hour=start_hour, minute=0, second=0) + timedelta(minutes=offset_minutes)
+        times.append(t)
+    return sorted(times)
+
+
+def run_simulation(
+    db: Session,
+    days: int,
+    profile: StudentProfile,
+    start_date: datetime | None = None,
+    seed: int = 42,
+) -> list[DaySnapshot]:
+    """Run a multi-day simulation using real services against the given DB session.
+
+    Models multiple short sessions per day with realistic time gaps.
+    All LLM-dependent code paths are mocked out. Time is controlled via freezegun.
+    The DB session is modified in-place (use a copy of the production DB).
+    """
+    os.environ["TESTING"] = "1"
+    random.seed(seed)
+
+    # Suppress noisy logging from mocked LLM calls
+    logging.getLogger("app.services.sentence_selector").setLevel(logging.ERROR)
+    logging.getLogger("app.services.sentence_generator").setLevel(logging.ERROR)
+    logging.getLogger("app.services.material_generator").setLevel(logging.ERROR)
+
+    if start_date is None:
+        start_date = datetime(2026, 3, 1, tzinfo=timezone.utc)
+
+    snapshots: list[DaySnapshot] = []
+
+    for day in range(1, days + 1):
+        day_start = start_date + timedelta(days=day - 1)
+        snap = DaySnapshot(day=day, date=day_start.strftime("%Y-%m-%d"))
+
+        if not profile.should_study_today(day_start.weekday(), day):
+            snap.skipped = True
+            _fill_state_counts(db, snap)
+            snapshots.append(snap)
+            continue
+
+        pre_learning = _count_state(db, "learning")
+        pre_suspended = _count_state(db, "suspended")
+        pre_acquiring = _count_state(db, "acquiring")
+
+        num_sessions = profile.sessions_today()
+        snap.num_sessions = num_sessions
+        session_times = _session_times(num_sessions, day_start)
+
+        from app.services.sentence_generator import GenerationError
+
+        for session_idx, session_time in enumerate(session_times):
+            session_limit = profile.session_size()
+            snap.session_limit += session_limit
+
+            with (
+                freeze_time(session_time),
+                patch(
+                    "app.services.material_generator.generate_material_for_word",
+                    return_value=None,
+                ),
+                patch(
+                    "app.services.sentence_generator.generate_validated_sentence",
+                    side_effect=GenerationError("Simulation mode — no LLM"),
+                ),
+            ):
+                from app.services.leech_service import check_leech_reintroductions
+                from app.services.sentence_selector import build_session
+
+                # Only check leech reintroductions on first session of the day
+                if session_idx == 0:
+                    reintro = check_leech_reintroductions(db)
+                    snap.leeches_reintroduced = len(reintro)
+
+                session = build_session(
+                    db, limit=session_limit, mode="reading", log_events=False
+                )
+
+            # Track due/covered from the last session of the day (most representative)
+            snap.total_due = session["total_due_words"]
+            snap.covered_due = session["covered_due_words"]
+            snap.items_received += len(session["items"])
+
+            # Review each item with advancing time within this session
+            for i, item in enumerate(session["items"]):
+                review_time = session_time + timedelta(minutes=1 + i * 1.5)
+
+                words = item.get("words", [])
+                comprehension = profile.decide_comprehension(words)
+                missed, confused = profile.decide_missed_words(words, comprehension)
+
+                if comprehension == "understood":
+                    snap.understood += 1
+                elif comprehension == "partial":
+                    snap.partial += 1
+                else:
+                    snap.no_idea += 1
+
+                with freeze_time(review_time):
+                    from app.services.sentence_review_service import (
+                        submit_sentence_review,
+                    )
+
+                    submit_sentence_review(
+                        db,
+                        sentence_id=item.get("sentence_id"),
+                        primary_lemma_id=item["primary_lemma_id"],
+                        comprehension_signal=comprehension,
+                        missed_lemma_ids=missed,
+                        confused_lemma_ids=confused,
+                        session_id=session["session_id"],
+                        review_mode="reading",
+                    )
+                    snap.reviews_submitted += 1
+
+        # End-of-day snapshot
+        _fill_state_counts(db, snap)
+        post_learning = _count_state(db, "learning")
+        snap.graduated_today = max(0, post_learning - pre_learning)
+        snap.leeches_detected = max(0, _count_state(db, "suspended") - pre_suspended)
+        post_acquiring = _count_state(db, "acquiring")
+        snap.auto_introduced = max(0, post_acquiring - pre_acquiring + snap.graduated_today)
+
+        from app.services.cohort_service import get_focus_cohort
+
+        snap.cohort_size = len(get_focus_cohort(db))
+
+        snapshots.append(snap)
+
+        if day % 10 == 0 or day == days:
+            logger.info(
+                f"Day {day}: {snap.reviews_submitted} reviews across {snap.num_sessions} sessions, "
+                f"{snap.acquiring} acquiring, {snap.known} known"
+            )
+
+    return snapshots

--- a/backend/app/simulation/student.py
+++ b/backend/app/simulation/student.py
@@ -1,0 +1,182 @@
+"""Student behavior profiles for simulation.
+
+Calibrated against real usage data (Feb 2026):
+- Real user does 6-18 short sessions/day (avg 4.2 sentences each)
+- Almost zero "no_idea" ratings (<1%)
+- Comprehension: ~61% understood, ~39% partial on new algorithm
+- Studies every day, even lightly on some days
+"""
+
+import random
+from dataclasses import dataclass
+
+
+@dataclass
+class StudentProfile:
+    name: str
+    base_comprehension: float  # baseline word understanding probability
+    miss_probability: float  # chance of marking missed when struggling
+    session_size_range: tuple[int, int]  # (min, max) sentences per session
+    sessions_per_day_range: tuple[int, int]  # (min, max) sessions on study days
+    study_days_per_week: float  # expected study days out of 7
+    no_idea_threshold: float  # ratio below which sentence = "no_idea" (lower = rarer)
+
+    def should_study_today(self, weekday: int, day_number: int) -> bool:
+        """Decide whether the student studies on this day."""
+        prob = self.study_days_per_week / 7.0
+        return random.random() < prob
+
+    def sessions_today(self) -> int:
+        """How many sessions the student does on a study day."""
+        return random.randint(*self.sessions_per_day_range)
+
+    def session_size(self) -> int:
+        """Pick a random session size within the profile range."""
+        return random.randint(*self.session_size_range)
+
+    def word_understood_probability(self, word: dict) -> float:
+        """Probability this word is understood, based on its state and stability."""
+        state = word.get("knowledge_state", "new")
+        stability = word.get("stability") or 0.0
+
+        if word.get("is_function_word"):
+            return 0.95
+
+        if state == "known" and stability > 10.0:
+            return 0.95
+        elif state == "known":
+            return 0.85
+        elif state == "learning":
+            return 0.70 + (self.base_comprehension - 0.5) * 0.3
+        elif state == "lapsed":
+            return 0.55
+        elif state == "acquiring":
+            return self.base_comprehension * 0.8
+        elif state == "encountered":
+            return 0.40
+        else:
+            return 0.25
+
+    def decide_comprehension(self, words: list[dict]) -> str:
+        """Decide sentence-level comprehension from per-word probabilities."""
+        content_words = [
+            w for w in words
+            if not w.get("is_function_word") and w.get("lemma_id")
+        ]
+        if not content_words:
+            return "understood"
+
+        understood_flags = [
+            random.random() < self.word_understood_probability(w)
+            for w in content_words
+        ]
+        ratio = sum(understood_flags) / len(understood_flags)
+
+        if ratio >= 0.9:
+            return "understood"
+        elif ratio >= self.no_idea_threshold:
+            return "partial"
+        else:
+            return "no_idea"
+
+    def decide_missed_words(
+        self, words: list[dict], comprehension: str
+    ) -> tuple[list[int], list[int]]:
+        """Pick which words are missed/confused for a 'partial' sentence.
+
+        Returns (missed_lemma_ids, confused_lemma_ids).
+        """
+        if comprehension != "partial":
+            return [], []
+
+        missed = []
+        confused = []
+        for w in words:
+            if w.get("is_function_word") or not w.get("lemma_id"):
+                continue
+            p = self.word_understood_probability(w)
+            if random.random() >= p:
+                if random.random() < self.miss_probability:
+                    missed.append(w["lemma_id"])
+                else:
+                    confused.append(w["lemma_id"])
+        return missed, confused
+
+
+# Profiles calibrated against real usage patterns.
+# Key insight: real user does many short sessions throughout the day,
+# enabling same-day box progression (4h acquisition interval).
+
+REALISTIC = StudentProfile(
+    name="realistic",
+    base_comprehension=0.75,
+    miss_probability=0.25,
+    session_size_range=(3, 8),
+    sessions_per_day_range=(4, 8),
+    study_days_per_week=6.5,
+    no_idea_threshold=0.2,  # very rare no_idea
+)
+
+BEGINNER = StudentProfile(
+    name="beginner",
+    base_comprehension=0.55,
+    miss_probability=0.40,
+    session_size_range=(3, 6),
+    sessions_per_day_range=(2, 4),
+    study_days_per_week=5.0,
+    no_idea_threshold=0.3,  # rare no_idea
+)
+
+STRONG = StudentProfile(
+    name="strong",
+    base_comprehension=0.85,
+    miss_probability=0.10,
+    session_size_range=(4, 10),
+    sessions_per_day_range=(5, 10),
+    study_days_per_week=6.5,
+    no_idea_threshold=0.15,  # very rare no_idea
+)
+
+CASUAL = StudentProfile(
+    name="casual",
+    base_comprehension=0.70,
+    miss_probability=0.25,
+    session_size_range=(3, 5),
+    sessions_per_day_range=(1, 3),
+    study_days_per_week=3.5,
+    no_idea_threshold=0.25,
+)
+
+INTENSIVE = StudentProfile(
+    name="intensive",
+    base_comprehension=0.75,
+    miss_probability=0.20,
+    session_size_range=(5, 12),
+    sessions_per_day_range=(6, 12),
+    study_days_per_week=7.0,
+    no_idea_threshold=0.2,
+)
+
+# Calibrated from production data analysis (2026-02-20):
+# - 13 active days, 14.2 sessions/day avg, 6.8 sentences/session median 5
+# - 89.8% overall accuracy, 53.6% understood, 46.1% partial, 0.3% no_idea
+# - Acquisition accuracy: 83%, FSRS accuracy: 93.3%
+# - Retention improving: W06=78%, W07=90%, W08=97.5%
+CALIBRATED = StudentProfile(
+    name="calibrated",
+    base_comprehension=0.80,
+    miss_probability=0.20,
+    session_size_range=(3, 10),
+    sessions_per_day_range=(8, 18),
+    study_days_per_week=7.0,
+    no_idea_threshold=0.15,
+)
+
+PROFILES: dict[str, StudentProfile] = {
+    "realistic": REALISTIC,
+    "beginner": BEGINNER,
+    "strong": STRONG,
+    "casual": CASUAL,
+    "intensive": INTENSIVE,
+    "calibrated": CALIBRATED,
+}

--- a/backend/scripts/audit_sentences_claude.py
+++ b/backend/scripts/audit_sentences_claude.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+"""Batch sentence quality audit using Claude Code with vocabulary context.
+
+Claude reads all active sentences and the learner's vocabulary, reviews each
+sentence for grammar, translation accuracy, and vocabulary compliance, and
+produces a structured report with retire/fix/ok recommendations.
+
+Usage:
+    # Dry-run audit (default)
+    python3 scripts/audit_sentences_claude.py --db data/alif.db
+
+    # Audit and apply fixes
+    python3 scripts/audit_sentences_claude.py --db data/alif.db --apply
+
+    # Limit batch size
+    python3 scripts/audit_sentences_claude.py --db data/alif.db --batch-size 20
+
+    # Use a backup DB
+    python3 scripts/audit_sentences_claude.py --db ~/alif-backups/latest.db --verbose
+"""
+
+import argparse
+import json
+import os
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from app.services.claude_code import (
+    dump_vocabulary_for_claude,
+    generate_with_tools,
+    is_available,
+)
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+WORK_DIR = "/tmp/claude/alif-audit"
+VALIDATOR_SCRIPT = str(Path(__file__).resolve().parent / "validate_sentence_cli.py")
+DEFAULT_BATCH_SIZE = 25
+
+AUDIT_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "reviews": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "sentence_id": {"type": "integer"},
+                    "verdict": {
+                        "type": "string",
+                        "enum": ["ok", "fix", "retire"],
+                    },
+                    "issues": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                    },
+                    "fixed_arabic": {"type": "string", "description": "Corrected Arabic (only if verdict=fix)"},
+                    "fixed_english": {"type": "string", "description": "Corrected English (only if verdict=fix)"},
+                    "fixed_transliteration": {"type": "string", "description": "Corrected transliteration (only if verdict=fix)"},
+                },
+                "required": ["sentence_id", "verdict"],
+            },
+        },
+    },
+    "required": ["reviews"],
+}
+
+SYSTEM_PROMPT = """\
+You are an Arabic language quality auditor reviewing generated sentences for a \
+learner's spaced repetition system. Your job is to check each sentence for:
+
+1. **Grammar correctness** — proper Arabic grammar (i'rab, agreement, word order)
+2. **Translation accuracy** — English translation matches the Arabic meaning
+3. **Vocabulary compliance** — all content words should be in the learner's vocabulary
+4. **Naturalness** — sentence sounds like something a native speaker would say
+
+You have access to:
+- vocab_prompt.txt — the learner's vocabulary
+- vocab_lookup.tsv — machine-readable vocabulary lookup
+- validate_sentence_cli.py — validates vocabulary compliance
+
+WORKFLOW:
+1. Read vocab_prompt.txt to understand the learner's vocabulary
+2. For each sentence in the sentences file, evaluate quality
+3. Run the validator on suspicious sentences: python3 {validator} --arabic "SENTENCE" --target-bare "TARGET_BARE" --vocab-file {work_dir}/vocab_lookup.tsv
+4. Classify each sentence:
+   - "ok" — sentence is correct and useful
+   - "fix" — sentence has fixable issues (provide corrected version with full diacritics)
+   - "retire" — sentence is unfixable (severe grammar errors, nonsensical, or wrong translation)
+
+Guidelines:
+- Be lenient on style — simple/textbook style is OK for learners
+- Be strict on grammar errors and translation accuracy
+- Vocabulary compliance: if the validator flags unknown words, the sentence may still \
+be OK if the "unknown" words are conjugated forms of known words
+- For fixes: maintain the same target word and difficulty level
+- Include full diacritics (tashkeel) on all fixed Arabic text"""
+
+
+# ---------------------------------------------------------------------------
+# Sentence export
+# ---------------------------------------------------------------------------
+
+def export_sentences(db_path: str, limit: int | None = None) -> list[dict]:
+    """Export active sentences from the database."""
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+
+    query = """
+        SELECT s.sentence_id, s.arabic_text, s.english_text, s.transliteration,
+               s.source, s.times_shown, s.created_at,
+               l.lemma_ar, l.lemma_ar_bare, l.gloss_en
+        FROM sentences s
+        LEFT JOIN lemmas l ON s.target_lemma_id = l.lemma_id
+        WHERE s.is_active = 1
+        ORDER BY s.created_at DESC
+    """
+    if limit:
+        query += f" LIMIT {limit}"
+
+    rows = conn.execute(query).fetchall()
+    conn.close()
+
+    return [dict(r) for r in rows]
+
+
+def write_sentences_file(sentences: list[dict], output_dir: str) -> str:
+    """Write sentences to a JSONL file for Claude to read."""
+    os.makedirs(output_dir, exist_ok=True)
+    path = os.path.join(output_dir, "sentences.jsonl")
+    with open(path, "w") as f:
+        for s in sentences:
+            entry = {
+                "id": s["sentence_id"],
+                "arabic": s["arabic_text"],
+                "english": s["english_text"],
+                "transliteration": s.get("transliteration", ""),
+                "target_word": s.get("lemma_ar", ""),
+                "target_bare": s.get("lemma_ar_bare", ""),
+                "source": s.get("source", ""),
+            }
+            f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Apply fixes
+# ---------------------------------------------------------------------------
+
+def apply_audit_results(db_path: str, reviews: list[dict]) -> dict:
+    """Apply audit results to the database."""
+    conn = sqlite3.connect(db_path)
+    stats = {"retired": 0, "fixed": 0, "ok": 0, "skipped": 0}
+
+    for review in reviews:
+        sid = review.get("sentence_id")
+        verdict = review.get("verdict", "ok")
+
+        if verdict == "retire":
+            conn.execute(
+                "UPDATE sentences SET is_active = 0 WHERE sentence_id = ?",
+                (sid,),
+            )
+            stats["retired"] += 1
+        elif verdict == "fix":
+            fixed_ar = review.get("fixed_arabic")
+            fixed_en = review.get("fixed_english")
+            fixed_tr = review.get("fixed_transliteration")
+            if fixed_ar and fixed_en:
+                updates = ["arabic_text = ?", "english_text = ?"]
+                params = [fixed_ar, fixed_en]
+                if fixed_tr:
+                    updates.append("transliteration = ?")
+                    params.append(fixed_tr)
+                params.append(sid)
+                conn.execute(
+                    f"UPDATE sentences SET {', '.join(updates)} WHERE sentence_id = ?",
+                    params,
+                )
+                stats["fixed"] += 1
+            else:
+                stats["skipped"] += 1
+        else:
+            stats["ok"] += 1
+
+    conn.commit()
+    conn.close()
+    return stats
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(description="Audit sentences using Claude Code with vocabulary context")
+    parser.add_argument("--db", required=True, help="Path to SQLite DB")
+    parser.add_argument("--batch-size", type=int, default=DEFAULT_BATCH_SIZE, help=f"Sentences per Claude session (default: {DEFAULT_BATCH_SIZE})")
+    parser.add_argument("--limit", type=int, help="Max total sentences to audit")
+    parser.add_argument("--model", default="opus", help="Claude model (default: opus)")
+    parser.add_argument("--apply", action="store_true", help="Apply fixes and retirements to DB")
+    parser.add_argument("--verbose", "-v", action="store_true", help="Show detailed output")
+    args = parser.parse_args()
+
+    if not is_available():
+        print("ERROR: claude CLI not found. Install with: npm install -g @anthropic-ai/claude-code")
+        sys.exit(1)
+
+    # Export sentences
+    print(f"Exporting active sentences from {args.db}...")
+    sentences = export_sentences(args.db, args.limit)
+    if not sentences:
+        print("No active sentences found.")
+        return
+    print(f"  {len(sentences)} active sentences")
+
+    # Dump vocabulary
+    print(f"Dumping vocabulary to {WORK_DIR}...")
+    prompt_path, lookup_path = dump_vocabulary_for_claude(args.db, WORK_DIR)
+
+    # Process in batches
+    all_reviews = []
+    batches = [sentences[i:i + args.batch_size] for i in range(0, len(sentences), args.batch_size)]
+
+    for batch_idx, batch in enumerate(batches):
+        batch_label = f"Batch {batch_idx + 1}/{len(batches)} ({len(batch)} sentences)"
+        print(f"\n{batch_label}...")
+
+        # Write this batch to a file
+        sentences_path = write_sentences_file(batch, WORK_DIR)
+
+        system = SYSTEM_PROMPT.format(
+            validator=VALIDATOR_SCRIPT,
+            work_dir=WORK_DIR,
+        )
+
+        prompt = f"""Review the sentences in {sentences_path} for quality.
+
+STEPS:
+1. Read {WORK_DIR}/vocab_prompt.txt to understand the learner's vocabulary
+2. Read {sentences_path} — each line is a JSON object with: id, arabic, english, target_word, target_bare
+3. For each sentence, evaluate grammar, translation accuracy, and naturalness
+4. Run the validator on any sentence you suspect has vocabulary issues:
+   python3 {VALIDATOR_SCRIPT} --arabic "SENTENCE" --target-bare "TARGET_BARE" --vocab-file {lookup_path}
+5. Return your review for each sentence (verdict: ok/fix/retire)
+
+For "fix" verdicts, provide corrected arabic, english, and transliteration with full diacritics."""
+
+        start = time.time()
+        try:
+            result = generate_with_tools(
+                prompt=prompt,
+                system_prompt=system,
+                json_schema=AUDIT_SCHEMA,
+                work_dir=WORK_DIR,
+                model=args.model,
+                max_budget_usd=1.00,  # higher budget for audit
+                timeout=300,  # longer timeout for large batches
+            )
+        except Exception as e:
+            print(f"  ERROR: {e}")
+            continue
+
+        elapsed = time.time() - start
+        reviews = result.get("reviews", [])
+        print(f"  Done in {elapsed:.1f}s — reviewed {len(reviews)} sentences")
+
+        # Summary for this batch
+        verdicts = {"ok": 0, "fix": 0, "retire": 0}
+        for r in reviews:
+            v = r.get("verdict", "ok")
+            verdicts[v] = verdicts.get(v, 0) + 1
+
+        print(f"  Results: {verdicts['ok']} ok, {verdicts['fix']} fix, {verdicts['retire']} retire")
+
+        if args.verbose:
+            for r in reviews:
+                if r.get("verdict") != "ok":
+                    sid = r.get("sentence_id", "?")
+                    verdict = r.get("verdict", "?")
+                    issues = r.get("issues", [])
+                    print(f"    [{verdict.upper()}] #{sid}: {'; '.join(issues)}")
+                    if r.get("fixed_arabic"):
+                        print(f"      Fixed: {r['fixed_arabic']}")
+
+        all_reviews.extend(reviews)
+
+    # Overall summary
+    total_verdicts = {"ok": 0, "fix": 0, "retire": 0}
+    for r in all_reviews:
+        v = r.get("verdict", "ok")
+        total_verdicts[v] = total_verdicts.get(v, 0) + 1
+
+    print(f"\n{'='*60}")
+    print(f"Audit Summary: {len(all_reviews)} sentences reviewed")
+    print(f"  OK: {total_verdicts['ok']}")
+    print(f"  Fix: {total_verdicts['fix']}")
+    print(f"  Retire: {total_verdicts['retire']}")
+    print(f"{'='*60}")
+
+    # Apply if requested
+    if args.apply and (total_verdicts["fix"] > 0 or total_verdicts["retire"] > 0):
+        print(f"\nApplying changes to {args.db}...")
+        stats = apply_audit_results(args.db, all_reviews)
+        print(f"  Fixed: {stats['fixed']}, Retired: {stats['retired']}, Skipped: {stats['skipped']}")
+    elif not args.apply and (total_verdicts["fix"] > 0 or total_verdicts["retire"] > 0):
+        print(f"\nDry run — use --apply to apply {total_verdicts['fix']} fixes and {total_verdicts['retire']} retirements")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/benchmark_verification.py
+++ b/backend/scripts/benchmark_verification.py
@@ -1,0 +1,451 @@
+#!/usr/bin/env python3
+"""Benchmark different LLM models on mapping verification quality.
+
+Uses real flagged sentences as ground truth — cases where the verification
+LLM approved bad mappings that users later caught.
+
+Usage:
+    python3 scripts/benchmark_verification.py
+    python3 scripts/benchmark_verification.py --models claude_haiku,gemini
+"""
+import argparse
+import json
+import os
+import sys
+import time
+from datetime import datetime
+
+# Clear proxy env vars that block API calls locally
+for k in ["ALL_PROXY", "HTTPS_PROXY", "HTTP_PROXY", "all_proxy", "https_proxy", "http_proxy"]:
+    os.environ.pop(k, None)
+
+sys.path.insert(0, ".")
+
+# Ground truth: sentences with known-bad mappings that should have been flagged.
+# Each entry: arabic, english, mappings (position, surface, lemma_ar, gloss),
+# and expected_bad_positions (positions that SHOULD be flagged).
+GROUND_TRUTH = [
+    {
+        "id": "flag50",
+        "arabic": "لازمني أياما وهو يعالجني من أثر ذلك الغاز.",
+        "english": "He stayed by my side for days, treating me for the effects of that gas.",
+        "mappings": [
+            (0, "لَازَمَنِي", "لَازِمٌ", "necessary, urgent, unavoidable"),
+            (1, "أَيَّامًا", "يَوْم", "day"),
+            (2, "وَهُوَ", "هُوَ", "he"),
+            (3, "يُعَالِجُنِي", "عالَج", "to treat"),
+            (4, "مِنْ", "مِن", "from; than"),
+            (5, "أَثَرِ", "آثَار", "monuments"),
+            (6, "ذَلِكَ", "ذٰلِكَ", "that (masc.)"),
+            (7, "الْغَازِ.", "غَازٍ", "raider, invader, conqueror"),
+        ],
+        "expected_bad": [0, 5, 7],
+        "notes": "لَازَمَنِي=accompanied me (not 'necessary'), أَثَر=effect (not monuments), غاز=gas (not raider)",
+    },
+    {
+        "id": "flag49",
+        "arabic": "قرأت كتبا متنوعة وعرفت حينذاك أنني أميل إلى نوع معين من العلوم...",
+        "english": "I read many different books and realized then that I was drawn to a specific type of science...",
+        "mappings": [
+            (0, "قَرَأْتُ", "قَرَأَ", "to read"),
+            (1, "كُتُبًا", "كِتاب", "book"),
+            (2, "مُتَنَوِّعَةً", "مُتَنَوِّعَة", "diverse / various"),
+            (3, "وَعَرَفْتُ", "عَرَفَ", "to know"),
+            (4, "حِينَذَاكَ", "حِينَذاك", "at that time"),
+            (5, "أَنَّنِي", "الآن", "now"),
+            (6, "أَمِيلُ", "مَالٌ", "money, wealth"),
+            (7, "إِلَى", "إِلَى", "to, towards"),
+            (8, "نَوْعٍ", "نَوَّعَ", "to diversify"),
+            (9, "مُعَيَّنٍ", "مُعَيَّنَة", "specific"),
+            (10, "مِنَ", "مِن", "from; than"),
+            (11, "الْعُلُومِ...", "عَلِمَ", "to know"),
+        ],
+        "expected_bad": [5, 6, 8, 11],
+        "notes": "أَنَّنِي=that I (not now), أَمِيلُ=I incline (not money), نَوْعٍ=type (not diversify), العلوم=sciences (not to know)",
+    },
+    {
+        "id": "flag46",
+        "arabic": "المَقْعَدُ عَالٍ وَأَنَا أَحْتَاجُ سُلَّمًا لِلْجُلُوسِ عَلَيْهِ.",
+        "english": "The seat is high and I need a ladder to sit on it.",
+        "mappings": [
+            (0, "المَقْعَدُ", "مَقْعَد", "seat"),
+            (1, "عَالٍ", "عَالٍ", "high"),
+            (2, "وَأَنَا", "أَنا", "I"),
+            (3, "أَحْتَاجُ", "ٱِحْتاج", "to need"),
+            (4, "سُلَّمًا", "سِلْمٌ", "peace"),
+            (5, "لِلْجُلُوسِ", "جُلُوس", "sitting"),
+            (6, "عَلَيْهِ.", "عَلى", "on, on top of"),
+        ],
+        "expected_bad": [4],
+        "notes": "سُلَّم=ladder (not سِلْم=peace)",
+    },
+    {
+        "id": "flag45",
+        "arabic": "هَلْ اِتَّصَلَ أَحَدٌ بِالنَّادِي لِلسُّؤَالِ؟",
+        "english": "Did anyone contact the club to ask?",
+        "mappings": [
+            (0, "هَلْ", "هَل", "(question particle)"),
+            (1, "اِتَّصَلَ", "اِتَّصَلَ", "to contact"),
+            (2, "أَحَدٌ", "احد", "Sunday"),
+            (3, "بِالنَّادِي", "نَادِي", "club"),
+            (4, "لِلسُّؤَالِ؟", "سُؤال", "question"),
+        ],
+        "expected_bad": [2],
+        "notes": "أَحَدٌ=anyone/someone (not Sunday)",
+    },
+    {
+        "id": "flag44",
+        "arabic": "يَشْعُرُ المَرِيضُ بِدُوَارٍ كُلَّمَا وَقَفَ بِسُرْعَةٍ، لٰكِنَّ الطَّبِيبَ قَالَ إِنَّهُ أَمْرٌ عَادِيٌّ.",
+        "english": "The patient feels dizziness whenever he stands quickly, but the doctor said it is a normal matter.",
+        "mappings": [
+            (0, "يَشْعُرُ", "شَعَرَ", "to feel"),
+            (1, "المَرِيضُ", "مَرِيض", "sick"),
+            (2, "بِدُوَارٍ", "دُوَارٌ", "dizziness, vertigo"),
+            (3, "كُلَّمَا", "كلما", "whenever"),
+            (4, "وَقَفَ", "وَقَفَ", "to come to a stop, to come to a standstill"),
+            (5, "بِسُرْعَةٍ،", "بِسُرْعة", "quickly"),
+            (6, "لٰكِنَّ", "لكن", "but"),
+            (7, "الطَّبِيبَ", "طَبِيب", "doctor"),
+            (8, "قَالَ", "قالَ", "to say"),
+            (9, "إِنَّهُ", "الآن", "now"),
+            (10, "أَمْرٌ", "أَمْر", "matter/affair"),
+            (11, "عَادِيٌّ.", "عَادِيٌّ", "normal"),
+        ],
+        "expected_bad": [9],
+        "notes": "إِنَّهُ=indeed it/that it (not الآن=now)",
+    },
+    {
+        "id": "flag41",
+        "arabic": "أَمَلَ الصَّيَّادُ فِي حَظٍّ أَكْثَرَ اليَوْمَ.",
+        "english": "The fisherman hoped for more luck today.",
+        "mappings": [
+            (0, "أَمَلَ", "أَمَلَ", "to hope for"),
+            (1, "الصَّيَّادُ", "صَيّادِيَة", "Sayadieh (dish)"),
+            (2, "فِي", "فِي", "in"),
+            (3, "حَظٍّ", "حَظّ", "luck"),
+            (4, "أَكْثَرَ", "كَثِير", "many, many, a lot"),
+            (5, "اليَوْمَ.", "اَلْيَوْمَ", "today"),
+        ],
+        "expected_bad": [1],
+        "notes": "الصَّيَّادُ=fisherman/hunter (not Sayadieh dish)",
+    },
+    {
+        "id": "flag40",
+        "arabic": "الأَبُ يُعِدُّ طَعَاماً لَذِيذاً لِلْأُسْرَةِ كُلَّ يَوْمٍ.",
+        "english": "The father prepares delicious food for the family every day.",
+        "mappings": [
+            (0, "الأَبُ", "أب", "father"),
+            (1, "يُعِدُّ", "عَدَد", "count"),
+            (2, "طَعَاماً", "طَعام", "food"),
+            (3, "لَذِيذاً", "لَذِيذ", "delicious, tasty"),
+            (4, "لِلْأُسْرَةِ", "سَرَّ", "to gladden, delight"),
+            (5, "كُلَّ", "كُلّ", "all (of), each"),
+            (6, "يَوْمٍ.", "يَوْم", "day"),
+        ],
+        "expected_bad": [1, 4],
+        "notes": "يُعِدُّ=prepares (Form IV of عدّ, not عدد=count), لِلْأُسْرَةِ=for the family (not سَرَّ=to gladden)",
+    },
+    {
+        "id": "flag39",
+        "arabic": "قَضَى الرَّجُلُ يَوْمَهُ فِي المَكْتَبَةِ يَقْرَأُ كُتُباً عَنِ التَّارِيخِ وَالأَدَبِ.",
+        "english": "The man spent his day in the library reading books about history and literature.",
+        "mappings": [
+            (0, "قَضَى", "قَضَى", "to spend time"),
+            (1, "الرَّجُلُ", "رَجُل", "man"),
+            (2, "يَوْمَهُ", "اَلْيَوْمَ", "today"),
+            (3, "فِي", "فِي", "in"),
+            (4, "المَكْتَبَةِ", "مَكْتَبَة", "bookstore, library"),
+            (5, "يَقْرَأُ", "قَرَأَ", "to read"),
+            (6, "كُتُباً", "كِتاب", "book"),
+            (7, "عَنِ", "عَن", "about"),
+            (8, "التَّارِيخِ", "تَارِيخٌ", "history, date"),
+            (9, "وَالأَدَبِ.", "دَبَّ", "to creep, to crawl"),
+        ],
+        "expected_bad": [2, 9],
+        "notes": "يَوْمَهُ=his day (يوم not اليوم=today), وَالأَدَبِ=literature (أدب not دبّ=to creep)",
+    },
+    {
+        "id": "flag34",
+        "arabic": "هُنَاكَ تِرٌّ قَدِيمٌ فِي المَخْزَنِ، وَلَكِنْ لَا يَعْرِفُ أَحَدٌ مَنْ وَضَعَهُ هُنَاكَ.",
+        "english": "There is an old plumb line in the storeroom, but no one knows who put it there.",
+        "mappings": [
+            (0, "هُنَاكَ", "هُناك", "there"),
+            (1, "تِرٌّ", "تِرٌّ", "plumb line"),
+            (2, "قَدِيمٌ", "قَديم", "old"),
+            (3, "فِي", "فِي", "in"),
+            (4, "المَخْزَنِ،", "مَخْزَنٌ", "storeroom, storehouse"),
+            (5, "وَلَكِنْ", "وَلَكِنْ", "but"),
+            (6, "لَا", "لَا", "neither"),
+            (7, "يَعْرِفُ", "عَرَفَ", "to know"),
+            (8, "أَحَدٌ", "احد", "Sunday"),
+            (9, "مَنْ", "مِن", "from; than"),
+            (10, "وَضَعَهُ", "وَضْع", "situation, state"),
+            (11, "هُنَاكَ.", "هُناك", "there"),
+        ],
+        "expected_bad": [8, 9, 10],
+        "notes": "أَحَدٌ=anyone (not Sunday), مَنْ=who (not مِن=from), وَضَعَهُ=put it (verb وضع, not noun وَضْع=situation)",
+    },
+    {
+        "id": "flag30",
+        "arabic": "حَلَقَ أَبِي شَارِبَهُ أَمْسِ.",
+        "english": "My father shaved his mustache yesterday.",
+        "mappings": [
+            (0, "حَلَقَ", "حَلَق", "throat"),
+            (1, "أَبِي", "أب", "father"),
+            (2, "شَارِبَهُ", "شَارِبٌ", "mustache"),
+            (3, "أَمْسِ.", "أَمْسٌ", "yesterday"),
+        ],
+        "expected_bad": [0],
+        "notes": "حَلَقَ=to shave (verb, not حَلَق=throat)",
+    },
+    {
+        "id": "flag29",
+        "arabic": "أَعْطَى الصَّيَّادُ القِرْدَ تُفَّاحًا لَذِيذًا.",
+        "english": "The hunter gave the monkey delicious apples.",
+        "mappings": [
+            (0, "أَعْطَى", "أَعْطَى", "to give"),
+            (1, "الصَّيَّادُ", "صَيّادِيَة", "Sayadieh (dish)"),
+            (2, "القِرْدَ", "قِرْد", "monkey"),
+            (3, "تُفَّاحًا", "تُفَّاح", "apples"),
+            (4, "لَذِيذًا.", "لَذِيذ", "delicious, tasty"),
+        ],
+        "expected_bad": [1],
+        "notes": "الصَّيَّادُ=hunter (not Sayadieh dish)",
+    },
+    {
+        "id": "flag14",
+        "arabic": "وَضَعَ الطَّالِبُ الحَقِيبَةَ عَلَى كَتِفِهِ وَذَهَبَ إِلَى الجَامِعَةِ.",
+        "english": "The student put the bag on his shoulder and went to the university.",
+        "mappings": [
+            (0, "وَضَعَ", "وَضْع", "situation, state"),
+            (1, "الطَّالِبُ", "طالِب", "student"),
+            (2, "الحَقِيبَةَ", "حَقيبَة", "bag"),
+            (3, "عَلَى", "عَلى", "on, on top of"),
+            (4, "كَتِفِهِ", "كَتِف", "shoulder"),
+            (5, "وَذَهَبَ", "ذَهَبَ", "to go"),
+            (6, "إِلَى", "إِلَى", "to, towards"),
+            (7, "الجَامِعَةِ.", "جامِعة", "university"),
+        ],
+        "expected_bad": [0],
+        "notes": "وَضَعَ=to put/place (verb, not وَضْع=situation noun)",
+    },
+    {
+        "id": "flag12",
+        "arabic": "هَلْ لَمَعَ الذَّهَبُ تَحْتَ الشَّمْسِ؟",
+        "english": "Did the gold glisten under the sun?",
+        "mappings": [
+            (0, "هَلْ", "هَل", "(question particle)"),
+            (1, "لَمَعَ", "لَمَعَ", "to glisten, to gleam"),
+            (2, "الذَّهَبُ", "ذَهَبَ", "to go"),
+            (3, "تَحْتَ", "تَحْت", "under"),
+            (4, "الشَّمْسِ؟", "شَمْس", "sun"),
+        ],
+        "expected_bad": [2],
+        "notes": "الذَّهَبُ=gold (noun, not ذَهَبَ=to go)",
+    },
+    {
+        "id": "flag47",
+        "arabic": "كَفَّ الطُّلَّابُ عَنِ الحَدِيثِ عِنْدَمَا دَخَلَ المُعَلِّمُ إِلَى الصَّفِّ.",
+        "english": "The students stopped talking when the teacher entered the classroom.",
+        "mappings": [
+            (0, "كَفَّ", "كَفَّ", "desist, cease"),
+            (1, "الطُّلَّابُ", "طُلّاب", "students"),
+            (2, "عَنِ", "عَن", "about"),
+            (3, "الحَدِيثِ", "حَدِيثٌ", "modern"),
+            (4, "عِنْدَمَا", "عندما", "when"),
+            (5, "دَخَلَ", "دَخَلَ", "to enter"),
+            (6, "المُعَلِّمُ", "مُعَلِّم", "teacher"),
+            (7, "إِلَى", "إِلَى", "to, towards"),
+            (8, "الصَّفِّ.", "صَفّ", "class, classroom"),
+        ],
+        "expected_bad": [3],
+        "notes": "الحَدِيثِ=talking/conversation (not حَدِيثٌ=modern). Homograph: حديث means both 'modern' and 'speech/conversation'",
+    },
+]
+
+
+def build_prompt(case: dict) -> tuple[str, str]:
+    """Build the exact same prompt used in production verification."""
+    word_lines = []
+    for pos, surface, lemma_ar, gloss in case["mappings"]:
+        word_lines.append(f"  {pos}: {surface} → {lemma_ar} ({gloss})")
+
+    prompt = f"""Arabic sentence: {case['arabic']}
+English translation: {case['english']}
+
+Word-to-lemma mappings:
+{chr(10).join(word_lines)}
+
+Your task: check that each word's lemma MAKES SENSE in the context of this sentence and its English translation. For each wrong mapping, provide the correct lemma.
+
+Flag as WRONG (and provide correction):
+- The lemma's English gloss doesn't match what the word means in this sentence (e.g. "to sleep" in a sentence about growing, "classroom" in a sentence about describing)
+- **Homograph collisions**: same consonants but different meanings depending on voweling (e.g. جَدّ "grandfather" vs جِدّ "seriousness", حَرَم "to deprive" vs حَرَم "sanctuary", عِلم "knowledge" vs عَلَم "flag"). If the English translation uses a meaning that doesn't match the mapped gloss, FLAG IT even if they share the same root.
+- A verb mapped to an unrelated noun or vice versa when they happen to share consonants (e.g. طَائِر "bird" mapped to طار "to fly" — these are different lemmas)
+- A clitic prefix (و/ف/ب/ل/ك) wrongly stripped from a word where the letter is part of the root (e.g. وَصْف "description" stripped to صف "row/class")
+- An active participle / verbal noun mapped to the root verb when it should be its own lemma (e.g. حُضُور "attendance" mapped to حاضر "present")
+- A noun/verb homograph mapped to the wrong part of speech (e.g. ذَهَب "gold" mapped to ذَهَبَ "to go")
+
+Do NOT flag (these are CORRECT):
+- A conjugated verb mapped to its dictionary form, when the MEANING matches the sentence (e.g. يَكْتُبُ "he writes" mapped to كَتَبَ "to write")
+- A plural/feminine/dual form mapped to its base lemma (e.g. مُعَلِّمَة mapped to مُعَلِّم)
+- A noun with possessive suffix mapped to the base noun (e.g. أُمِّي mapped to أُمّ)
+- A word with preposition prefix where the base word is correct (e.g. بِالعَرَبِيَّة mapped to عَرَبِيّ)
+
+Words marked [via clitic stripping] had a prefix/suffix removed during lookup — these are higher risk for errors. Pay extra attention to them.
+
+When in doubt, flag it — a false positive just causes a retry, but a false negative reaches the user.
+
+Return JSON: {{"issues": []}} if all correct, or:
+{{"issues": [{{"position": <int>, "correct_lemma_ar": "<bare form>", "correct_gloss": "<English>", "correct_pos": "<noun/verb/adj/etc>", "explanation": "<brief>"}}]}}"""
+
+    system = "You are an Arabic morphology expert. Check each mapping against the English translation. Flag any mapping where the gloss doesn't fit the sentence meaning."
+
+    return prompt, system
+
+
+def run_model(model: str, prompt: str, system: str) -> tuple[list[int], float, str | None]:
+    """Run verification with a specific model, return (flagged_positions, latency_s, error)."""
+    from app.services.llm import generate_completion, AllProvidersFailed
+
+    start = time.time()
+    try:
+        result = generate_completion(
+            prompt=prompt,
+            system_prompt=system,
+            json_mode=True,
+            temperature=0.0,
+            model_override=model,
+            task_type="mapping_verification",
+        )
+        elapsed = time.time() - start
+        issues = result.get("issues", [])
+        if not isinstance(issues, list):
+            return [], elapsed, f"Bad response format: {type(issues)}"
+        positions = [int(iss["position"]) for iss in issues if isinstance(iss, dict) and "position" in iss]
+        return positions, elapsed, None
+    except (AllProvidersFailed, Exception) as e:
+        return [], time.time() - start, str(e)
+
+
+def score_result(flagged: list[int], expected: list[int], total_mappings: int) -> dict:
+    """Compute precision/recall/F1 for a single case."""
+    flagged_set = set(flagged)
+    expected_set = set(expected)
+
+    tp = len(flagged_set & expected_set)
+    fp = len(flagged_set - expected_set)
+    fn = len(expected_set - flagged_set)
+    tn = total_mappings - tp - fp - fn
+
+    precision = tp / (tp + fp) if (tp + fp) > 0 else 1.0
+    recall = tp / (tp + fn) if (tp + fn) > 0 else 1.0
+    f1 = 2 * precision * recall / (precision + recall) if (precision + recall) > 0 else 0.0
+
+    return {
+        "tp": tp, "fp": fp, "fn": fn, "tn": tn,
+        "precision": precision, "recall": recall, "f1": f1,
+        "missed": sorted(expected_set - flagged_set),
+        "false_alarms": sorted(flagged_set - expected_set),
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--models", default="claude_haiku,gemini,claude_sonnet",
+        help="Comma-separated model names to benchmark",
+    )
+    parser.add_argument("--cases", default="all", help="Comma-separated case IDs or 'all'")
+    args = parser.parse_args()
+
+    models = [m.strip() for m in args.models.split(",")]
+    cases = GROUND_TRUTH if args.cases == "all" else [
+        c for c in GROUND_TRUTH if c["id"] in args.cases.split(",")
+    ]
+
+    print(f"Benchmarking {len(models)} models on {len(cases)} cases")
+    print(f"Models: {', '.join(models)}")
+    print(f"{'='*80}\n")
+
+    # results[model] = list of per-case scores
+    all_results: dict[str, list] = {m: [] for m in models}
+    all_latencies: dict[str, list] = {m: [] for m in models}
+    all_errors: dict[str, int] = {m: 0 for m in models}
+
+    for case in cases:
+        prompt, system = build_prompt(case)
+        total = len(case["mappings"])
+        expected = case["expected_bad"]
+
+        print(f"Case {case['id']}: {case['arabic'][:60]}...")
+        print(f"  Expected bad positions: {expected}")
+        print(f"  ({case['notes']})")
+
+        for model in models:
+            flagged, latency, error = run_model(model, prompt, system)
+            if error:
+                print(f"  {model:20s}: ERROR ({latency:.1f}s) — {error[:80]}")
+                all_errors[model] += 1
+                all_results[model].append({"recall": 0, "precision": 0, "f1": 0, "fn": len(expected), "fp": 0})
+                all_latencies[model].append(latency)
+                continue
+
+            scores = score_result(flagged, expected, total)
+            all_results[model].append(scores)
+            all_latencies[model].append(latency)
+
+            status = "PERFECT" if scores["fn"] == 0 and scores["fp"] == 0 else (
+                "GOOD" if scores["fn"] == 0 else "MISSED"
+            )
+            missed_str = f" missed={scores['missed']}" if scores["missed"] else ""
+            false_str = f" false_alarms={scores['false_alarms']}" if scores["false_alarms"] else ""
+            flagged_str = str(sorted(flagged))
+            print(f"  {model:20s}: flagged={flagged_str:30s} {status:8s} "
+                  f"P={scores['precision']:.0%} R={scores['recall']:.0%} F1={scores['f1']:.0%} "
+                  f"({latency:.1f}s){missed_str}{false_str}")
+
+        print()
+
+    # Summary
+    print(f"{'='*80}")
+    print("SUMMARY")
+    print(f"{'='*80}\n")
+
+    for model in models:
+        results = all_results[model]
+        if not results:
+            print(f"{model}: no results")
+            continue
+
+        avg_recall = sum(r["recall"] for r in results) / len(results)
+        avg_precision = sum(r["precision"] for r in results) / len(results)
+        avg_f1 = sum(r["f1"] for r in results) / len(results)
+        total_fn = sum(r["fn"] for r in results)
+        total_fp = sum(r["fp"] for r in results)
+        avg_latency = sum(all_latencies[model]) / len(all_latencies[model])
+        perfect = sum(1 for r in results if r["fn"] == 0 and r["fp"] == 0)
+        no_miss = sum(1 for r in results if r["fn"] == 0)
+        errors = all_errors[model]
+
+        print(f"{model}:")
+        print(f"  Avg Recall:    {avg_recall:.0%}  (catches bad mappings)")
+        print(f"  Avg Precision: {avg_precision:.0%}  (doesn't flag good ones)")
+        print(f"  Avg F1:        {avg_f1:.0%}")
+        print(f"  Total missed:  {total_fn}  (false negatives — bad mappings approved)")
+        print(f"  Total false:   {total_fp}  (false positives — good mappings flagged)")
+        print(f"  Perfect cases: {perfect}/{len(results)}")
+        print(f"  No-miss cases: {no_miss}/{len(results)}  (caught all bad, maybe some false alarms)")
+        print(f"  Avg latency:   {avg_latency:.1f}s")
+        print(f"  Errors:        {errors}")
+        print()
+
+    # Cost comparison note
+    total_bad = sum(len(c["expected_bad"]) for c in cases)
+    print(f"Total ground-truth bad mappings across all cases: {total_bad}")
+    print(f"\nNote: For production use, recall matters most — a false negative")
+    print(f"reaches the user, while a false positive just retries generation.")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/generate_experiment_passages.py
+++ b/backend/scripts/generate_experiment_passages.py
@@ -1,0 +1,417 @@
+#!/usr/bin/env python3
+"""Generate 5 mini-stories for the passage reading speed experiment.
+
+Each story: exactly 4 sentences, comfortable vocabulary (FSRS stability ≥ 7d),
+plus 1 "challenge" word (stability 1-7d) per story.
+
+Usage:
+    # Dry-run: see the prompt and vocabulary stats
+    python3 scripts/generate_experiment_passages.py --db ~/alif-backups/alif_20260303_090005.db --dry-run
+
+    # Generate all 5 stories
+    python3 scripts/generate_experiment_passages.py --db ~/alif-backups/alif_20260303_090005.db
+
+    # Generate and import into production
+    python3 scripts/generate_experiment_passages.py --db ~/alif-backups/alif_20260303_090005.db \
+        --import-url http://46.225.75.29:3000
+
+See: research/experiment-passage-reading-speed.md
+"""
+
+import argparse
+import json
+import random
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from app.services.sentence_validator import (
+    FUNCTION_WORD_GLOSSES,
+    FUNCTION_WORD_FORMS,
+    build_lemma_lookup,
+    lookup_lemma,
+    normalize_alef,
+    strip_diacritics,
+    strip_tatweel,
+    tokenize,
+)
+
+# Reuse the Claude CLI wrapper and compliance check from generate_story_claude
+from scripts.generate_story_claude import (
+    SimpleLemma,
+    call_claude,
+    check_compliance,
+    format_vocab_grouped,
+    STORY_JSON_SCHEMA,
+)
+
+MAX_RETRIES = 3
+COMPLIANCE_THRESHOLD = 75.0
+
+GENRES = [
+    "a short poem (4 lines) — lyrical, evocative imagery, each line a complete thought",
+    "a joke or riddle with a punchline — setup, misdirection, payoff",
+    "a tiny fable where an animal teaches a surprising lesson",
+    "a love letter or confession — passionate, specific, bittersweet",
+    "a dramatic monologue — someone speaking at a pivotal moment in their life",
+    "a ghost story or supernatural encounter — atmospheric and eerie",
+    "a diary entry from an unusual day — intimate voice, vivid detail",
+    "a speech by a village elder giving life advice — wise and poetic",
+    "a scene from a bazaar — haggling, colors, smells, a twist",
+    "a letter home from someone far away — nostalgia and longing",
+]
+
+SYSTEM_PROMPT = """\
+You are a master Arabic storyteller — think Naguib Mahfouz writing flash fiction, \
+or Mahmoud Darwish writing prose poetry. Write for an adult reader who happens to be \
+learning Arabic. The writing must be genuinely good: vivid, surprising, emotionally resonant.
+
+ABSOLUTE RULES:
+- EXACTLY 4 sentences (or 4 lines for poems). Not 3, not 5.
+- Each sentence: 5-10 words (allow slightly longer for natural flow)
+- Full diacritics (tashkeel) on ALL Arabic words with correct i'rab
+- Arabic punctuation: ؟ . ، ! — use naturally
+- Use dialogue with «» when it serves the piece
+- ALA-LC transliteration with macrons
+
+CRAFT:
+- Every word must earn its place — no filler, no "vocabulary exercise" feeling
+- Use concrete sensory details (a specific color, sound, smell)
+- Vary sentence rhythm — mix short punchy sentences with flowing ones
+- Characters need names AND a specific situation (not "Ali went to school" generics)
+- The ending must land — a twist, a punchline, an image that lingers
+
+WHAT MAKES IT BAD (avoid these):
+- Generic school/classroom settings (overused)
+- "Ali did X. Ali felt Y. Ali saw Z." repetitive structure
+- Explaining the point — trust the reader
+- Flat descriptions with no tension or surprise
+
+Vocabulary constraint:
+- Use ONLY words from the provided vocabulary list and common function words
+- Common function words you may freely use: في، من، على، إلى، و، ب، ل، ك، هذا، هذه، \
+ذلك، تلك، هو، هي، أنا، أنت، نحن، هم، ما، لا، أن، إن، كان، كانت، ليس، هل، لم، \
+لن، قد، الذي، التي، كل، بعض، هنا، هناك، الآن، جدا، فقط، أيضا، أو، ثم، لكن، يا
+- You may use conjugated forms of verbs (past, present, imperative, all persons)
+- You may use case endings and possessive suffixes on nouns"""
+
+
+def load_experiment_vocabulary(db_path):
+    """Load vocabulary split by stability tier."""
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+
+    # Strong words: FSRS stability ≥ 7 days
+    strong_rows = conn.execute("""
+        SELECT l.lemma_id, l.lemma_ar, l.lemma_ar_bare, l.gloss_en, l.pos,
+               l.forms_json, ulk.knowledge_state,
+               CAST(json_extract(ulk.fsrs_card_json, '$.stability') AS REAL) as stability
+        FROM lemmas l
+        JOIN user_lemma_knowledge ulk ON l.lemma_id = ulk.lemma_id
+        WHERE ulk.knowledge_state IN ('learning', 'known')
+          AND l.canonical_lemma_id IS NULL
+          AND ulk.fsrs_card_json IS NOT NULL
+          AND CAST(json_extract(ulk.fsrs_card_json, '$.stability') AS REAL) >= 7.0
+    """).fetchall()
+
+    # Challenge words: FSRS stability 1-7 days (graduated but fragile)
+    challenge_rows = conn.execute("""
+        SELECT l.lemma_id, l.lemma_ar, l.lemma_ar_bare, l.gloss_en, l.pos,
+               l.forms_json, ulk.knowledge_state,
+               CAST(json_extract(ulk.fsrs_card_json, '$.stability') AS REAL) as stability
+        FROM lemmas l
+        JOIN user_lemma_knowledge ulk ON l.lemma_id = ulk.lemma_id
+        WHERE ulk.knowledge_state IN ('learning', 'known')
+          AND l.canonical_lemma_id IS NULL
+          AND ulk.fsrs_card_json IS NOT NULL
+          AND CAST(json_extract(ulk.fsrs_card_json, '$.stability') AS REAL) >= 1.0
+          AND CAST(json_extract(ulk.fsrs_card_json, '$.stability') AS REAL) < 7.0
+    """).fetchall()
+
+    def row_to_word(r):
+        return {
+            "lemma_id": r["lemma_id"],
+            "arabic": r["lemma_ar"],
+            "arabic_bare": r["lemma_ar_bare"],
+            "english": r["gloss_en"] or "",
+            "pos": r["pos"] or "",
+            "state": r["knowledge_state"],
+            "stability": r["stability"],
+        }
+
+    strong_words = [row_to_word(r) for r in strong_rows]
+    challenge_words = [row_to_word(r) for r in challenge_rows]
+
+    # Build compliance lookup from strong + challenge words
+    all_usable_rows = strong_rows + challenge_rows
+    usable_lemmas = []
+    for r in all_usable_rows:
+        forms = None
+        if r["forms_json"]:
+            try:
+                forms = json.loads(r["forms_json"]) if isinstance(r["forms_json"], str) else r["forms_json"]
+            except (json.JSONDecodeError, TypeError):
+                forms = None
+        usable_lemmas.append(SimpleLemma(r["lemma_id"], r["lemma_ar_bare"], forms))
+
+    # Also load all lemmas for the full lookup
+    all_rows = conn.execute(
+        "SELECT lemma_id, lemma_ar_bare, forms_json FROM lemmas"
+    ).fetchall()
+    all_lemmas = []
+    for r in all_rows:
+        forms = None
+        if r["forms_json"]:
+            try:
+                forms = json.loads(r["forms_json"]) if isinstance(r["forms_json"], str) else r["forms_json"]
+            except (json.JSONDecodeError, TypeError):
+                forms = None
+        all_lemmas.append(SimpleLemma(r["lemma_id"], r["lemma_ar_bare"], forms))
+
+    conn.close()
+
+    func_bares = set()
+    for fw in FUNCTION_WORD_GLOSSES:
+        func_bares.add(normalize_alef(fw))
+    for fw in FUNCTION_WORD_FORMS:
+        func_bares.add(normalize_alef(fw))
+
+    return {
+        "strong_words": strong_words,
+        "challenge_words": challenge_words,
+        "compliance_lookup": build_lemma_lookup(usable_lemmas),
+        "all_lemma_lookup": build_lemma_lookup(all_lemmas),
+        "function_word_bares": func_bares,
+    }
+
+
+def build_experiment_prompt(strong_words, challenge_word, genre, retry_feedback=None):
+    """Build prompt for a single 4-sentence story."""
+    vocab = format_vocab_grouped(strong_words)
+
+    retry_section = ""
+    if retry_feedback:
+        retry_section = f"""
+IMPORTANT CORRECTION: Your previous attempt used words NOT in the vocabulary list.
+These words are NOT allowed: {', '.join(retry_feedback['unknown_words'][:15])}
+Please rewrite using ONLY words from the vocabulary list below.
+Previous compliance was {retry_feedback['compliance_pct']}% — aim for 90%+.
+"""
+
+    prompt = f"""{retry_section}Write EXACTLY 4 sentences (or 4 lines if a poem).
+
+GENRE/FORM: {genre}
+
+FEATURED WORD (MUST appear naturally):
+{challenge_word['arabic']} ({challenge_word['english']}) [{challenge_word['pos']}]
+
+VOCABULARY (use ONLY these content words, plus common function words):
+{vocab}
+
+CONSTRAINTS:
+- EXACTLY 4 sentences/lines
+- Each: 5-10 words
+- The featured word MUST appear at least once
+- ONLY vocabulary list words (any conjugated form is fine)
+- Full diacritics (tashkeel) on ALL Arabic words
+- NO generic school/classroom settings — be specific and vivid
+- Give characters real names (not just Ali) and specific situations
+- The ending must surprise, move, or delight the reader"""
+
+    return prompt
+
+
+def generate_experiment_stories(db_path, model="opus", dry_run=False, num_stories=5):
+    """Generate all experiment stories."""
+    print(f"Loading vocabulary from {db_path}...")
+    vocab = load_experiment_vocabulary(db_path)
+
+    strong = vocab["strong_words"]
+    challenges = vocab["challenge_words"]
+
+    print(f"  Strong words (stability ≥ 7d): {len(strong)}")
+    print(f"  Challenge words (stability 1-7d): {len(challenges)}")
+
+    if len(challenges) < num_stories:
+        print(f"  WARNING: Only {len(challenges)} challenge words available, need {num_stories}")
+        num_stories = len(challenges)
+
+    # Pick challenge words — prefer content-rich POS (nouns, verbs, adjectives)
+    content_challenges = [w for w in challenges if w["pos"] in ("noun", "verb", "adj", "adj_comp")]
+    if len(content_challenges) >= num_stories:
+        random.shuffle(content_challenges)
+        selected_challenges = content_challenges[:num_stories]
+    else:
+        random.shuffle(challenges)
+        selected_challenges = challenges[:num_stories]
+
+    print(f"\n  Selected challenge words:")
+    for i, w in enumerate(selected_challenges):
+        print(f"    {i+1}. {w['arabic']} ({w['english']}) — stability: {w['stability']:.1f}d")
+
+    if dry_run:
+        prompt = build_experiment_prompt(strong, selected_challenges[0], GENRES[0])
+        print(f"\n{'='*60}")
+        print("DRY RUN — Sample prompt:")
+        print(f"{'='*60}")
+        print(prompt[:2000])
+        print(f"...\n[{len(prompt)} chars total, {len(strong)} strong words in vocab]")
+        return []
+
+    stories = []
+    for i, challenge in enumerate(selected_challenges):
+        genre = GENRES[i % len(GENRES)]
+        print(f"\n--- Story {i+1}/{num_stories}: {challenge['arabic']} ({challenge['english']}) ---")
+        print(f"    Genre: {genre}")
+
+        best_story = None
+        best_compliance = 0
+
+        for attempt in range(MAX_RETRIES):
+            retry_feedback = None
+            if attempt > 0 and best_story:
+                last_check = check_compliance(
+                    best_story["body_ar"],
+                    vocab["compliance_lookup"],
+                    vocab["function_word_bares"],
+                    set(),  # no acquiring IDs in this experiment
+                )
+                retry_feedback = {
+                    "unknown_words": last_check["unknown_words"],
+                    "compliance_pct": last_check["compliance_pct"],
+                }
+
+            prompt = build_experiment_prompt(strong, challenge, genre, retry_feedback)
+
+            label = f"  Attempt {attempt + 1}/{MAX_RETRIES}"
+            if retry_feedback:
+                label += f" (prev: {retry_feedback['compliance_pct']}%)"
+            print(f"{label}...", end=" ", flush=True)
+
+            try:
+                story, meta = call_claude(prompt, model=model)
+            except Exception as e:
+                print(f"FAIL: {e}")
+                continue
+
+            compliance = check_compliance(
+                story["body_ar"],
+                vocab["compliance_lookup"],
+                vocab["function_word_bares"],
+                set(),
+            )
+
+            pct = compliance["compliance_pct"]
+            print(f"OK ({meta['duration_ms']}ms, ${meta['cost_usd']:.3f})")
+            print(f"    Compliance: {pct}% ({compliance['content_known']}/{compliance['content_total']})")
+
+            # Count sentences
+            sentences = [s.strip() for s in story["body_ar"].split(".") if s.strip()]
+            print(f"    Sentences: {len(sentences)}")
+
+            if compliance["unknown_words"]:
+                print(f"    Unknown: {', '.join(compliance['unknown_words'][:8])}")
+
+            if pct > best_compliance:
+                best_compliance = pct
+                best_story = story
+                best_story["_compliance"] = compliance
+                best_story["_meta"] = meta
+                best_story["_challenge_word"] = challenge
+
+            if pct >= COMPLIANCE_THRESHOLD:
+                break
+
+        if best_story:
+            stories.append(best_story)
+            print(f"\n  Title: {best_story['title_en']}")
+            print(f"  Arabic: {best_story['body_ar'][:120]}...")
+        else:
+            print(f"  FAILED to generate story for {challenge['arabic']}")
+
+    return stories
+
+
+def import_story(story, import_url):
+    """Import a story via the API."""
+    import urllib.request
+
+    url = f"{import_url.rstrip('/')}/api/stories/import"
+    # Tag the title so we can identify experiment stories
+    title = f"[EXP] {story.get('title_ar', '')}"
+    data = json.dumps({
+        "arabic_text": story["body_ar"],
+        "title": title,
+        "english_text": story.get("body_en", ""),
+        "transliteration": story.get("transliteration", ""),
+    }).encode()
+    req = urllib.request.Request(url, data=data, headers={"Content-Type": "application/json"})
+
+    with urllib.request.urlopen(req) as resp:
+        result = json.loads(resp.read())
+        return result
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate experiment passage stories")
+    parser.add_argument("--db", required=True, help="Path to SQLite DB backup")
+    parser.add_argument("--model", default="opus", help="Claude model (default: opus)")
+    parser.add_argument("--dry-run", action="store_true", help="Show prompt without generating")
+    parser.add_argument("--num-stories", type=int, default=5, help="Number of stories (default: 5)")
+    parser.add_argument("--output", "-o", help="Save all stories as JSON to file")
+    parser.add_argument("--import-url", help="Import into production (e.g. http://46.225.75.29:3000)")
+    args = parser.parse_args()
+
+    stories = generate_experiment_stories(
+        db_path=args.db,
+        model=args.model,
+        dry_run=args.dry_run,
+        num_stories=args.num_stories,
+    )
+
+    if not stories:
+        if not args.dry_run:
+            print("\nNo stories generated.")
+            sys.exit(1)
+        return
+
+    # Summary
+    print(f"\n{'='*60}")
+    print(f"GENERATED {len(stories)} EXPERIMENT STORIES")
+    print(f"{'='*60}")
+    for i, s in enumerate(stories):
+        c = s.get("_challenge_word", {})
+        comp = s.get("_compliance", {})
+        print(f"\n{i+1}. {s['title_en']}")
+        print(f"   Challenge: {c.get('arabic', '?')} ({c.get('english', '?')})")
+        print(f"   Compliance: {comp.get('compliance_pct', '?')}%")
+        print(f"   Arabic: {s['body_ar'][:100]}...")
+
+    # Save to file
+    if args.output:
+        clean = []
+        for s in stories:
+            clean.append({
+                k: v for k, v in s.items() if not k.startswith("_")
+            })
+        Path(args.output).write_text(json.dumps(clean, ensure_ascii=False, indent=2))
+        print(f"\nSaved to {args.output}")
+
+    # Import to production
+    if args.import_url:
+        print(f"\nImporting to {args.import_url}...")
+        for i, s in enumerate(stories):
+            try:
+                result = import_story(s, args.import_url)
+                sid = result.get("id", "?")
+                readiness = result.get("readiness_pct", "?")
+                print(f"  Story {i+1}: imported as #{sid} (readiness: {readiness}%)")
+            except Exception as e:
+                print(f"  Story {i+1}: import failed — {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/import_michel_thomas.py
+++ b/backend/scripts/import_michel_thomas.py
@@ -1,0 +1,731 @@
+"""Import Michel Thomas Arabic audio course into Alif.
+
+Pipeline:
+  1. Transcribe MP3s with Soniox (Arabic + English code-switching)
+  2. Extract Arabic segments from token stream
+  3. Classify segments via LLM (Egyptian vs MSA, add diacritics, translate)
+  4. Import words + sentences into DB
+
+Usage:
+  python3 scripts/import_michel_thomas.py --audio-dir /path/to/cd1/
+  python3 scripts/import_michel_thomas.py --phase transcribe --audio-dir /path/to/cd1/
+  python3 scripts/import_michel_thomas.py --phase extract
+  python3 scripts/import_michel_thomas.py --phase classify
+  python3 scripts/import_michel_thomas.py --phase import [--dry-run]
+  python3 scripts/import_michel_thomas.py --phase verify
+"""
+
+import argparse
+import json
+import logging
+import sys
+from dataclasses import dataclass, asdict
+from datetime import datetime, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from app.database import engine, Base, SessionLocal
+from app.models import (
+    Lemma, Root, Sentence, SentenceWord, Story, StoryWord,
+    UserLemmaKnowledge,
+)
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+DATA_DIR = Path(__file__).resolve().parent.parent / "data" / "michel_thomas"
+TRANSCRIPTS_DIR = DATA_DIR / "transcripts"
+SEGMENTS_FILE = DATA_DIR / "segments.json"
+CLASSIFIED_FILE = DATA_DIR / "classified.json"
+PROGRESS_FILE = DATA_DIR / "progress.jsonl"
+
+MIN_ARABIC_WORDS = 3  # minimum words for a segment to be imported as a sentence
+
+
+@dataclass
+class ArabicSegment:
+    arabic_text: str
+    english_context: str
+    start_ms: int
+    end_ms: int
+    track: str
+    speaker: str | None = None
+
+
+# --------------------------------------------------------------------------- #
+# Phase 1: Transcribe
+# --------------------------------------------------------------------------- #
+
+def load_progress() -> dict[str, str]:
+    """Load checkpoint: {filename: transcription_id}."""
+    progress = {}
+    if PROGRESS_FILE.exists():
+        for line in PROGRESS_FILE.read_text().strip().split("\n"):
+            if line.strip():
+                entry = json.loads(line)
+                progress[entry["file"]] = entry["txn_id"]
+    return progress
+
+
+def save_progress(filename: str, txn_id: str):
+    PROGRESS_FILE.parent.mkdir(parents=True, exist_ok=True)
+    with open(PROGRESS_FILE, "a") as f:
+        f.write(json.dumps({"file": filename, "txn_id": txn_id}) + "\n")
+
+
+def phase_transcribe(audio_dir: Path, soniox_key: str):
+    """Transcribe all MP3 files in audio_dir using Soniox."""
+    from app.services.soniox_service import SonioxService
+
+    svc = SonioxService(api_key=soniox_key)
+    TRANSCRIPTS_DIR.mkdir(parents=True, exist_ok=True)
+
+    completed = load_progress()
+    mp3_files = sorted(audio_dir.glob("*.mp3"))
+
+    if not mp3_files:
+        logger.error(f"No MP3 files found in {audio_dir}")
+        return
+
+    logger.info(f"Found {len(mp3_files)} tracks, {len(completed)} already transcribed")
+
+    for mp3 in mp3_files:
+        if mp3.name in completed:
+            logger.info(f"Skipping {mp3.name} (already transcribed)")
+            continue
+
+        logger.info(f"Transcribing {mp3.name}...")
+        try:
+            transcript = svc.transcribe_file(mp3, language_hints=["ar", "en"])
+            out_path = TRANSCRIPTS_DIR / f"{mp3.stem}.json"
+            out_path.write_text(json.dumps(transcript, ensure_ascii=False, indent=2))
+            save_progress(mp3.name, "completed")
+            logger.info(f"  → {len(transcript.get('tokens', []))} tokens saved to {out_path.name}")
+        except Exception as e:
+            logger.error(f"  Failed: {e}")
+            save_progress(mp3.name, f"error:{e}")
+
+    logger.info("Transcription phase complete.")
+
+
+# --------------------------------------------------------------------------- #
+# Phase 2: Extract Arabic segments
+# --------------------------------------------------------------------------- #
+
+def phase_extract():
+    """Extract Arabic segments from Soniox transcripts."""
+    transcript_files = sorted(TRANSCRIPTS_DIR.glob("*.json"))
+    if not transcript_files:
+        logger.error(f"No transcripts found in {TRANSCRIPTS_DIR}")
+        return
+
+    all_segments: list[dict] = []
+
+    for tf in transcript_files:
+        transcript = json.loads(tf.read_text())
+        tokens = transcript.get("tokens", [])
+        track_name = tf.stem
+
+        segments = _extract_segments_from_tokens(tokens, track_name)
+        all_segments.extend([asdict(s) for s in segments])
+        logger.info(f"  {track_name}: {len(tokens)} tokens → {len(segments)} Arabic segments")
+
+    SEGMENTS_FILE.write_text(json.dumps(all_segments, ensure_ascii=False, indent=2))
+    logger.info(f"Extracted {len(all_segments)} total segments → {SEGMENTS_FILE}")
+
+    # Show stats
+    long_segments = [s for s in all_segments if len(s["arabic_text"].split()) >= MIN_ARABIC_WORDS]
+    logger.info(f"  {len(long_segments)} segments with {MIN_ARABIC_WORDS}+ Arabic words (will become sentences)")
+
+
+def _extract_segments_from_tokens(tokens: list[dict], track_name: str) -> list[ArabicSegment]:
+    """Group consecutive Arabic tokens into segments with English context."""
+    segments: list[ArabicSegment] = []
+    current_arabic: list[dict] = []
+    english_before: list[str] = []
+    last_english: list[str] = []
+
+    for token in tokens:
+        lang = token.get("language", "")
+        text = token.get("text", "").strip()
+        if not text:
+            continue
+
+        if lang == "ar":
+            if not current_arabic:
+                english_before = list(last_english)
+            current_arabic.append(token)
+        else:
+            if current_arabic:
+                # Flush Arabic segment
+                seg = _build_segment(current_arabic, english_before, track_name)
+                if seg:
+                    segments.append(seg)
+                current_arabic = []
+                english_before = []
+
+            last_english.append(text)
+            # Keep only last ~20 English words for context
+            if len(last_english) > 20:
+                last_english = last_english[-20:]
+
+    # Flush final Arabic segment
+    if current_arabic:
+        seg = _build_segment(current_arabic, english_before, track_name)
+        if seg:
+            segments.append(seg)
+
+    return segments
+
+
+def _build_segment(
+    arabic_tokens: list[dict],
+    english_context: list[str],
+    track_name: str,
+) -> ArabicSegment | None:
+    """Build an ArabicSegment from a group of consecutive Arabic tokens."""
+    arabic_text = " ".join(t["text"].strip() for t in arabic_tokens if t["text"].strip())
+    if not arabic_text:
+        return None
+
+    return ArabicSegment(
+        arabic_text=arabic_text,
+        english_context=" ".join(english_context),
+        start_ms=arabic_tokens[0].get("start_ms", 0),
+        end_ms=arabic_tokens[-1].get("end_ms", 0),
+        track=track_name,
+        speaker=arabic_tokens[0].get("speaker"),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Phase 3: LLM Classification
+# --------------------------------------------------------------------------- #
+
+def phase_classify():
+    """Classify Arabic segments: Egyptian vs MSA, add diacritics, translate."""
+    from app.services.llm import generate_completion
+
+    if not SEGMENTS_FILE.exists():
+        logger.error(f"No segments file at {SEGMENTS_FILE}. Run --phase extract first.")
+        return
+
+    segments = json.loads(SEGMENTS_FILE.read_text())
+    logger.info(f"Classifying {len(segments)} segments...")
+
+    # Deduplicate Arabic text for classification
+    unique_texts: dict[str, dict] = {}
+    for seg in segments:
+        text = seg["arabic_text"].strip()
+        if text not in unique_texts:
+            unique_texts[text] = seg
+
+    unique_list = list(unique_texts.values())
+    logger.info(f"  {len(unique_list)} unique Arabic texts (after dedup)")
+
+    # Process in batches of 25
+    batch_size = 25
+    all_classified: list[dict] = []
+
+    for i in range(0, len(unique_list), batch_size):
+        batch = unique_list[i:i + batch_size]
+        logger.info(f"  Classifying batch {i // batch_size + 1} ({len(batch)} segments)...")
+
+        entries = []
+        for seg in batch:
+            entries.append({
+                "arabic": seg["arabic_text"],
+                "english_context": seg["english_context"][:200],
+            })
+
+        prompt = f"""You are analyzing Arabic segments from a Michel Thomas Egyptian Arabic course.
+For each segment, provide:
+
+1. "arabic_cleaned": The segment with correct Arabic spelling and FULL diacritics (tashkeel on every letter)
+2. "english": Concise English translation
+3. "dialect_status": One of:
+   - "msa" — Standard MSA word/phrase
+   - "shared" — Used in both Egyptian and MSA (same form, same meaning)
+   - "egyptian_with_msa_equivalent" — Egyptian form with a clear MSA equivalent
+   - "egyptian_only" — Egyptian-only with no clean MSA mapping
+4. "msa_equivalent": If dialect_status is "egyptian_with_msa_equivalent", the MSA form with full diacritics. Otherwise null.
+5. "words": List of individual words in base/dictionary form, each with:
+   - "arabic": base form with diacritics
+   - "english": gloss
+   - "pos": part of speech (noun/verb/adj/adv/prep/particle/conj/pron)
+
+The English context from the lesson is provided to help with meaning.
+Only extract meaningful content words (skip filler, hesitations, repetitions).
+
+Segments:
+{json.dumps(entries, ensure_ascii=False, indent=2)}
+
+Respond with JSON: {{"classifications": [...]}}"""
+
+        try:
+            result = generate_completion(
+                prompt=prompt,
+                system_prompt="You are an Arabic linguistics expert. Respond with JSON only.",
+                json_mode=True,
+                temperature=0.3,
+                model_override="claude_haiku",
+            )
+            classifications = result.get("classifications", [])
+            for j, cls in enumerate(classifications):
+                cls["original_arabic"] = batch[j]["arabic_text"]
+                cls["track"] = batch[j]["track"]
+                cls["english_context"] = batch[j]["english_context"]
+                cls["start_ms"] = batch[j]["start_ms"]
+                cls["end_ms"] = batch[j]["end_ms"]
+            all_classified.extend(classifications)
+        except Exception as e:
+            logger.error(f"  LLM classification failed for batch: {e}")
+            # Add unclassified entries
+            for seg in batch:
+                all_classified.append({
+                    "original_arabic": seg["arabic_text"],
+                    "arabic_cleaned": seg["arabic_text"],
+                    "english": "",
+                    "dialect_status": "unknown",
+                    "msa_equivalent": None,
+                    "words": [],
+                    "track": seg["track"],
+                    "english_context": seg["english_context"],
+                })
+
+    CLASSIFIED_FILE.write_text(json.dumps(all_classified, ensure_ascii=False, indent=2))
+
+    # Stats
+    by_status = {}
+    for c in all_classified:
+        status = c.get("dialect_status", "unknown")
+        by_status[status] = by_status.get(status, 0) + 1
+    logger.info(f"Classification complete → {CLASSIFIED_FILE}")
+    logger.info(f"  Status breakdown: {by_status}")
+
+    # Count total unique words
+    all_words = set()
+    for c in all_classified:
+        for w in c.get("words", []):
+            all_words.add(w.get("arabic", ""))
+    logger.info(f"  Total unique words across all segments: {len(all_words)}")
+
+
+# --------------------------------------------------------------------------- #
+# Phase 4: Database import
+# --------------------------------------------------------------------------- #
+
+def phase_import(dry_run: bool = False):
+    """Import classified segments into the database."""
+    from fsrs import Scheduler, Card, Rating
+    from app.services.sentence_validator import (
+        build_lemma_lookup,
+        resolve_existing_lemma,
+        strip_diacritics,
+        normalize_alef,
+        tokenize_display,
+        map_tokens_to_lemmas,
+    )
+    from app.services.transliteration import transliterate_arabic
+    from app.services.activity_log import log_activity
+
+    if not CLASSIFIED_FILE.exists():
+        logger.error(f"No classified file at {CLASSIFIED_FILE}. Run --phase classify first.")
+        return
+
+    classified = json.loads(CLASSIFIED_FILE.read_text())
+    logger.info(f"Importing from {len(classified)} classified segments...")
+
+    db = SessionLocal()
+    Base.metadata.create_all(bind=engine)
+
+    try:
+        # Build lemma lookup for dedup
+        all_lemmas = db.query(Lemma).all()
+        lemma_lookup = build_lemma_lookup(all_lemmas)
+        existing_bares = {normalize_alef(l.lemma_ar_bare) for l in all_lemmas}
+
+        # Collect all words to import (dedup across segments)
+        words_to_import: dict[str, dict] = {}  # bare_form -> word_info
+        sentences_to_import: list[dict] = []
+        skipped_egyptian = []
+
+        for seg in classified:
+            status = seg.get("dialect_status", "unknown")
+            if status == "egyptian_only":
+                skipped_egyptian.append(seg)
+                continue
+
+            # Use MSA equivalent if available
+            arabic_text = seg.get("arabic_cleaned", seg.get("original_arabic", ""))
+            if status == "egyptian_with_msa_equivalent" and seg.get("msa_equivalent"):
+                arabic_text = seg["msa_equivalent"]
+
+            english = seg.get("english", "")
+            original_tokens = tokenize(arabic_text)
+
+            # Collect words
+            for word_info in seg.get("words", []):
+                word_ar = word_info.get("arabic", "").strip()
+                if not word_ar:
+                    continue
+                bare = strip_diacritics(word_ar)
+                bare_norm = normalize_alef(bare)
+                if bare_norm not in words_to_import:
+                    words_to_import[bare_norm] = {
+                        "arabic": word_ar,
+                        "bare": bare,
+                        "english": word_info.get("english", ""),
+                        "pos": word_info.get("pos", ""),
+                    }
+
+            # Collect sentences (3+ words)
+            if len(original_tokens) >= MIN_ARABIC_WORDS and english:
+                sentences_to_import.append({
+                    "arabic": arabic_text,
+                    "english": english,
+                    "track": seg.get("track", ""),
+                })
+
+        logger.info(f"  Words to process: {len(words_to_import)}")
+        logger.info(f"  Sentences to create: {len(sentences_to_import)}")
+        logger.info(f"  Skipped (egyptian_only): {len(skipped_egyptian)}")
+
+        if dry_run:
+            logger.info("\n--- DRY RUN: Words ---")
+            for bare, info in sorted(words_to_import.items()):
+                exists = bare in existing_bares or resolve_existing_lemma(bare, lemma_lookup)
+                marker = "EXISTS" if exists else "NEW"
+                logger.info(f"  [{marker}] {info['arabic']} ({info['bare']}) = {info['english']}")
+
+            logger.info(f"\n--- DRY RUN: Sentences ({len(sentences_to_import)}) ---")
+            for s in sentences_to_import[:10]:
+                logger.info(f"  {s['arabic']} = {s['english']}")
+            if len(sentences_to_import) > 10:
+                logger.info(f"  ... and {len(sentences_to_import) - 10} more")
+
+            logger.info(f"\n--- DRY RUN: Skipped Egyptian ({len(skipped_egyptian)}) ---")
+            for s in skipped_egyptian[:10]:
+                logger.info(f"  {s.get('arabic_cleaned', s.get('original_arabic', ''))} = {s.get('english', '')}")
+            return
+
+        # --- Actually import ---
+
+        # 1. Create Story for CD
+        story = Story(
+            title_ar="ميشيل توماس - العربية المصرية",
+            title_en="Michel Thomas Egyptian Arabic - CD 1",
+            body_ar="",
+            body_en="",
+            source="michel_thomas",
+            status="completed",
+            difficulty_level="beginner",
+        )
+        db.add(story)
+        db.flush()
+        logger.info(f"  Created Story id={story.id}")
+
+        # 2. Import words
+        new_lemma_ids: list[int] = []
+        n_existing = 0
+        now = datetime.now(timezone.utc)
+
+        for bare_norm, info in words_to_import.items():
+            # Check existing
+            if bare_norm in existing_bares:
+                n_existing += 1
+                continue
+            existing_id = resolve_existing_lemma(info["bare"], lemma_lookup)
+            if existing_id:
+                n_existing += 1
+                continue
+
+            # Strip al-prefix for canonical bare
+            bare = info["bare"]
+            canonical_bare = bare[2:] if bare.startswith("ال") and len(bare) > 2 else bare
+            canonical_norm = normalize_alef(canonical_bare)
+
+            # Skip if canonical form exists
+            if canonical_norm in existing_bares:
+                n_existing += 1
+                continue
+
+            # Create lemma
+            lemma = Lemma(
+                lemma_ar=info["arabic"],
+                lemma_ar_bare=canonical_bare,
+                pos=info.get("pos", ""),
+                gloss_en=info["english"],
+                source="michel_thomas",
+            )
+            db.add(lemma)
+            db.flush()
+
+            # Create ULK as "learning" with fresh FSRS card (skip Leitner)
+            scheduler = Scheduler()
+            card = Card()
+            reviewed_card, _ = scheduler.review_card(card, Rating.Good, now)
+
+            ulk = UserLemmaKnowledge(
+                lemma_id=lemma.lemma_id,
+                knowledge_state="learning",
+                fsrs_card_json=reviewed_card.to_dict(),
+                source="michel_thomas",
+                times_seen=5,
+                times_correct=4,
+                total_encounters=10,
+                introduced_at=now,
+                graduated_at=now,
+            )
+            db.add(ulk)
+            new_lemma_ids.append(lemma.lemma_id)
+
+            # Update lookup
+            existing_bares.add(canonical_norm)
+            lemma_lookup[canonical_norm] = lemma.lemma_id
+            if bare_norm != canonical_norm:
+                existing_bares.add(bare_norm)
+
+        logger.info(f"  Created {len(new_lemma_ids)} new lemmas, {n_existing} already existed")
+
+        # 3. Rebuild lemma lookup with new lemmas for sentence mapping
+        all_lemmas = db.query(Lemma).all()
+        lemma_lookup = build_lemma_lookup(all_lemmas)
+
+        # 4. Create sentences
+        n_sentences = 0
+        for sent_data in sentences_to_import:
+            arabic = sent_data["arabic"]
+            english = sent_data["english"]
+            tokens = tokenize_display(arabic)
+
+            if len(tokens) < MIN_ARABIC_WORDS:
+                continue
+
+            mappings = map_tokens_to_lemmas(
+                tokens=tokens,
+                lemma_lookup=lemma_lookup,
+                target_lemma_id=0,
+                target_bare="",
+            )
+
+            # Pick primary target (rarest word)
+            target_lid = _pick_primary_target_simple(mappings, db)
+
+            try:
+                translit = transliterate_arabic(arabic)
+            except Exception:
+                translit = ""
+
+            sent = Sentence(
+                arabic_text=arabic,
+                english_translation=english,
+                transliteration=translit,
+                source="michel_thomas",
+                target_lemma_id=target_lid,
+                story_id=story.id,
+                is_active=True,
+                created_at=now,
+                max_word_count=len(tokens),
+            )
+            db.add(sent)
+            db.flush()
+
+            for m in mappings:
+                sw = SentenceWord(
+                    sentence_id=sent.id,
+                    position=m.position,
+                    surface_form=m.surface_form,
+                    lemma_id=m.lemma_id,
+                    is_target_word=(m.lemma_id == target_lid) if target_lid else False,
+                )
+                db.add(sw)
+
+            n_sentences += 1
+
+        logger.info(f"  Created {n_sentences} sentences")
+
+        # 5. Update story body with all sentence text
+        all_sents = (
+            db.query(Sentence)
+            .filter(Sentence.story_id == story.id)
+            .order_by(Sentence.id)
+            .all()
+        )
+        story.body_ar = "\n".join(s.arabic_text for s in all_sents)
+        story.body_en = "\n".join(s.english_translation or "" for s in all_sents)
+
+        # 6. Variant detection on new lemmas
+        variants_marked = 0
+        if new_lemma_ids:
+            try:
+                from app.services.variant_detection import (
+                    detect_variants_llm,
+                    detect_definite_variants,
+                    mark_variants,
+                )
+                camel_vars = detect_variants_llm(db, lemma_ids=new_lemma_ids)
+                already = {v[0] for v in camel_vars}
+                def_vars = detect_definite_variants(
+                    db, lemma_ids=new_lemma_ids, already_variant_ids=already
+                )
+                all_vars = camel_vars + def_vars
+                if all_vars:
+                    variants_marked = mark_variants(db, all_vars)
+                    for var_id, canon_id, vtype, _ in all_vars:
+                        var = db.get(Lemma, var_id)
+                        canon = db.get(Lemma, canon_id)
+                        logger.info(f"  Variant: {var.lemma_ar_bare} → {canon.lemma_ar_bare} [{vtype}]")
+            except Exception as e:
+                logger.warning(f"  Variant detection failed: {e}")
+
+        # 7. Activity log
+        try:
+            log_activity(db, "michel_thomas_imported", (
+                f"Imported CD1: {len(new_lemma_ids)} new words, "
+                f"{n_existing} existing, {n_sentences} sentences, "
+                f"{len(skipped_egyptian)} Egyptian-only skipped"
+            ), {
+                "cd": 1,
+                "words_new": len(new_lemma_ids),
+                "words_existing": n_existing,
+                "sentences": n_sentences,
+                "egyptian_skipped": len(skipped_egyptian),
+                "variants_marked": variants_marked,
+            })
+        except Exception as e:
+            logger.warning(f"  Activity logging failed: {e}")
+
+        db.commit()
+        logger.info("Import complete!")
+        logger.info(f"  Story: id={story.id}")
+        logger.info(f"  New words: {len(new_lemma_ids)}")
+        logger.info(f"  Existing: {n_existing}")
+        logger.info(f"  Sentences: {n_sentences}")
+        logger.info(f"  Variants: {variants_marked}")
+        logger.info(f"  Egyptian skipped: {len(skipped_egyptian)}")
+
+        # Save Egyptian-only words for reference
+        if skipped_egyptian:
+            egyptian_file = DATA_DIR / "skipped_egyptian.json"
+            egyptian_file.write_text(json.dumps(skipped_egyptian, ensure_ascii=False, indent=2))
+            logger.info(f"  Egyptian-only words saved to {egyptian_file}")
+
+    finally:
+        db.close()
+
+
+def _pick_primary_target_simple(mappings: list, db) -> int | None:
+    """Pick rarest word as primary target (simplified version)."""
+    lemma_ids = [m.lemma_id for m in mappings if m.lemma_id]
+    if not lemma_ids:
+        return None
+
+    lemmas = (
+        db.query(Lemma.lemma_id, Lemma.frequency_rank)
+        .filter(Lemma.lemma_id.in_(lemma_ids))
+        .all()
+    )
+    ranked = sorted(lemmas, key=lambda l: l.frequency_rank or 999999, reverse=True)
+    return ranked[0].lemma_id if ranked else lemma_ids[0]
+
+
+# --------------------------------------------------------------------------- #
+# Phase 5: Verify
+# --------------------------------------------------------------------------- #
+
+def phase_verify():
+    """Print verification report."""
+    db = SessionLocal()
+    Base.metadata.create_all(bind=engine)
+
+    try:
+        # Stories
+        stories = db.query(Story).filter(Story.source == "michel_thomas").all()
+        print(f"\n=== Michel Thomas Stories ({len(stories)}) ===")
+        for s in stories:
+            print(f"  id={s.id} | {s.title_en} | status={s.status}")
+
+        # Words
+        mt_lemmas = (
+            db.query(Lemma)
+            .filter(Lemma.source == "michel_thomas")
+            .all()
+        )
+        print(f"\n=== Words ({len(mt_lemmas)}) ===")
+        for l in mt_lemmas[:20]:
+            ulk = db.query(UserLemmaKnowledge).filter(
+                UserLemmaKnowledge.lemma_id == l.lemma_id
+            ).first()
+            state = ulk.knowledge_state if ulk else "no ULK"
+            print(f"  {l.lemma_ar} ({l.lemma_ar_bare}) = {l.gloss_en} [{state}]")
+        if len(mt_lemmas) > 20:
+            print(f"  ... and {len(mt_lemmas) - 20} more")
+
+        # Sentences
+        mt_sents = (
+            db.query(Sentence)
+            .filter(Sentence.source == "michel_thomas")
+            .all()
+        )
+        print(f"\n=== Sentences ({len(mt_sents)}) ===")
+        for s in mt_sents[:15]:
+            print(f"  [{s.id}] {s.arabic_text}")
+            print(f"       = {s.english_translation}")
+        if len(mt_sents) > 15:
+            print(f"  ... and {len(mt_sents) - 15} more")
+
+        # Skipped Egyptian
+        egyptian_file = DATA_DIR / "skipped_egyptian.json"
+        if egyptian_file.exists():
+            skipped = json.loads(egyptian_file.read_text())
+            print(f"\n=== Skipped Egyptian-Only ({len(skipped)}) ===")
+            for s in skipped[:10]:
+                print(f"  {s.get('arabic_cleaned', s.get('original_arabic', ''))} = {s.get('english', '')}")
+
+    finally:
+        db.close()
+
+
+# --------------------------------------------------------------------------- #
+# Main
+# --------------------------------------------------------------------------- #
+
+def main():
+    parser = argparse.ArgumentParser(description="Import Michel Thomas Arabic audio course")
+    parser.add_argument("--audio-dir", type=Path, help="Directory with MP3 files")
+    parser.add_argument("--soniox-key", type=str, help="Soniox API key (or set SONIOX_API_KEY env)")
+    parser.add_argument("--phase", choices=["transcribe", "extract", "classify", "import", "verify", "all"],
+                        default="all", help="Which phase to run")
+    parser.add_argument("--dry-run", action="store_true", help="Show what would be imported")
+    args = parser.parse_args()
+
+    # Resolve Soniox key
+    import os
+    soniox_key = args.soniox_key or os.environ.get("SONIOX_API_KEY", "")
+
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+
+    if args.phase in ("transcribe", "all"):
+        if not args.audio_dir:
+            parser.error("--audio-dir required for transcribe phase")
+        if not soniox_key:
+            parser.error("--soniox-key or SONIOX_API_KEY required for transcribe phase")
+        phase_transcribe(args.audio_dir, soniox_key)
+
+    if args.phase in ("extract", "all"):
+        phase_extract()
+
+    if args.phase in ("classify", "all"):
+        phase_classify()
+
+    if args.phase in ("import", "all"):
+        phase_import(dry_run=args.dry_run)
+
+    if args.phase in ("verify", "all"):
+        phase_verify()
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/investigate_mapping_flags.py
+++ b/backend/scripts/investigate_mapping_flags.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Investigate and fix word_mapping flags.
+
+Lists sentences flagged for poor lemmatization, shows current word-lemma
+mappings, and optionally re-evaluates and fixes them.
+
+Usage:
+    python3 scripts/investigate_mapping_flags.py              # show pending flags
+    python3 scripts/investigate_mapping_flags.py --all        # show all statuses
+    python3 scripts/investigate_mapping_flags.py --fix        # re-evaluate and fix pending flags
+"""
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from app.database import SessionLocal
+from app.models import ContentFlag, Lemma, Sentence, SentenceWord
+
+
+def show_flag(db, flag):
+    """Display a single flag with its sentence and word mappings."""
+    print(f"\n{'='*60}")
+    print(f"Flag #{flag.id}  status={flag.status}  created={flag.created_at}")
+    if flag.resolution_note:
+        print(f"  Resolution: {flag.resolution_note}")
+
+    sentence = db.query(Sentence).filter(Sentence.id == flag.sentence_id).first()
+    if not sentence:
+        print("  Sentence not found!")
+        return
+
+    print(f"  Arabic: {sentence.arabic_text}")
+    print(f"  English: {sentence.english_translation}")
+    print(f"  Source: {sentence.source}  Active: {sentence.is_active}")
+
+    words = (
+        db.query(SentenceWord)
+        .filter(SentenceWord.sentence_id == sentence.id)
+        .order_by(SentenceWord.position)
+        .all()
+    )
+
+    lemma_ids = [w.lemma_id for w in words if w.lemma_id]
+    lemmas_by_id = {}
+    if lemma_ids:
+        for lemma in db.query(Lemma).filter(Lemma.lemma_id.in_(lemma_ids)).all():
+            lemmas_by_id[lemma.lemma_id] = lemma
+
+    print("  Word mappings:")
+    for w in words:
+        lemma = lemmas_by_id.get(w.lemma_id)
+        if lemma:
+            marker = " *" if flag.lemma_id and w.lemma_id == flag.lemma_id else ""
+            print(f"    [{w.position}] {w.surface_form:>15} → {lemma.lemma_ar_bare} ({lemma.gloss_en}){marker}")
+        else:
+            print(f"    [{w.position}] {w.surface_form:>15} → (unmapped)")
+
+    if flag.corrected_value:
+        print(f"  Corrections applied: {flag.corrected_value}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Investigate word_mapping flags")
+    parser.add_argument("--all", action="store_true", help="Show all statuses (not just pending)")
+    parser.add_argument("--fix", action="store_true", help="Re-evaluate and fix pending flags")
+    args = parser.parse_args()
+
+    db = SessionLocal()
+    try:
+        q = db.query(ContentFlag).filter(ContentFlag.content_type == "word_mapping")
+        if not args.all:
+            q = q.filter(ContentFlag.status.in_(["pending", "reviewing"]))
+        flags = q.order_by(ContentFlag.created_at.desc()).all()
+
+        print(f"Found {len(flags)} word_mapping flag(s)")
+
+        for flag in flags:
+            show_flag(db, flag)
+
+        if args.fix:
+            pending = [f for f in flags if f.status in ("pending", "reviewing")]
+            if not pending:
+                print("\nNo pending flags to fix.")
+                return
+
+            print(f"\nRe-evaluating {len(pending)} pending flag(s)...")
+            from app.services.flag_evaluator import evaluate_flag
+
+            for flag in pending:
+                # Reset to pending so evaluator picks it up
+                flag.status = "pending"
+                db.commit()
+                print(f"  Evaluating flag #{flag.id}...")
+                evaluate_flag(flag.id)
+                # Reload to show result
+                db.refresh(flag)
+                print(f"    → {flag.status}: {flag.resolution_note}")
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/simulate_sessions.py
+++ b/backend/scripts/simulate_sessions.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Simulate a student's learning journey over multiple days.
+
+Drives the real Alif service stack against a copy of the production database.
+
+Usage:
+    python3 scripts/simulate_sessions.py --days 30 --profile beginner
+    python3 scripts/simulate_sessions.py --days 60 --profile strong --db ~/alif-backups/alif_20260210.db
+    python3 scripts/simulate_sessions.py --days 30 --profile casual --csv /tmp/claude/sim.csv
+"""
+
+import argparse
+import logging
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+os.environ["ALIF_SKIP_MIGRATIONS"] = "1"
+os.environ["TESTING"] = "1"
+
+from datetime import datetime, timezone
+
+from app.simulation.db_setup import create_simulation_db, find_latest_backup
+from app.simulation.reporter import print_console_report, write_csv_report
+from app.simulation.runner import run_simulation
+from app.simulation.student import PROFILES
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Simulate a student's learning journey over multiple days"
+    )
+    parser.add_argument("--days", type=int, required=True, help="Number of days to simulate")
+    parser.add_argument(
+        "--profile",
+        choices=list(PROFILES.keys()),
+        required=True,
+        help="Student behavior profile",
+    )
+    parser.add_argument("--db", type=str, help="Path to DB backup (default: latest from ~/alif-backups/)")
+    parser.add_argument("--csv", type=str, help="Write CSV report to this path")
+    parser.add_argument("--seed", type=int, default=42, help="Random seed (default: 42)")
+    parser.add_argument(
+        "--start-date",
+        type=str,
+        help="Simulation start date YYYY-MM-DD (default: 2026-03-01)",
+    )
+    parser.add_argument("--verbose", action="store_true", help="Enable debug logging")
+    args = parser.parse_args()
+
+    if args.verbose:
+        logging.basicConfig(level=logging.DEBUG)
+    else:
+        logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+    db_path = args.db or find_latest_backup()
+    print(f"Source DB: {db_path}")
+
+    engine, SessionFactory, tmp_path = create_simulation_db(db_path)
+    print(f"Simulation DB: {tmp_path}")
+
+    profile = PROFILES[args.profile]
+    start_date = None
+    if args.start_date:
+        start_date = datetime.strptime(args.start_date, "%Y-%m-%d").replace(
+            tzinfo=timezone.utc
+        )
+
+    print(f"Profile: {profile.name}, Days: {args.days}, Seed: {args.seed}")
+    print()
+
+    db = SessionFactory()
+    try:
+        snapshots = run_simulation(
+            db, args.days, profile, start_date=start_date, seed=args.seed
+        )
+        print_console_report(snapshots, profile_name=profile.name)
+        if args.csv:
+            write_csv_report(snapshots, args.csv)
+    finally:
+        db.close()
+        engine.dispose()
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/validate_sentence_cli.py
+++ b/backend/scripts/validate_sentence_cli.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""CLI wrapper around sentence_validator for use by Claude Code sessions.
+
+Validates an Arabic sentence against a vocabulary lookup file, checking that
+the target word is present and all other words are known.
+
+Usage:
+    python3 scripts/validate_sentence_cli.py \
+      --arabic "الوَلَدُ يَقْرَأُ الكِتَابَ" \
+      --target-bare "كتاب" \
+      --vocab-file /tmp/claude/lookup.tsv
+
+    # Multi-target validation
+    python3 scripts/validate_sentence_cli.py \
+      --arabic "الوَلَدُ يَقْرَأُ الكِتَابَ فِي البَيْتِ" \
+      --target-bare "كتاب,بيت" \
+      --vocab-file /tmp/claude/lookup.tsv
+
+The vocab-file is a TSV with columns: bare_form<TAB>lemma_id
+Built by dump_vocabulary_for_claude() using the same build_lemma_lookup() logic.
+
+Output: JSON on stdout with validation results.
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from app.services.sentence_validator import (
+    normalize_alef,
+    validate_sentence,
+    validate_sentence_multi_target,
+)
+
+
+def load_vocab_lookup(vocab_file: str) -> set[str]:
+    """Load bare forms from a TSV lookup file into a set."""
+    bare_forms: set[str] = set()
+    with open(vocab_file) as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            parts = line.split("\t")
+            if parts:
+                bare_forms.add(parts[0])
+    return bare_forms
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Validate an Arabic sentence against known vocabulary")
+    parser.add_argument("--arabic", required=True, help="Arabic sentence text (with or without diacritics)")
+    parser.add_argument("--target-bare", required=True, help="Bare form(s) of target word(s), comma-separated for multi-target")
+    parser.add_argument("--vocab-file", required=True, help="Path to TSV file with bare_form<TAB>lemma_id")
+    args = parser.parse_args()
+
+    known_bare_forms = load_vocab_lookup(args.vocab_file)
+    targets = [t.strip() for t in args.target_bare.split(",") if t.strip()]
+
+    if len(targets) == 1:
+        result = validate_sentence(
+            arabic_text=args.arabic,
+            target_bare=targets[0],
+            known_bare_forms=known_bare_forms,
+        )
+        output = {
+            "valid": result.valid,
+            "target_found": result.target_found,
+            "unknown_words": result.unknown_words,
+            "known_words": result.known_words,
+            "function_words": result.function_words,
+            "issues": result.issues,
+        }
+    else:
+        target_bares = {t: i for i, t in enumerate(targets)}
+        result = validate_sentence_multi_target(
+            arabic_text=args.arabic,
+            target_bares=target_bares,
+            known_bare_forms=known_bare_forms,
+        )
+        output = {
+            "valid": result.valid,
+            "targets_found": result.targets_found,
+            "target_count": result.target_count,
+            "unknown_words": result.unknown_words,
+            "known_words": result.known_words,
+            "function_words": result.function_words,
+            "issues": result.issues,
+        }
+
+    print(json.dumps(output, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/test_n_plus_one.py
+++ b/backend/tests/test_n_plus_one.py
@@ -1,0 +1,166 @@
+"""Tests for N+1 query fixes in review, words, and story_service."""
+
+from datetime import datetime, timezone, timedelta
+
+import pytest
+
+from app.models import (
+    Lemma, Root, UserLemmaKnowledge, Story, StoryWord,
+)
+from app.services.fsrs_service import create_new_card
+from tests.conftest import count_queries
+
+
+def _make_card(stability_days=30.0):
+    card = create_new_card()
+    card["stability"] = stability_days
+    card["due"] = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+    return card
+
+
+class TestWordLookupSiblingBatch:
+    """Verify word-lookup batches sibling ULK queries instead of N+1."""
+
+    def test_returns_all_siblings_with_correct_states(self, client, db_session):
+        root = Root(root="ك.ت.ب", core_meaning_en="writing")
+        db_session.add(root)
+        db_session.flush()
+
+        # Primary word
+        primary = Lemma(lemma_ar="كِتَاب", lemma_ar_bare="كتاب", root_id=root.root_id, pos="noun", gloss_en="book")
+        db_session.add(primary)
+        db_session.flush()
+        db_session.add(UserLemmaKnowledge(lemma_id=primary.lemma_id, knowledge_state="learning", fsrs_card_json=_make_card(), source="study"))
+
+        # 5 siblings with different states
+        states = ["learning", "known", "encountered", "acquiring", "new"]
+        siblings = []
+        for i, state in enumerate(states):
+            sib = Lemma(lemma_ar=f"sib_{i}", lemma_ar_bare=f"sib_{i}", root_id=root.root_id, pos="noun", gloss_en=f"sib {i}")
+            db_session.add(sib)
+            db_session.flush()
+            if state != "new":
+                db_session.add(UserLemmaKnowledge(lemma_id=sib.lemma_id, knowledge_state=state, fsrs_card_json=_make_card() if state != "encountered" else None, source="study"))
+            siblings.append((sib, state))
+
+        db_session.commit()
+
+        resp = client.get(f"/api/review/word-lookup/{primary.lemma_id}")
+        assert resp.status_code == 200
+        data = resp.json()
+
+        family = data["root_family"]
+        assert len(family) == 5
+
+        family_by_id = {f["lemma_id"]: f for f in family}
+        for sib, expected_state in siblings:
+            entry = family_by_id[sib.lemma_id]
+            assert entry["state"] == expected_state if expected_state != "new" else "new"
+
+    def test_sibling_query_count_is_bounded(self, client, db_session):
+        """Verify we use batch queries, not one per sibling."""
+        root = Root(root="د.ر.س", core_meaning_en="study")
+        db_session.add(root)
+        db_session.flush()
+
+        primary = Lemma(lemma_ar="دَرْس", lemma_ar_bare="درس", root_id=root.root_id, pos="noun", gloss_en="lesson")
+        db_session.add(primary)
+        db_session.flush()
+        db_session.add(UserLemmaKnowledge(lemma_id=primary.lemma_id, knowledge_state="learning", fsrs_card_json=_make_card(), source="study"))
+
+        for i in range(10):
+            sib = Lemma(lemma_ar=f"sib_{i}", lemma_ar_bare=f"sib_{i}", root_id=root.root_id, pos="noun", gloss_en=f"sib {i}")
+            db_session.add(sib)
+            db_session.flush()
+            db_session.add(UserLemmaKnowledge(lemma_id=sib.lemma_id, knowledge_state="learning", fsrs_card_json=_make_card(), source="study"))
+
+        db_session.commit()
+
+        with count_queries(db_session) as counter:
+            resp = client.get(f"/api/review/word-lookup/{primary.lemma_id}")
+
+        assert resp.status_code == 200
+        assert len(resp.json()["root_family"]) == 10
+        # With batch: should be ~4 queries (lemma, siblings, ULKs batch, grammar features)
+        # Without batch: would be 4 + 10 = 14
+        assert counter["count"] <= 8
+
+
+class TestProperNamesBatch:
+    """Verify proper names endpoint batches story lookups."""
+
+    def test_returns_names_with_story_titles(self, client, db_session):
+        story1 = Story(title_ar="قصة ١", title_en="Story 1", body_ar="text", source="imported", status="active")
+        story2 = Story(title_ar="قصة ٢", title_en="Story 2", body_ar="text", source="imported", status="active")
+        db_session.add_all([story1, story2])
+        db_session.flush()
+
+        sw1 = StoryWord(story_id=story1.id, position=0, surface_form="أحمد", name_type="personal", gloss_en="Ahmed")
+        sw2 = StoryWord(story_id=story2.id, position=0, surface_form="القاهرة", name_type="place", gloss_en="Cairo")
+        sw3 = StoryWord(story_id=story1.id, position=1, surface_form="فاطمة", name_type="personal", gloss_en="Fatima")
+        db_session.add_all([sw1, sw2, sw3])
+        db_session.commit()
+
+        resp = client.get("/api/words?category=names")
+        assert resp.status_code == 200
+        data = resp.json()
+
+        assert len(data) == 3
+        titles = {d["surface_form"]: d["story_title"] for d in data}
+        assert titles["أحمد"] == "Story 1"
+        assert titles["القاهرة"] == "Story 2"
+        assert titles["فاطمة"] == "Story 1"
+
+    def test_name_query_count_is_bounded(self, client, db_session):
+        """Verify we batch-load stories, not one per name."""
+        stories = []
+        for i in range(5):
+            s = Story(title_en=f"Story {i}", body_ar="text", source="imported", status="active")
+            db_session.add(s)
+            db_session.flush()
+            stories.append(s)
+
+        for i, s in enumerate(stories):
+            for j in range(3):
+                sw = StoryWord(story_id=s.id, position=j, surface_form=f"name_{i}_{j}", name_type="personal", gloss_en=f"Name {i}.{j}")
+                db_session.add(sw)
+        db_session.commit()
+
+        with count_queries(db_session) as counter:
+            resp = client.get("/api/words?category=names")
+
+        assert resp.status_code == 200
+        # With batch: 2 queries (story_words + stories batch)
+        # Without batch: 1 + N (one per unique name)
+        assert counter["count"] <= 4
+
+
+class TestStoryKnowledgeMapScope:
+    """Verify story knowledge map uses scoped queries."""
+
+    def test_get_story_detail_scoped(self, db_session):
+        from app.services.story_service import get_story_detail
+
+        # Create words in DB that are NOT part of the story
+        other_lemma = Lemma(lemma_ar="أخرى", lemma_ar_bare="اخرى", pos="adj", gloss_en="other")
+        db_session.add(other_lemma)
+        db_session.flush()
+        db_session.add(UserLemmaKnowledge(lemma_id=other_lemma.lemma_id, knowledge_state="known", source="study"))
+
+        # Create story with one word
+        story_lemma = Lemma(lemma_ar="كِتَاب", lemma_ar_bare="كتاب", pos="noun", gloss_en="book")
+        db_session.add(story_lemma)
+        db_session.flush()
+        db_session.add(UserLemmaKnowledge(lemma_id=story_lemma.lemma_id, knowledge_state="learning", source="study"))
+
+        story = Story(title_en="Test", body_ar="كتاب", source="imported", status="active")
+        db_session.add(story)
+        db_session.flush()
+
+        sw = StoryWord(story_id=story.id, position=0, surface_form="كِتَاب", lemma_id=story_lemma.lemma_id)
+        db_session.add(sw)
+        db_session.commit()
+
+        result = get_story_detail(db_session, story.id)
+        assert len(result["words"]) == 1
+        assert result["words"][0]["is_known"] is True

--- a/backend/tests/test_simulation.py
+++ b/backend/tests/test_simulation.py
@@ -1,0 +1,263 @@
+"""Integration tests for the simulation framework.
+
+Uses in-memory SQLite with synthetic data (no production backup needed).
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app.models import Lemma, Root, Sentence, SentenceWord, UserLemmaKnowledge
+from app.services.fsrs_service import create_new_card
+from app.simulation.runner import run_simulation
+from app.simulation.student import BEGINNER, CASUAL, STRONG
+
+
+def _seed_simulation_data(db):
+    """Create minimal realistic data for simulation testing.
+
+    Creates 20 lemmas across states + sentences with word breakdowns
+    so that build_session() can assemble a session.
+    """
+    root = Root(root_id=1, root="ك.ت.ب", core_meaning_en="writing")
+    db.add(root)
+    db.flush()
+
+    now = datetime(2026, 2, 28, tzinfo=timezone.utc)
+
+    # Create 20 lemmas
+    for i in range(1, 21):
+        lemma = Lemma(
+            lemma_id=i,
+            lemma_ar=f"كلمة{i}",
+            lemma_ar_bare=f"كلمه{i}",
+            pos="noun",
+            gloss_en=f"word{i}",
+            frequency_rank=i * 100,
+            root_id=1 if i <= 5 else None,
+        )
+        db.add(lemma)
+    db.flush()
+
+    # Create ULK records with a mix of states
+    for i in range(1, 21):
+        if i <= 5:
+            # Known words — stable FSRS cards, past due
+            card = create_new_card()
+            card["stability"] = 15.0 + i
+            card["difficulty"] = 2.1
+            card["due"] = (now - timedelta(hours=i)).isoformat()
+            card["last_review"] = (now - timedelta(days=2)).isoformat()
+            card["state"] = 2  # Review state
+            card["step"] = None
+            ulk = UserLemmaKnowledge(
+                lemma_id=i,
+                knowledge_state="known",
+                fsrs_card_json=card,
+                times_seen=10 + i,
+                times_correct=8 + i,
+                introduced_at=now - timedelta(days=30),
+                last_reviewed=now - timedelta(days=2),
+                source="duolingo",
+            )
+        elif i <= 10:
+            # Learning words — moderate FSRS cards
+            card = create_new_card()
+            card["stability"] = 3.0
+            card["difficulty"] = 3.0
+            card["due"] = (now - timedelta(hours=1)).isoformat()
+            card["last_review"] = (now - timedelta(days=1)).isoformat()
+            card["state"] = 2
+            card["step"] = None
+            ulk = UserLemmaKnowledge(
+                lemma_id=i,
+                knowledge_state="learning",
+                fsrs_card_json=card,
+                times_seen=5,
+                times_correct=3,
+                introduced_at=now - timedelta(days=10),
+                last_reviewed=now - timedelta(days=1),
+                source="study",
+            )
+        elif i <= 15:
+            # Acquiring words — Leitner boxes
+            box = ((i - 11) % 3) + 1
+            ulk = UserLemmaKnowledge(
+                lemma_id=i,
+                knowledge_state="acquiring",
+                acquisition_box=box,
+                acquisition_next_due=now - timedelta(hours=1),
+                acquisition_started_at=now - timedelta(days=3),
+                times_seen=i - 10,
+                times_correct=max(0, i - 11),
+                introduced_at=now - timedelta(days=3),
+                source="study",
+            )
+        else:
+            # Encountered words — passive, not yet introduced
+            ulk = UserLemmaKnowledge(
+                lemma_id=i,
+                knowledge_state="encountered",
+                total_encounters=3,
+                source="encountered",
+            )
+        db.add(ulk)
+    db.flush()
+
+    # Create sentences covering words 1-15 (the ones with active states)
+    # Each sentence has its target word + 2 known scaffold words
+    for i in range(1, 16):
+        sent = Sentence(
+            id=i,
+            arabic_text=f"جُمْلَةٌ تَحْتَوِي عَلَى كَلِمَة{i}",
+            english_translation=f"A sentence containing word{i}",
+            target_lemma_id=i,
+            is_active=True,
+        )
+        db.add(sent)
+        db.flush()
+
+        # Target word
+        db.add(
+            SentenceWord(
+                sentence_id=i,
+                position=0,
+                surface_form=f"كلمة{i}",
+                lemma_id=i,
+                is_target_word=True,
+            )
+        )
+        # Two known scaffold words
+        for j, scaffold_id in enumerate([((i - 1) % 5) + 1, ((i) % 5) + 1]):
+            db.add(
+                SentenceWord(
+                    sentence_id=i,
+                    position=j + 1,
+                    surface_form=f"كلمة{scaffold_id}",
+                    lemma_id=scaffold_id,
+                    is_target_word=False,
+                )
+            )
+    db.flush()
+
+    # Add a second sentence for some words (to give the selector options)
+    for i in range(1, 6):
+        sent_id = 100 + i
+        sent = Sentence(
+            id=sent_id,
+            arabic_text=f"جُمْلَةٌ ثَانِيَةٌ مَعَ كَلِمَة{i}",
+            english_translation=f"A second sentence with word{i}",
+            target_lemma_id=i,
+            is_active=True,
+        )
+        db.add(sent)
+        db.flush()
+
+        db.add(
+            SentenceWord(
+                sentence_id=sent_id,
+                position=0,
+                surface_form=f"كلمة{i}",
+                lemma_id=i,
+                is_target_word=True,
+            )
+        )
+        for j, scaffold_id in enumerate([((i) % 5) + 1, ((i + 1) % 5) + 1]):
+            db.add(
+                SentenceWord(
+                    sentence_id=sent_id,
+                    position=j + 1,
+                    surface_form=f"كلمة{scaffold_id}",
+                    lemma_id=scaffold_id,
+                    is_target_word=False,
+                )
+            )
+    db.flush()
+    db.commit()
+
+
+class TestSimulationBasic:
+    def test_beginner_7_days(self, db_session):
+        _seed_simulation_data(db_session)
+        snapshots = run_simulation(
+            db_session,
+            days=7,
+            profile=BEGINNER,
+            start_date=datetime(2026, 3, 1, tzinfo=timezone.utc),
+        )
+        assert len(snapshots) == 7
+        active_days = [s for s in snapshots if not s.skipped]
+        assert len(active_days) >= 2
+        assert any(s.reviews_submitted > 0 for s in active_days)
+
+    def test_strong_7_days(self, db_session):
+        _seed_simulation_data(db_session)
+        snapshots = run_simulation(
+            db_session,
+            days=7,
+            profile=STRONG,
+            start_date=datetime(2026, 3, 1, tzinfo=timezone.utc),
+        )
+        active_days = [s for s in snapshots if not s.skipped]
+        assert len(active_days) >= 4
+
+    def test_no_crash_empty_db(self, db_session):
+        """Simulation should handle empty DB gracefully."""
+        snapshots = run_simulation(
+            db_session,
+            days=3,
+            profile=BEGINNER,
+            start_date=datetime(2026, 3, 1, tzinfo=timezone.utc),
+        )
+        assert len(snapshots) == 3
+        for s in snapshots:
+            assert s.reviews_submitted == 0
+
+    def test_state_counts_non_negative(self, db_session):
+        _seed_simulation_data(db_session)
+        snapshots = run_simulation(
+            db_session,
+            days=5,
+            profile=CASUAL,
+            start_date=datetime(2026, 3, 1, tzinfo=timezone.utc),
+        )
+        for s in snapshots:
+            assert s.encountered >= 0
+            assert s.acquiring >= 0
+            assert s.learning >= 0
+            assert s.known >= 0
+            assert s.lapsed >= 0
+            assert s.suspended >= 0
+
+    def test_reviews_change_state(self, db_session):
+        """After simulation, word states should have changed from initial seed."""
+        _seed_simulation_data(db_session)
+        initial_acquiring = (
+            db_session.query(UserLemmaKnowledge)
+            .filter(UserLemmaKnowledge.knowledge_state == "acquiring")
+            .count()
+        )
+        snapshots = run_simulation(
+            db_session,
+            days=14,
+            profile=STRONG,
+            start_date=datetime(2026, 3, 1, tzinfo=timezone.utc),
+        )
+        # Something should have changed
+        final = snapshots[-1]
+        total_active = final.acquiring + final.learning + final.known + final.lapsed
+        assert total_active > 0
+
+    def test_deterministic_with_same_seed(self, db_session):
+        """Same seed should produce same results."""
+        _seed_simulation_data(db_session)
+        snap1 = run_simulation(
+            db_session,
+            days=3,
+            profile=BEGINNER,
+            start_date=datetime(2026, 3, 1, tzinfo=timezone.utc),
+            seed=123,
+        )
+        # Can't easily re-run on same session (state changed),
+        # but we can verify the snapshots are deterministic length
+        assert len(snap1) == 3

--- a/research/history-pkm-people.html
+++ b/research/history-pkm-people.html
@@ -1,0 +1,623 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>History + PKM: People at the Intersection</title>
+<style>
+  :root {
+    --bg: #faf9f6;
+    --card: #ffffff;
+    --text: #2d2d2d;
+    --muted: #6b7280;
+    --accent: #7c3aed;
+    --accent-light: #ede9fe;
+    --border: #e5e7eb;
+    --link: #4f46e5;
+    --tier1: #7c3aed;
+    --tier2: #2563eb;
+    --tier3: #059669;
+  }
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    font-family: 'Georgia', 'Times New Roman', serif;
+    background: var(--bg);
+    color: var(--text);
+    line-height: 1.7;
+    padding: 2rem 1rem;
+  }
+  .container { max-width: 900px; margin: 0 auto; }
+  h1 {
+    font-size: 2.2rem;
+    margin-bottom: 0.3rem;
+    color: var(--text);
+    letter-spacing: -0.02em;
+  }
+  .subtitle {
+    color: var(--muted);
+    font-size: 1.05rem;
+    margin-bottom: 2.5rem;
+    font-style: italic;
+  }
+  .tier-label {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    font-size: 0.75rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    padding: 0.25rem 0.75rem;
+    border-radius: 100px;
+    display: inline-block;
+    margin-bottom: 1.5rem;
+    margin-top: 2.5rem;
+  }
+  .tier-label.t1 { background: #ede9fe; color: var(--tier1); }
+  .tier-label.t2 { background: #dbeafe; color: var(--tier2); }
+  .tier-label.t3 { background: #d1fae5; color: var(--tier3); }
+
+  .person {
+    background: var(--card);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 1.75rem 2rem;
+    margin-bottom: 1.25rem;
+    transition: box-shadow 0.2s;
+  }
+  .person:hover { box-shadow: 0 4px 20px rgba(0,0,0,0.06); }
+
+  .person-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+  }
+  .person h2 {
+    font-size: 1.35rem;
+    color: var(--text);
+    letter-spacing: -0.01em;
+  }
+  .affiliation {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    font-size: 0.82rem;
+    color: var(--muted);
+    flex-shrink: 0;
+  }
+  .person .description {
+    margin-bottom: 1rem;
+    color: #374151;
+  }
+  .links {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+  .links a {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    font-size: 0.8rem;
+    text-decoration: none;
+    color: var(--link);
+    background: #f3f4f6;
+    padding: 0.3rem 0.7rem;
+    border-radius: 6px;
+    transition: background 0.15s;
+    white-space: nowrap;
+  }
+  .links a:hover { background: #e0e7ff; }
+  .links a.email { color: #059669; background: #ecfdf5; }
+  .links a.email:hover { background: #d1fae5; }
+
+  .key-work {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    font-size: 0.82rem;
+    color: var(--muted);
+    margin-top: 0.75rem;
+    padding-top: 0.75rem;
+    border-top: 1px solid var(--border);
+  }
+  .key-work strong { color: #4b5563; }
+
+  .communities {
+    background: var(--card);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 1.75rem 2rem;
+    margin-top: 2.5rem;
+  }
+  .communities h2 {
+    font-size: 1.2rem;
+    margin-bottom: 1rem;
+  }
+  .communities ul {
+    list-style: none;
+    padding: 0;
+  }
+  .communities li {
+    padding: 0.4rem 0;
+    border-bottom: 1px solid var(--border);
+    font-size: 0.95rem;
+  }
+  .communities li:last-child { border-bottom: none; }
+  .communities a { color: var(--link); }
+
+  footer {
+    text-align: center;
+    color: var(--muted);
+    font-size: 0.8rem;
+    margin-top: 3rem;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  }
+</style>
+</head>
+<body>
+<div class="container">
+
+<h1>History + Personal Knowledge Management</h1>
+<p class="subtitle">Researchers and educators working at the intersection of historical scholarship and networked notetaking tools</p>
+
+<!-- ============ TIER 1 ============ -->
+<div class="tier-label t1">Core &mdash; History + PKM is central to their work</div>
+
+<div class="person">
+  <div class="person-header">
+    <h2>Shawn Graham</h2>
+    <span class="affiliation">Carleton University, Ottawa</span>
+  </div>
+  <p class="description">
+    Professor of Digital Humanities who builds entire courses around Obsidian as a research instrument.
+    Students create a "Personal Memex" &mdash; an interconnected knowledge base that grows across the semester.
+    Teaches Zettelkasten methodology as foundational to digital archaeology. His toolchain integrates
+    Hypothes.is &rarr; Zotero &rarr; Obsidian &rarr; GitHub. Practices "open notebook scholarship" &mdash;
+    his blog Electric Archaeology is itself a public lab notebook. Created an Obsidian vault template
+    for game design history courses. Key argument: building a linked knowledge base <em>is itself</em>
+    a form of learning, not just productivity.
+  </p>
+  <div class="links">
+    <a href="https://electricarchaeology.ca/">Blog</a>
+    <a href="https://scholar.social/@electricarchaeo">Mastodon</a>
+    <a href="https://github.com/shawngraham">GitHub (365 repos)</a>
+    <a href="https://shawngraham.github.io/hist1900/">HIST1900 Course</a>
+    <a href="https://digiarch.netlify.app/">HIST3000 Course</a>
+    <a href="https://carleton.ca/history/people/shawn-graham/">Faculty Page</a>
+    <a href="https://scholar.google.com/citations?user=IU6usq8AAAAJ">Google Scholar</a>
+    <a class="email" href="mailto:shawn.graham@carleton.ca">Email</a>
+  </div>
+  <div class="key-work">
+    <strong>Key books:</strong> <em>Practical Necromancy for Beginners</em> (AI for history students, 2025),
+    <em>The Historian's Macroscope</em> (with Milligan &amp; Weingart),
+    <em>An Enchantment of Digital Archaeology</em>,
+    <em>Failing Gloriously</em>
+  </div>
+</div>
+
+<div class="person">
+  <div class="person-header">
+    <h2>Chris Aldrich</h2>
+    <span class="affiliation">Independent researcher, Los Angeles</span>
+  </div>
+  <p class="description">
+    Traces the unbroken lineage from ancient mnemonic practices to modern PKM tools. Core argument:
+    Roam, Obsidian, and Notion are reinventing centuries-old practices while ignoring their predecessors.
+    Studies commonplace books (Erasmus, Locke, Newton), florilegia (900&ndash;1300s CE),
+    Zettelkasten (from Gessner's 1548 <em>Pandectarum</em> through Luhmann), waste books, and
+    Indigenous Australian songlines (~65,000 years of spatial-mnemonic knowledge encoding).
+    Presented a PKM Timeline spanning 35,000 BCE to the present at PKM Summit Utrecht (2024).
+    Johns Hopkins-trained biomedical engineer, active in the IndieWeb community.
+    Over 10,000 public annotations on Hypothes.is.
+  </p>
+  <div class="links">
+    <a href="https://boffosocko.com/">Blog (Digital Commonplace Book)</a>
+    <a href="https://x.com/ChrisAldrich">X/Twitter</a>
+    <a href="https://mastodon.social/@chrisaldrich">Mastodon</a>
+    <a href="https://hypothes.is/users/chrisaldrich">Hypothes.is (10K+ annotations)</a>
+    <a href="https://bsky.app/profile/chrisaldrich.bsky.social">Bluesky</a>
+    <a href="https://github.com/chrisaldrich">GitHub</a>
+    <a href="https://www.youtube.com/christopherjaldrich">YouTube</a>
+    <a href="https://theinformed.life/2024/05/05/episode-139-chris-aldrich/">Podcast Interview</a>
+    <a class="email" href="mailto:chris@boffosocko.com">Email</a>
+  </div>
+  <div class="key-work">
+    <strong>Key writing:</strong>
+    <a href="https://boffosocko.com/2021/07/03/differentiating-online-variations-of-the-commonplace-book-digital-gardens-wikis-zettlekasten-waste-books-florilegia-and-second-brains/">Differentiating Online Variations of the Commonplace Book</a> (his most-cited piece)
+  </div>
+</div>
+
+<div class="person">
+  <div class="person-header">
+    <h2>Dan Allosso</h2>
+    <span class="affiliation">Saint Paul College (Minnesota State)</span>
+  </div>
+  <p class="description">
+    History educator who runs the Obsidian Book Club &mdash; a weekly Saturday group reading session
+    (92+ recorded sessions) alternating between note-making methodology books and history/politics texts.
+    Uses Zotero + Research Rabbit + Obsidian as his primary toolchain. Practices a zettelkasten-influenced
+    system with two note types: source notes and point notes. Influenced by historical note-makers
+    including Beatrice Webb, Marcel Mauss, L&eacute;vi-Strauss, Roland Barthes, and Luhmann.
+    Strong advocate for Open Educational Resources in history (authored 3 OER textbooks).
+    Previously at Bemidji State University. PhD from UMass Amherst.
+  </p>
+  <div class="links">
+    <a href="https://danallosso.substack.com/">Substack (MakingHistory)</a>
+    <a href="https://lifelonglearn.substack.com/">Substack (Lifelong Learners)</a>
+    <a href="https://www.youtube.com/channel/UCNw0lsJ9-4ya4OiDQWsRl5A">YouTube</a>
+    <a href="https://x.com/AllossoDan">X/Twitter</a>
+    <a href="https://podcasts.apple.com/us/podcast/makinghistory/id1529500787">Podcast</a>
+    <a href="https://drdanallosso.com">Personal Site</a>
+    <a class="email" href="mailto:danallosso@icloud.com">Email</a>
+  </div>
+  <div class="key-work">
+    <strong>Key books:</strong>
+    <em>How to Make Notes and Write</em> (2022, with S.F. Allosso),
+    <em>Peppermint Kings</em> (Yale University Press, 2020)
+  </div>
+</div>
+
+<div class="person">
+  <div class="person-header">
+    <h2>Johannes F.K. Schmidt</h2>
+    <span class="affiliation">Bielefeld University, Germany</span>
+  </div>
+  <p class="description">
+    Academic custodian of Niklas Luhmann's original 90,000-card Zettelkasten. Scientific coordinator
+    of the long-term research project "Niklas Luhmann &mdash; Theorie als Passion" (2015&ndash;2030),
+    producing a critical digital edition of the entire card index. His research spans the archival science
+    of digitizing a non-linear, self-referential note system; how the Zettelkasten functioned as a
+    "surprise generator" enabling serendipitous discovery; and the broader history of card index systems
+    as cognitive tools. Has published extensively on where Luhmann's system came from, how it worked,
+    and why it was so productive (50 books, ~600 articles).
+  </p>
+  <div class="links">
+    <a href="https://niklas-luhmann-archiv.de/">Luhmann Archive (Digital Edition)</a>
+    <a href="https://www.uni-bielefeld.de/fakultaeten/soziologie/forschung/luhmann-archiv/">Project Page</a>
+    <a href="https://ekvv.uni-bielefeld.de/pers_publ/publ/PersonDetail.jsp?personId=25653450&lang=en">Faculty Profile</a>
+    <a href="https://vimeo.com/173128404">Talk (Vimeo, German)</a>
+    <a href="https://soundcloud.com/undisciplinedpod/jschmidt">Podcast (English)</a>
+    <a class="email" href="mailto:johannes.schmidt@uni-bielefeld.de">Email</a>
+  </div>
+  <div class="key-work">
+    <strong>Key paper:</strong> "Niklas Luhmann's Card Index: The Fabrication of Serendipity" (<em>Sociologica</em>, 2018; expanded Columbia UP edition 2024)
+  </div>
+</div>
+
+<!-- ============ TIER 2 ============ -->
+<div class="tier-label t2">Strong &mdash; Significant work at the intersection</div>
+
+<div class="person">
+  <div class="person-header">
+    <h2>Sean Takats</h2>
+    <span class="affiliation">University of Luxembourg &amp; Digital Scholar</span>
+  </div>
+  <p class="description">
+    Co-CEO of Digital Scholar, the nonprofit behind Zotero, Tropy, Omeka, and PressForward &mdash;
+    tools built <em>by historians, for historians</em>. Spent 12+ years at the Roy Rosenzweig Center
+    for History and New Media (RRCHNM) leading these projects. Tropy in particular fills a gap
+    no general PKM tool covers: organizing, annotating, and managing photographs of archival documents.
+    His current research is on early tropical medicine and colonial medical practice (France and colonies,
+    the Enlightenment). Yale BA, Michigan PhD, former IBM systems engineer.
+  </p>
+  <div class="links">
+    <a href="https://quintessenceofham.org/">Blog</a>
+    <a href="https://x.com/stakats">X/Twitter</a>
+    <a href="https://hcommons.social/@stakats">Mastodon</a>
+    <a href="https://www.uni.lu/c2dh-en/people/sean-takats/">Luxembourg Profile</a>
+    <a href="https://tropy.org">Tropy</a>
+    <a href="https://zotero.org">Zotero</a>
+    <a class="email" href="mailto:sean.takats@uni.lu">Email</a>
+  </div>
+</div>
+
+<div class="person">
+  <div class="person-header">
+    <h2>Ian Milligan</h2>
+    <span class="affiliation">University of Waterloo, Canada</span>
+  </div>
+  <p class="description">
+    Studies how digital sources transform historical practice. His book <em>The Transformation of
+    Historical Research in the Digital Age</em> (Cambridge, 2022) directly examines how historians'
+    workflows &mdash; including knowledge management &mdash; are changing. Led the Archives Unleashed
+    project (2017&ndash;2023) building tools for web archive research, now offered as a service by
+    the Internet Archive. Also Associate Vice-President for Research Oversight at Waterloo.
+    Fellow of the Royal Historical Society. Co-author of <em>The Historian's Macroscope</em> with
+    Shawn Graham.
+  </p>
+  <div class="links">
+    <a href="https://www.ianmilligan.ca/">Website</a>
+    <a href="https://x.com/ianmilligan1">X/Twitter</a>
+    <a href="https://github.com/ianmilligan1">GitHub</a>
+    <a href="https://scholar.google.ca/citations?user=ZDmByc4AAAAJ">Google Scholar</a>
+    <a href="https://uwaterloo.ca/history/profiles/ian-milligan">Faculty Page</a>
+    <a class="email" href="mailto:i2millig@uwaterloo.ca">Email</a>
+  </div>
+  <div class="key-work">
+    <strong>6 books</strong> including <em>Averting the Digital Dark Age</em> (2024),
+    <em>History in the Age of Abundance</em> (2019)
+  </div>
+</div>
+
+<div class="person">
+  <div class="person-header">
+    <h2>Caleb McDaniel</h2>
+    <span class="affiliation">Rice University, Houston</span>
+  </div>
+  <p class="description">
+    Pulitzer Prize winner (2020) for <em>Sweet Taste of Liberty</em>, which he wrote using
+    plain-text Markdown with Git version control. One of the most prominent examples of a
+    working historian using programmer-style PKM workflows (Pandoc, Markdown, Git) for
+    serious scholarship. Course materials and research notes shared openly on GitHub.
+    Demonstrates that these tools aren't just for tech enthusiasts &mdash; they can support
+    prize-winning historical work.
+  </p>
+  <div class="links">
+    <a href="http://wcm1.web.rice.edu/">Website</a>
+    <a href="https://x.com/wcaleb">X/Twitter</a>
+    <a href="https://github.com/wcm1">GitHub</a>
+    <a class="email" href="mailto:wcm1@rice.edu">Email</a>
+  </div>
+</div>
+
+<div class="person">
+  <div class="person-header">
+    <h2>Kathleen Fitzpatrick</h2>
+    <span class="affiliation">Michigan State University</span>
+  </div>
+  <p class="description">
+    Director of Digital Humanities. Writes about digital scholarly infrastructure &mdash;
+    how scholars manage, share, and publish knowledge in networked environments.
+    Co-founded MediaCommons and involved with Humanities Commons (hcommons.org),
+    an open-access platform for humanities scholars. Her books <em>Planned Obsolescence</em> (2011)
+    and <em>Generous Thinking</em> (2019) argue for new models of scholarly communication
+    and public engagement with academic knowledge.
+  </p>
+  <div class="links">
+    <a href="https://kfitz.info/">Website</a>
+    <a href="https://x.com/kfitz">X/Twitter</a>
+    <a href="https://hcommons.org">Humanities Commons</a>
+  </div>
+</div>
+
+<!-- ============ TIER 3 ============ -->
+<div class="tier-label t3">Adjacent &mdash; Notable contributions from related angles</div>
+
+<div class="person">
+  <div class="person-header">
+    <h2>William J. Turkel</h2>
+    <span class="affiliation">Western University, Canada</span>
+  </div>
+  <p class="description">
+    Digital history pioneer. Co-founded The Programming Historian project with Alan MacEachern &mdash;
+    now the leading resource for computational methods in historical research. His "Digital History Hacks"
+    blog was one of the earliest to document using Python, web scraping, and computational tools
+    for historical scholarship. Also works on physical computing for history and co-founded NiCHE
+    (Network in Canadian History &amp; Environment).
+  </p>
+  <div class="links">
+    <a href="http://digitalhistoryhacks.blogspot.com/">Blog (Digital History Hacks)</a>
+    <a href="https://x.com/williamjturkel">X/Twitter</a>
+    <a href="https://www.history.uwo.ca/people/faculty/turkel.html">Faculty Page</a>
+    <a href="https://programminghistorian.org">The Programming Historian</a>
+  </div>
+</div>
+
+<div class="person">
+  <div class="person-header">
+    <h2>Elena Razlogova</h2>
+    <span class="affiliation">Concordia University, Montreal</span>
+  </div>
+  <p class="description">
+    Associate Professor of History working on digital history, sound studies, and the history of
+    broadcasting and media. Has written and presented about using plain-text tools and Obsidian
+    for historical research. Also studies Russian/American cultural exchange.
+    Involved in digital humanities projects at Concordia.
+  </p>
+  <div class="links">
+    <a href="https://www.concordia.ca/artsci/history/faculty.html?fpid=elena-razlogova">Faculty Page</a>
+    <a class="email" href="mailto:elena.razlogova@concordia.ca">Email</a>
+  </div>
+</div>
+
+<div class="person">
+  <div class="person-header">
+    <h2>Manfred Kuehn</h2>
+    <span class="affiliation">Boston University (possibly retired)</span>
+  </div>
+  <p class="description">
+    Philosophy professor who maintained the influential "Taking Note" blog (~2007&ndash;2018) &mdash;
+    one of the earliest English-language sources discussing Luhmann's Zettelkasten, commonplace books,
+    and the history of note-taking methods in depth. Predated the PKM boom by nearly a decade.
+    The blog remains an invaluable archive of scholarly note-taking history, even though it is
+    no longer actively updated.
+  </p>
+  <div class="links">
+    <a href="https://takingnotenow.blogspot.com/">Blog (Taking Note, archived)</a>
+  </div>
+</div>
+
+<div class="person">
+  <div class="person-header">
+    <h2>Cameron Blevins</h2>
+    <span class="affiliation">University of Colorado Denver</span>
+  </div>
+  <p class="description">
+    Digital historian who uses computational methods (topic modeling, text mining, large-scale mapping)
+    for historical research. His "Geography of the Post" project mapped thousands of US post offices
+    in the American West. Active in discussions about labor, credit, and collaboration in
+    digital humanities. Author of <em>Paper Trails: The US Post and the Making of the American West</em>.
+  </p>
+  <div class="links">
+    <a href="http://cameronblevins.org/">Website</a>
+    <a href="https://x.com/historying">X/Twitter</a>
+  </div>
+</div>
+
+<!-- ============ PETRARCA RELEVANCE ============ -->
+<div class="tier-label" style="background: #fef3c7; color: #92400e; margin-top: 3rem;">Petrarca Relevance &mdash; Tools and repos useful for article processing &amp; knowledge modeling</div>
+
+<div class="person" style="border-left: 4px solid #f59e0b;">
+  <div class="person-header">
+    <h2>Zotero Translation Server</h2>
+    <span class="affiliation">Digital Scholar (Takats et al.)</span>
+  </div>
+  <p class="description">
+    <strong>Priority: Highest.</strong> Self-hostable Node.js server (Docker: <code>zotero/translation-server</code>, port 1969)
+    that extracts structured metadata from any URL using 600+ community-maintained translators.
+    <code>POST /web</code> with a URL &rarr; structured JSON (title, authors, date, abstract, DOI, tags, language).
+    The "Embedded Metadata" fallback parses Highwire Press, OpenGraph, Dublin Core, and Twitter card meta tags.
+    Wikipedia uses this (via Citoid) for citation generation. Could replace or augment Petrarca's
+    custom metadata extraction entirely.
+  </p>
+  <div class="links">
+    <a href="https://github.com/zotero/translation-server">translation-server (148 stars)</a>
+    <a href="https://github.com/zotero/translators">translators (1,575 stars)</a>
+    <a href="https://github.com/zotero/zotero-schema">zotero-schema (64 stars)</a>
+  </div>
+</div>
+
+<div class="person" style="border-left: 4px solid #f59e0b;">
+  <div class="person-header">
+    <h2>steamroller &amp; kg-hybrid</h2>
+    <span class="affiliation">Shawn Graham</span>
+  </div>
+  <p class="description">
+    <strong>Priority: High.</strong> Two text-to-knowledge-graph pipelines.
+    <strong>steamroller</strong>: LLM-based triplet extraction with a controlled predicate vocabulary (32 relationship types),
+    multi-model verification (Model 1 checks triplets against source, Model 2 reviews), outputs CSV + GEXF.
+    <strong>kg-hybrid</strong>: Combines spaCy NER with LLM refinement &mdash; fast free entity extraction first,
+    LLM for canonicalization and relationships second. Includes graph embedding analysis scripts.
+    Both use chunking for large documents. The predicate-controlled approach prevents garbage knowledge graphs.
+  </p>
+  <div class="links">
+    <a href="https://github.com/shawngraham/steamroller">steamroller</a>
+    <a href="https://github.com/shawngraham/kg-hybrid">kg-hybrid</a>
+    <a href="https://github.com/shawngraham/structured-cultural-heritage-crime">structured-cultural-heritage-crime (Pydantic validation)</a>
+    <a href="https://github.com/shawngraham/claude_antiquities_extractor_skill">Claude extraction skill</a>
+  </div>
+</div>
+
+<div class="person" style="border-left: 4px solid #f59e0b;">
+  <div class="person-header">
+    <h2>PressForward</h2>
+    <span class="affiliation">Digital Scholar / RRCHNM</span>
+  </div>
+  <p class="description">
+    <strong>Priority: High.</strong> WordPress plugin for content aggregation and editorial curation.
+    Battle-tested <strong>metadata cascade</strong>: JSON-LD &rarr; OpenGraph &rarr; Highwire meta tags &rarr;
+    Twitter cards &rarr; meta description &rarr; Mozilla Readability extraction.
+    Three-stage content lifecycle (Feed Item &rarr; Nomination with team voting &rarr; Published Draft)
+    maps to incremental reading stages. Includes Google Scholar scraping, RSS/Atom feed aggregation
+    with dedup and staleness checks, URL resolution for aggregator redirects, and Internet Archive submission.
+  </p>
+  <div class="links">
+    <a href="https://github.com/PressForward/pressforward">pressforward (124 stars)</a>
+  </div>
+</div>
+
+<div class="person" style="border-left: 4px solid #f59e0b;">
+  <div class="person-header">
+    <h2>discourser</h2>
+    <span class="affiliation">Shawn Graham</span>
+  </div>
+  <p class="description">
+    <strong>Priority: High.</strong> Streamlit app for corpus influence/novelty analysis using embeddings.
+    Compares a "core corpus" (what you know) against a "target corpus" (new articles) via similarity matrices.
+    Does topic modeling on the core corpus and projects texts into vector spaces.
+    The "custom vector creation" feature builds semantic axes from extracted terms for domain-specific
+    novelty metrics. This is conceptually the exact novelty-detection problem Petrarca solves.
+  </p>
+  <div class="links">
+    <a href="https://github.com/shawngraham/discourser">discourser</a>
+  </div>
+</div>
+
+<div class="person" style="border-left: 4px solid #eab308;">
+  <div class="person-header">
+    <h2>Knowledge Commons (KCWorks)</h2>
+    <span class="affiliation">MESH Research, Michigan State</span>
+  </div>
+  <p class="description">
+    <strong>Priority: Medium-High.</strong> Formerly Humanities Commons, now on InvenioRDM (CERN/Zenodo platform).
+    REST API at <code>works.hcommons.org</code> for searching/retrieving humanities scholarship.
+    OAI-PMH for bulk harvesting. DataCite-based metadata schema. The <code>kcworks-nlp-tools</code> repo
+    has experimental NLP tools for processing article content in chunks via the API.
+    Could serve as a curated source of humanities articles for Petrarca.
+  </p>
+  <div class="links">
+    <a href="https://github.com/MESH-Research/knowledge-commons-works">knowledge-commons-works</a>
+    <a href="https://github.com/MESH-Research/kcworks-nlp-tools">kcworks-nlp-tools</a>
+    <a href="https://hcommons.org">Knowledge Commons</a>
+  </div>
+</div>
+
+<div class="person" style="border-left: 4px solid #eab308;">
+  <div class="person-header">
+    <h2>Luhmann Archive API</h2>
+    <span class="affiliation">Johannes Schmidt, Bielefeld University</span>
+  </div>
+  <p class="description">
+    <strong>Priority: Medium.</strong> Public JSON API to 90,000 cross-referenced Zettelkasten cards.
+    TEI P5 data model with named entity markup, cross-references via <code>&lt;ref&gt;</code>/<code>&lt;ptr&gt;</code>,
+    and Luhmann's branching numbering system (1, 1a, 1b, 1a1&hellip;) creating an implicit hierarchical knowledge graph.
+    Interesting as a test corpus for entity linking against real scholarly knowledge structures,
+    and as a reference for how to encode inter-document relationships.
+  </p>
+  <div class="links">
+    <a href="https://niklas-luhmann-archiv.de/">Digital Edition</a>
+    <a href="https://niklas-luhmann-archiv.de/assets/odd-doku/luhmann.html">TEI Documentation</a>
+  </div>
+</div>
+
+<div class="person" style="border-left: 4px solid #eab308;">
+  <div class="person-header">
+    <h2>Smaller Tools &amp; Patterns</h2>
+    <span class="affiliation">Various</span>
+  </div>
+  <p class="description">
+    <strong>pandocket</strong> (McDaniel): URL + CSS selector &rarr; clean Markdown via Pandoc. Lightweight article ingestion.
+    <strong>RAKE</strong> (Turkel): Rapid Automatic Keyword Extraction &mdash; no training data needed, no LLM cost.
+    <strong>OCRnormalizer</strong> (Blevins): Rule-based text cleaning (long-S, hyphenation, spacing).
+    <strong>us-post-offices</strong> (Blevins): Multi-pass entity resolution (exact &rarr; targeted string mod &rarr; fuzzy Levenshtein).
+    <strong>compute-tfidf.py</strong> (Turkel): TF-IDF computation on SQLite-stored documents.
+    <strong>archivelens</strong> (Graham): LLM "provocation engine" that identifies what's <em>missing</em> from a corpus.
+    <strong>latinepi</strong> (Graham): 111 regex patterns for Roman entity extraction (names, military ranks, tribes).
+    <strong>Passim</strong> (Programming Historian lesson): N-gram text reuse detection for dedup.
+    <strong>gooseberry</strong> (starred by Aldrich): Rust CLI that syncs Hypothesis annotations, supports bulk tagging,
+    generates a knowledge base wiki. Reference for annotation import pipelines.
+    <strong>NewSyntopicon</strong> (starred by Aldrich): Digital recreation of Adler's Syntopicon &mdash; links ideas
+    across great books via a knowledge graph in Obsidian. Cross-text idea linking.
+    <strong>Hypothesis API</strong> (Aldrich's core workflow): <code>/api/search</code> with user/tags/URI filters +
+    RSS feeds at <code>/stream.atom?user=X</code> for annotation import.
+  </p>
+  <div class="links">
+    <a href="https://github.com/wcaleb/pandocket">pandocket</a>
+    <a href="https://github.com/williamjturkel/RAKE">RAKE</a>
+    <a href="https://github.com/cblevins/DataMunging">OCRnormalizer</a>
+    <a href="https://github.com/cblevins/us-post-offices">us-post-offices (29 stars)</a>
+    <a href="https://github.com/shawngraham/archivelens">archivelens</a>
+    <a href="https://github.com/shawngraham/latinepi">latinepi</a>
+    <a href="https://github.com/out-of-cheese-error/gooseberry">gooseberry (170 stars)</a>
+    <a href="https://github.com/sajjad2881/NewSyntopicon">NewSyntopicon</a>
+  </div>
+</div>
+
+<!-- ============ COMMUNITIES ============ -->
+<div class="communities">
+  <h2>Communities &amp; Resources</h2>
+  <ul>
+    <li><a href="https://programminghistorian.org">The Programming Historian</a> &mdash; open-access tutorials on digital methods for historians</li>
+    <li><a href="https://obsidian.md/community">Obsidian Discord &amp; Forum</a> &mdash; search "historian" or "history" for active academic workflows</li>
+    <li><a href="https://tropy.org">Tropy</a> &mdash; open-source tool for organizing archival research photographs, built by historians</li>
+    <li><a href="https://zotero.org">Zotero</a> &mdash; reference manager born at the Center for History and New Media</li>
+    <li><a href="https://hcommons.org">Humanities Commons</a> &mdash; open-access platform for humanities scholars</li>
+    <li><a href="https://niklas-luhmann-archiv.de/">Niklas Luhmann Archive</a> &mdash; digital edition of the original 90,000-card Zettelkasten</li>
+    <li><a href="https://www.linkingyourthinking.com/">Linking Your Thinking (LYT)</a> &mdash; PKM community with academic use cases and conferences</li>
+    <li><strong>#DigitalHumanities</strong> on X/Twitter and Mastodon &mdash; historians discussing tools and methods</li>
+  </ul>
+</div>
+
+<footer>
+  Compiled April 2026. Links verified via web search; some may have changed.
+</footer>
+
+</div>
+</body>
+</html>

--- a/research/learning-analysis-2026-04-23.json
+++ b/research/learning-analysis-2026-04-23.json
@@ -1,0 +1,717 @@
+{
+  "vocabulary_by_status": {
+    "state_counts": {
+      "known": 1561,
+      "encountered": 222,
+      "acquiring": 81,
+      "suspended": 69,
+      "learning": 46,
+      "lapsed": 32
+    },
+    "by_source": {
+      "acquiring": {
+        "textbook_scan": 52,
+        "book": 17,
+        "leech_reintro": 7,
+        "quran": 3,
+        "collateral": 2
+      },
+      "encountered": {
+        "book": 91,
+        "quran": 61,
+        "textbook_scan": 43,
+        "study": 25,
+        "mapping_correction": 2
+      },
+      "known": {
+        "textbook_scan": 1004,
+        "book": 213,
+        "auto_intro": 102,
+        "duolingo": 87,
+        "collateral": 57,
+        "leech_reintro": 39,
+        "study": 19,
+        "mapping_correction": 16,
+        "story_import": 15,
+        "flag_autocreate": 6,
+        "quran": 2,
+        "encountered": 1
+      },
+      "lapsed": {
+        "textbook_scan": 25,
+        "book": 4,
+        "auto_intro": 2,
+        "collateral": 1
+      },
+      "learning": {
+        "textbook_scan": 32,
+        "book": 7,
+        "collateral": 5,
+        "quran": 2
+      },
+      "suspended": {
+        "textbook_scan": 41,
+        "duolingo": 8,
+        "story_import": 6,
+        "book": 5,
+        "leech_reintro": 4,
+        "collateral": 2,
+        "mapping_correction": 1,
+        "flag_autocreate": 1,
+        "auto_intro": 1
+      }
+    },
+    "total": 2011
+  },
+  "acquisition_rate": {
+    "total_graduations": 1538,
+    "daily_graduations": {
+      "2026-02-08": 19,
+      "2026-02-09": 27,
+      "2026-02-10": 6,
+      "2026-02-11": 26,
+      "2026-02-12": 92,
+      "2026-02-13": 52,
+      "2026-02-14": 20,
+      "2026-02-15": 8,
+      "2026-02-16": 39,
+      "2026-02-17": 30,
+      "2026-02-18": 21,
+      "2026-02-19": 6,
+      "2026-02-20": 37,
+      "2026-02-21": 23,
+      "2026-02-22": 14,
+      "2026-02-23": 39,
+      "2026-02-24": 11,
+      "2026-02-25": 12,
+      "2026-02-26": 16,
+      "2026-02-27": 21,
+      "2026-02-28": 3,
+      "2026-03-01": 8,
+      "2026-03-02": 22,
+      "2026-03-03": 77,
+      "2026-03-04": 17,
+      "2026-03-05": 30,
+      "2026-03-06": 30,
+      "2026-03-07": 38,
+      "2026-03-08": 14,
+      "2026-03-09": 43,
+      "2026-03-10": 30,
+      "2026-03-11": 22,
+      "2026-03-12": 13,
+      "2026-03-13": 18,
+      "2026-03-14": 25,
+      "2026-03-15": 17,
+      "2026-03-16": 16,
+      "2026-03-17": 6,
+      "2026-03-18": 12,
+      "2026-03-19": 5,
+      "2026-03-20": 20,
+      "2026-03-21": 34,
+      "2026-03-22": 17,
+      "2026-03-23": 27,
+      "2026-03-24": 20,
+      "2026-03-25": 4,
+      "2026-03-26": 31,
+      "2026-03-27": 24,
+      "2026-03-28": 24,
+      "2026-03-29": 20,
+      "2026-03-30": 28,
+      "2026-03-31": 16,
+      "2026-04-01": 14,
+      "2026-04-02": 2,
+      "2026-04-03": 24,
+      "2026-04-04": 14,
+      "2026-04-05": 17,
+      "2026-04-06": 19,
+      "2026-04-07": 11,
+      "2026-04-08": 25,
+      "2026-04-09": 11,
+      "2026-04-10": 9,
+      "2026-04-11": 3,
+      "2026-04-12": 16,
+      "2026-04-13": 33,
+      "2026-04-14": 2,
+      "2026-04-15": 13,
+      "2026-04-16": 1,
+      "2026-04-17": 6,
+      "2026-04-18": 28,
+      "2026-04-19": 8,
+      "2026-04-20": 19,
+      "2026-04-21": 13,
+      "2026-04-22": 13,
+      "2026-04-23": 7
+    },
+    "weekly_graduations": {
+      "2026-W06": 19,
+      "2026-W07": 231,
+      "2026-W08": 170,
+      "2026-W09": 110,
+      "2026-W10": 228,
+      "2026-W11": 168,
+      "2026-W12": 110,
+      "2026-W13": 150,
+      "2026-W14": 115,
+      "2026-W15": 94,
+      "2026-W16": 91,
+      "2026-W17": 52
+    },
+    "median_hours_in_acquisition": 46.8,
+    "mean_hours_in_acquisition": 85.5,
+    "durations_hours_p25_p50_p75": [
+      0.41,
+      46.85,
+      133.1
+    ]
+  },
+  "review_accuracy": {
+    "rating_distribution": {
+      "1": 2493,
+      "2": 397,
+      "3": 29117
+    },
+    "total_reviews": 32007,
+    "overall_accuracy_pct": 91.0,
+    "by_mode": {
+      "listening": {
+        "1": 16,
+        "3": 41
+      },
+      "quiz": {
+        "1": 8,
+        "3": 29
+      },
+      "reading": {
+        "1": 2420,
+        "2": 397,
+        "3": 28711
+      },
+      "reintro": {
+        "1": 49,
+        "3": 89
+      },
+      "textbook_scan": {
+        "3": 247
+      }
+    },
+    "by_credit_type": {
+      "null": {
+        "1": 65,
+        "3": 427
+      },
+      "collateral": {
+        "1": 1252,
+        "2": 323,
+        "3": 24035
+      },
+      "primary": {
+        "1": 1176,
+        "2": 74,
+        "3": 4655
+      }
+    },
+    "by_acquisition": {
+      "fsrs": {
+        "1": 934,
+        "2": 304,
+        "3": 23227
+      },
+      "acquisition": {
+        "1": 1559,
+        "2": 93,
+        "3": 5890
+      }
+    },
+    "weekly_accuracy": {
+      "2026-W06": 80.8,
+      "2026-W07": 88.9,
+      "2026-W08": 92.4,
+      "2026-W09": 91.5,
+      "2026-W10": 93.2,
+      "2026-W11": 95.1,
+      "2026-W12": 92.7,
+      "2026-W13": 90.8,
+      "2026-W14": 89.2,
+      "2026-W15": 85.7,
+      "2026-W16": 85.0,
+      "2026-W17": 91.1
+    }
+  },
+  "session_patterns": {
+    "total_sessions": 536,
+    "session_size_median": 10,
+    "session_size_mean": 11.7,
+    "session_size_buckets": {
+      "16-20": 66,
+      "1-5": 166,
+      "21-30": 112,
+      "6-10": 106,
+      "11-15": 86
+    },
+    "comprehension_distribution": {
+      "no_idea": 6,
+      "partial": 2369,
+      "understood": 3882
+    },
+    "sessions_per_day": {
+      "2026-02-08": 12,
+      "2026-02-09": 17,
+      "2026-02-10": 3,
+      "2026-02-11": 6,
+      "2026-02-12": 27,
+      "2026-02-13": 16,
+      "2026-02-14": 14,
+      "2026-02-15": 9,
+      "2026-02-16": 26,
+      "2026-02-17": 9,
+      "2026-02-18": 24,
+      "2026-02-19": 10,
+      "2026-02-20": 14,
+      "2026-02-21": 6,
+      "2026-02-22": 13,
+      "2026-02-23": 28,
+      "2026-02-24": 7,
+      "2026-02-25": 3,
+      "2026-02-26": 4,
+      "2026-02-27": 6,
+      "2026-02-28": 1,
+      "2026-03-01": 3,
+      "2026-03-02": 10,
+      "2026-03-03": 9,
+      "2026-03-04": 2,
+      "2026-03-05": 5,
+      "2026-03-06": 4,
+      "2026-03-07": 7,
+      "2026-03-08": 4,
+      "2026-03-09": 8,
+      "2026-03-10": 6,
+      "2026-03-11": 4,
+      "2026-03-12": 5,
+      "2026-03-13": 5,
+      "2026-03-14": 4,
+      "2026-03-15": 6,
+      "2026-03-16": 6,
+      "2026-03-17": 6,
+      "2026-03-18": 8,
+      "2026-03-19": 2,
+      "2026-03-20": 7,
+      "2026-03-21": 8,
+      "2026-03-22": 3,
+      "2026-03-23": 9,
+      "2026-03-24": 6,
+      "2026-03-25": 2,
+      "2026-03-26": 6,
+      "2026-03-27": 6,
+      "2026-03-28": 8,
+      "2026-03-29": 3,
+      "2026-03-30": 12,
+      "2026-03-31": 3,
+      "2026-04-01": 5,
+      "2026-04-02": 2,
+      "2026-04-03": 6,
+      "2026-04-04": 4,
+      "2026-04-05": 3,
+      "2026-04-06": 2,
+      "2026-04-07": 3,
+      "2026-04-08": 6,
+      "2026-04-09": 4,
+      "2026-04-10": 4,
+      "2026-04-11": 3,
+      "2026-04-12": 9,
+      "2026-04-13": 5,
+      "2026-04-14": 3,
+      "2026-04-15": 7,
+      "2026-04-16": 3,
+      "2026-04-17": 3,
+      "2026-04-18": 5,
+      "2026-04-19": 4,
+      "2026-04-20": 8,
+      "2026-04-21": 7,
+      "2026-04-22": 6,
+      "2026-04-23": 2
+    }
+  },
+  "fsrs_stability": {
+    "total_cards_with_fsrs": 1615,
+    "stability_median": 56.7,
+    "stability_mean": 69.2,
+    "stability_buckets": {
+      "90+d": 546,
+      "30-90d": 543,
+      "7-30d": 306,
+      "1-7d": 183,
+      "<1d": 37
+    },
+    "stability_by_state": {
+      "known": {
+        "count": 1525,
+        "median": 61.9,
+        "mean": 73.1
+      },
+      "suspended": {
+        "count": 14,
+        "median": 0.9,
+        "mean": 4.9
+      },
+      "learning": {
+        "count": 43,
+        "median": 2.3,
+        "mean": 3.5
+      },
+      "lapsed": {
+        "count": 31,
+        "median": 0.7,
+        "mean": 1.1
+      },
+      "encountered": {
+        "count": 1,
+        "median": 2.3,
+        "mean": 2.3
+      },
+      "acquiring": {
+        "count": 1,
+        "median": 2.3,
+        "mean": 2.3
+      }
+    },
+    "difficulty_buckets": {
+      "<3 (easy)": 1058,
+      "7+ (very hard)": 391,
+      "5-7 (hard)": 52,
+      "3-5 (medium)": 114
+    },
+    "difficulty_median": 2.1
+  },
+  "time_to_acquisition": {
+    "graduated_words": 1422,
+    "duration_hours_percentiles": [
+      0.41,
+      46.85,
+      133.1
+    ],
+    "reviews_to_graduation_median": 0,
+    "reviews_to_graduation_mean": 3.2,
+    "reviews_to_graduation_percentiles": [
+      0,
+      0,
+      5
+    ]
+  },
+  "retention_rate": {
+    "fsrs_reviews_total": 24465,
+    "fsrs_correct": 23227,
+    "retention_rate_pct": 94.9,
+    "weekly_retention": {
+      "2026-W06": 80.8,
+      "2026-W07": 92.4,
+      "2026-W08": 97.5,
+      "2026-W09": 98.3,
+      "2026-W10": 98.5,
+      "2026-W11": 98.7,
+      "2026-W12": 95.3,
+      "2026-W13": 93.5,
+      "2026-W14": 92.7,
+      "2026-W15": 90.3,
+      "2026-W16": 89.9,
+      "2026-W17": 93.1
+    }
+  },
+  "learning_velocity": {
+    "total_introduced": 1773,
+    "total_graduated": 1538,
+    "weekly_introduced": {
+      "2026-W06": 25,
+      "2026-W07": 292,
+      "2026-W08": 261,
+      "2026-W09": 290,
+      "2026-W10": 56,
+      "2026-W11": 128,
+      "2026-W12": 138,
+      "2026-W13": 174,
+      "2026-W14": 143,
+      "2026-W15": 125,
+      "2026-W16": 94,
+      "2026-W17": 47
+    },
+    "weekly_graduated": {
+      "2026-W06": 19,
+      "2026-W07": 231,
+      "2026-W08": 170,
+      "2026-W09": 110,
+      "2026-W10": 228,
+      "2026-W11": 168,
+      "2026-W12": 110,
+      "2026-W13": 150,
+      "2026-W14": 115,
+      "2026-W15": 94,
+      "2026-W16": 91,
+      "2026-W17": 52
+    },
+    "cumulative": [
+      {
+        "week": "2026-W06",
+        "cumulative_introduced": 25,
+        "cumulative_graduated": 19
+      },
+      {
+        "week": "2026-W07",
+        "cumulative_introduced": 317,
+        "cumulative_graduated": 250
+      },
+      {
+        "week": "2026-W08",
+        "cumulative_introduced": 578,
+        "cumulative_graduated": 420
+      },
+      {
+        "week": "2026-W09",
+        "cumulative_introduced": 868,
+        "cumulative_graduated": 530
+      },
+      {
+        "week": "2026-W10",
+        "cumulative_introduced": 924,
+        "cumulative_graduated": 758
+      },
+      {
+        "week": "2026-W11",
+        "cumulative_introduced": 1052,
+        "cumulative_graduated": 926
+      },
+      {
+        "week": "2026-W12",
+        "cumulative_introduced": 1190,
+        "cumulative_graduated": 1036
+      },
+      {
+        "week": "2026-W13",
+        "cumulative_introduced": 1364,
+        "cumulative_graduated": 1186
+      },
+      {
+        "week": "2026-W14",
+        "cumulative_introduced": 1507,
+        "cumulative_graduated": 1301
+      },
+      {
+        "week": "2026-W15",
+        "cumulative_introduced": 1632,
+        "cumulative_graduated": 1395
+      },
+      {
+        "week": "2026-W16",
+        "cumulative_introduced": 1726,
+        "cumulative_graduated": 1486
+      },
+      {
+        "week": "2026-W17",
+        "cumulative_introduced": 1773,
+        "cumulative_graduated": 1538
+      }
+    ]
+  },
+  "frequency_coverage": {
+    "coverage": {
+      "100": {
+        "raw_total": 72,
+        "raw_known": 42,
+        "content_total": 21,
+        "content_known": 17,
+        "content_active": 17,
+        "known_pct": 81.0,
+        "active_pct": 81.0
+      },
+      "500": {
+        "raw_total": 221,
+        "raw_known": 145,
+        "content_total": 132,
+        "content_known": 104,
+        "content_active": 108,
+        "known_pct": 78.8,
+        "active_pct": 81.8
+      },
+      "1000": {
+        "raw_total": 358,
+        "raw_known": 251,
+        "content_total": 258,
+        "content_known": 207,
+        "content_active": 213,
+        "known_pct": 80.2,
+        "active_pct": 82.6
+      },
+      "2000": {
+        "raw_total": 538,
+        "raw_known": 380,
+        "content_total": 429,
+        "content_known": 336,
+        "content_active": 346,
+        "known_pct": 78.3,
+        "active_pct": 80.7
+      }
+    },
+    "top_frequency_gaps": [
+      {
+        "lemma_id": 988,
+        "lemma_ar": "بْنٌ",
+        "gloss_en": "alternative form of اِبْن (ibn)",
+        "frequency_rank": 32,
+        "state": "encountered"
+      },
+      {
+        "lemma_id": 864,
+        "lemma_ar": "مَجْلِسٌ",
+        "gloss_en": "seat",
+        "frequency_rank": 58,
+        "state": "none"
+      },
+      {
+        "lemma_id": 1338,
+        "lemma_ar": "عَبْدٌ",
+        "gloss_en": "slave, servant",
+        "frequency_rank": 67,
+        "state": "none"
+      },
+      {
+        "lemma_id": 317,
+        "lemma_ar": "أخْبار",
+        "gloss_en": "news",
+        "frequency_rank": 80,
+        "state": "none"
+      },
+      {
+        "lemma_id": 1693,
+        "lemma_ar": "أولى",
+        "gloss_en": "first (feminine)",
+        "frequency_rank": 103,
+        "state": "encountered"
+      },
+      {
+        "lemma_id": 914,
+        "lemma_ar": "احد",
+        "gloss_en": "Sunday",
+        "frequency_rank": 106,
+        "state": "encountered"
+      },
+      {
+        "lemma_id": 820,
+        "lemma_ar": "مَوْقِعٌ",
+        "gloss_en": "site, location",
+        "frequency_rank": 107,
+        "state": "none"
+      },
+      {
+        "lemma_id": 1387,
+        "lemma_ar": "أَلَّ",
+        "gloss_en": "to be agitated",
+        "frequency_rank": 108,
+        "state": "none"
+      },
+      {
+        "lemma_id": 1886,
+        "lemma_ar": "أَبُو",
+        "gloss_en": "father of",
+        "frequency_rank": 143,
+        "state": "encountered"
+      },
+      {
+        "lemma_id": 112,
+        "lemma_ar": "جَديدة",
+        "gloss_en": "new",
+        "frequency_rank": 156,
+        "state": "none"
+      },
+      {
+        "lemma_id": 457,
+        "lemma_ar": "بـِ",
+        "gloss_en": "with",
+        "frequency_rank": 158,
+        "state": "encountered"
+      },
+      {
+        "lemma_id": 1163,
+        "lemma_ar": "إِدَارَةٌ",
+        "gloss_en": "administration, management",
+        "frequency_rank": 166,
+        "state": "none"
+      },
+      {
+        "lemma_id": 1969,
+        "lemma_ar": "عراق",
+        "gloss_en": "Iraq",
+        "frequency_rank": 214,
+        "state": "none"
+      },
+      {
+        "lemma_id": 452,
+        "lemma_ar": "لـِ",
+        "gloss_en": "to",
+        "frequency_rank": 234,
+        "state": "none"
+      },
+      {
+        "lemma_id": 2525,
+        "lemma_ar": "أَكْبَر",
+        "gloss_en": "greater, bigger",
+        "frequency_rank": 293,
+        "state": "none"
+      }
+    ]
+  },
+  "study_consistency": {
+    "total_active_days": 75,
+    "current_streak": 75,
+    "longest_streak": 75,
+    "first_active_day": "2026-02-08",
+    "last_active_day": "2026-04-23",
+    "day_of_week": {
+      "Sun": 11,
+      "Mon": 11,
+      "Tue": 11,
+      "Wed": 11,
+      "Thu": 11,
+      "Fri": 10,
+      "Sat": 10
+    },
+    "sessions_per_day_histogram": {
+      "14": 2,
+      "18": 2,
+      "4": 8,
+      "7": 9,
+      "17": 1,
+      "16": 1,
+      "10": 4,
+      "27": 1,
+      "26": 1,
+      "11": 2,
+      "15": 1,
+      "8": 7,
+      "29": 1,
+      "5": 6,
+      "3": 10,
+      "13": 2,
+      "6": 10,
+      "9": 3,
+      "2": 4
+    },
+    "mean_sessions_per_day": 7.8
+  },
+  "tashkeel_readiness": {
+    "total_review_words": 1568,
+    "eligible_count": 1089,
+    "eligible_pct": 69.5,
+    "stability_median": 59.5,
+    "stability_mean": 71.2,
+    "stability_buckets": {
+      "180+d": 59,
+      "90-180d": 487,
+      "30-90d": 543,
+      "7-30d": 302,
+      "1-7d": 168,
+      "<1d": 9
+    }
+  },
+  "_meta": {
+    "generated_at": "2026-04-23T11:42:42Z",
+    "db_path": "/opt/alif/backend/data/alif.db"
+  }
+}

--- a/research/petrarca-integration-plan.html
+++ b/research/petrarca-integration-plan.html
@@ -1,0 +1,659 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Petrarca Integration Plan: History + PKM Tools</title>
+<style>
+  :root {
+    --bg: #faf9f6;
+    --card: #ffffff;
+    --text: #1f2937;
+    --muted: #6b7280;
+    --accent: #7c3aed;
+    --green: #059669;
+    --amber: #d97706;
+    --red: #dc2626;
+    --border: #e5e7eb;
+    --link: #4f46e5;
+    --code-bg: #f3f4f6;
+  }
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    line-height: 1.65;
+    padding: 2rem 1rem;
+  }
+  .container { max-width: 900px; margin: 0 auto; }
+  h1 { font-size: 1.8rem; margin-bottom: 0.3rem; letter-spacing: -0.02em; }
+  .subtitle { color: var(--muted); font-size: 0.95rem; margin-bottom: 2rem; }
+  h2 { font-size: 1.3rem; margin: 2rem 0 0.75rem; color: var(--text); border-bottom: 2px solid var(--border); padding-bottom: 0.3rem; }
+  h3 { font-size: 1.05rem; margin: 1.25rem 0 0.5rem; color: #374151; }
+
+  .verdict {
+    display: inline-block;
+    font-size: 0.72rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    padding: 0.2rem 0.6rem;
+    border-radius: 100px;
+    margin-left: 0.5rem;
+    vertical-align: middle;
+  }
+  .verdict.yes { background: #d1fae5; color: var(--green); }
+  .verdict.maybe { background: #fef3c7; color: var(--amber); }
+  .verdict.no { background: #fee2e2; color: var(--red); }
+
+  .section {
+    background: var(--card);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 1.5rem 1.75rem;
+    margin-bottom: 1.25rem;
+  }
+  .section.highlight { border-left: 4px solid var(--green); }
+  .section.caution { border-left: 4px solid var(--amber); }
+  .section.skip { border-left: 4px solid #d1d5db; opacity: 0.85; }
+
+  table { width: 100%; border-collapse: collapse; margin: 0.75rem 0; font-size: 0.88rem; }
+  th { text-align: left; padding: 0.4rem 0.6rem; background: var(--code-bg); border-bottom: 2px solid var(--border); font-weight: 600; }
+  td { padding: 0.4rem 0.6rem; border-bottom: 1px solid var(--border); vertical-align: top; }
+  tr:last-child td { border-bottom: none; }
+
+  code {
+    font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
+    font-size: 0.82em;
+    background: var(--code-bg);
+    padding: 0.15em 0.4em;
+    border-radius: 4px;
+  }
+  pre {
+    background: #1f2937;
+    color: #e5e7eb;
+    padding: 1rem 1.25rem;
+    border-radius: 8px;
+    overflow-x: auto;
+    font-size: 0.82rem;
+    line-height: 1.5;
+    margin: 0.75rem 0;
+  }
+  pre code { background: none; padding: 0; color: inherit; }
+
+  .effort {
+    display: flex;
+    gap: 1.5rem;
+    margin: 0.75rem 0;
+    font-size: 0.85rem;
+    color: var(--muted);
+  }
+  .effort span { display: flex; align-items: center; gap: 0.3rem; }
+  .effort strong { color: var(--text); }
+
+  .file-list {
+    font-size: 0.85rem;
+    padding: 0.5rem 0;
+  }
+  .file-list code {
+    display: inline-block;
+    margin-right: 0.3rem;
+  }
+
+  ul { padding-left: 1.25rem; margin: 0.5rem 0; }
+  li { margin: 0.3rem 0; }
+
+  .priority-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
+    margin: 1rem 0;
+  }
+  .priority-card {
+    background: var(--card);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 1rem 1.25rem;
+  }
+  .priority-card h4 { font-size: 0.9rem; margin-bottom: 0.4rem; }
+  .priority-card p { font-size: 0.85rem; color: var(--muted); }
+
+  .summary-table { margin: 1rem 0; }
+  .summary-table td:first-child { font-weight: 600; white-space: nowrap; width: 30%; }
+
+  a { color: var(--link); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+
+  footer { text-align: center; color: var(--muted); font-size: 0.78rem; margin-top: 3rem; }
+</style>
+</head>
+<body>
+<div class="container">
+
+<h1>Petrarca Integration Plan</h1>
+<p class="subtitle">Concrete integration opportunities from the History + PKM ecosystem research (April 2026)</p>
+
+<!-- ============================================================ -->
+<h2>Executive Summary</h2>
+
+<div class="priority-grid">
+  <div class="priority-card" style="border-left: 4px solid var(--green);">
+    <h4>1. Hypothesis Annotations</h4>
+    <p>User-curated atomic claims, reading depth signals, tag-to-entity linking. ~370 lines, 1-2 sessions.</p>
+  </div>
+  <div class="priority-card" style="border-left: 4px solid var(--green);">
+    <h4>2. Entity Extraction Prompts</h4>
+    <p>Constrained relationship types + canonical IDs + mentions arrays. Prompt-only change, 1 session.</p>
+  </div>
+  <div class="priority-card" style="border-left: 4px solid var(--amber);">
+    <h4>3. Zotero Translation Server</h4>
+    <p>Richer metadata (itemType, DOI, structured authors, abstract). Docker sidecar, ~100 lines.</p>
+  </div>
+  <div class="priority-card" style="border-left: 4px solid var(--amber);">
+    <h4>4. Discourser-style Semantic Vectors</h4>
+    <p>Custom semantic dimensions for richer article characterization. Research spike first.</p>
+  </div>
+</div>
+
+<table class="summary-table">
+  <tr><td>PressForward metadata cascade</td><td><span class="verdict no">Skip</span> Trafilatura already covers it. No incremental value.</td></tr>
+  <tr><td>spaCy pre-pass (kg-hybrid)</td><td><span class="verdict no">Skip</span> For general-knowledge articles, LLM extraction is already good. Adds latency.</td></tr>
+  <tr><td>Gooseberry CLI</td><td><span class="verdict no">Skip</span> Its sync pattern is trivial to replicate. No need for the Rust dependency.</td></tr>
+  <tr><td>KCWorks / Knowledge Commons API</td><td><span class="verdict maybe">Later</span> Interesting as a humanities article source, but not a priority.</td></tr>
+  <tr><td>Luhmann Archive API</td><td><span class="verdict maybe">Later</span> Interesting test corpus, not an integration priority.</td></tr>
+</table>
+
+<!-- ============================================================ -->
+<h2>1. Hypothesis Annotation Integration <span class="verdict yes">Do this</span></h2>
+
+<div class="section highlight">
+  <h3>Why this is the highest-value integration</h3>
+  <p>
+    Hypothesis annotations are <strong>user-curated atomic claims</strong> &mdash; far more reliable than
+    LLM-extracted claims because the user selected the exact passage they found noteworthy.
+    This is the strongest knowledge signal Petrarca can get, and it's currently ignored.
+  </p>
+  <p style="margin-top: 0.5rem;">
+    Your Hypothesis account already exists (3 annotations from 2021). The API is open, unthrottled,
+    and well-documented. Incremental sync via <code>search_after</code> cursor is trivial.
+  </p>
+
+  <div class="effort">
+    <span><strong>Effort:</strong> ~370 lines, 1-2 sessions</span>
+    <span><strong>Dependencies:</strong> None (just <code>requests</code>)</span>
+    <span><strong>Env:</strong> <code>HYPOTHESIS_API_KEY</code>, <code>HYPOTHESIS_USERNAME</code></span>
+  </div>
+
+  <h3>Data model</h3>
+  <p>Each Hypothesis annotation contains:</p>
+  <table>
+    <tr><th>Field</th><th>Source</th><th>Petrarca use</th></tr>
+    <tr><td><code>target.selector[TextQuoteSelector].exact</code></td><td>The highlighted passage</td><td>User-curated atomic claim</td></tr>
+    <tr><td><code>text</code></td><td>User's note/comment</td><td>Elaboration, interpretation signal</td></tr>
+    <tr><td><code>tags[]</code></td><td>User-assigned tags</td><td>Map to entities / curriculum nodes</td></tr>
+    <tr><td><code>uri</code></td><td>Page URL</td><td>Match to existing articles or auto-import</td></tr>
+    <tr><td><code>created</code></td><td>Timestamp</td><td>Reading activity timeline</td></tr>
+  </table>
+
+  <h3>Four integration points</h3>
+
+  <p><strong>A. Highlighted passages &rarr; atomic claims</strong> (highest value)</p>
+  <p>
+    When a user highlights text, that's an atomic claim with <code>claim_type='user_highlight'</code>.
+    These claims should get higher weight in novelty detection &mdash; they represent what the user
+    found noteworthy, not what an LLM thought was important. User notes (<code>text</code> field)
+    become claim annotations.
+  </p>
+
+  <p><strong>B. Reading depth signal</strong></p>
+  <p>
+    Annotation count per article = reading depth. An article with 12 highlights was deeply read;
+    one with 0 was skimmed. This feeds into feed ranking (don't re-surface deeply-read articles)
+    and knowledge state confidence.
+  </p>
+
+  <p><strong>C. Tag &rarr; entity / curriculum linking</strong></p>
+  <p>
+    If a user tags a highlight with "Byzantine Empire", match to <code>shared_entities</code> and
+    upgrade linked curriculum nodes to <code>engaged</code>. This is direct user-declared knowledge evidence.
+  </p>
+
+  <p><strong>D. Auto-import annotated articles</strong></p>
+  <p>
+    If the user annotates a URL not in Petrarca's database, auto-import it via the existing article
+    pipeline. Annotated articles are high-priority candidates &mdash; the user already cared enough to highlight.
+  </p>
+
+  <h3>Sync implementation</h3>
+<pre><code># Incremental sync using search_after cursor (gooseberry pattern)
+def sync_annotations(username: str, api_key: str, since: str | None = None):
+    params = {
+        "user": f"acct:{username}@hypothes.is",
+        "sort": "updated", "order": "asc", "limit": 200,
+    }
+    if since:
+        params["search_after"] = since
+
+    while True:
+        resp = requests.get("https://hypothes.is/api/search",
+                           headers={"Authorization": f"Bearer {api_key}"},
+                           params=params)
+        batch = resp.json()["rows"]
+        if not batch:
+            break
+        yield from batch
+        params["search_after"] = batch[-1]["updated"]</code></pre>
+
+  <h3>Pipeline integration</h3>
+  <p>Add as Step 0c in the 4-hour cron, after Readwise Reader fetch:</p>
+<pre><code># In build_articles.py cron:
+Step 0c: Fetch Hypothesis annotations (incremental)
+         &rarr; Store in hypothesis_annotations table
+         &rarr; Match URIs to existing articles
+         &rarr; Auto-import unmatched URIs as article candidates
+Step 7:  Post-process annotations
+         &rarr; Convert highlights to atomic_claims (type='user_highlight')
+         &rarr; Map tags to entities/curriculum nodes
+         &rarr; Update knowledge_states for tagged nodes</code></pre>
+
+  <div class="file-list">
+    <strong>Files to create/modify:</strong>
+    <code>scripts/fetch_hypothesis.py</code> (new, ~150 lines),
+    <code>scripts/db.py</code> (add table, ~20 lines),
+    <code>scripts/build_articles.py</code> (cron integration, ~100 lines),
+    <code>.env</code> (add keys)
+  </div>
+</div>
+
+<!-- ============================================================ -->
+<h2>2. Entity Extraction Prompt Engineering <span class="verdict yes">Do this</span></h2>
+
+<div class="section highlight">
+  <h3>What to adopt from Graham's repos</h3>
+  <p>
+    Three specific prompt engineering patterns from
+    <a href="https://github.com/shawngraham/steamroller">steamroller</a>,
+    <a href="https://github.com/shawngraham/kg-hybrid">kg-hybrid</a>, and
+    <a href="https://github.com/shawngraham/claude_antiquities_extractor_skill">claude_antiquities_extractor_skill</a>
+    that would improve Petrarca's entity extraction with <strong>zero new dependencies</strong>:
+  </p>
+
+  <div class="effort">
+    <span><strong>Effort:</strong> Prompt changes only, 1 session</span>
+    <span><strong>Dependencies:</strong> None</span>
+    <span><strong>Risk:</strong> Low &mdash; A/B test against current extraction</span>
+  </div>
+
+  <h3>Change 1: Constrained relationship types</h3>
+  <p>
+    Currently Petrarca asks for "related entity pairs (max 5 per entity)" with free-form relationship descriptions.
+    Graham's repos constrain to a fixed vocabulary, producing more structured, queryable graphs.
+  </p>
+  <p>Proposed relationship vocabulary for Petrarca's historical domains (~15 types):</p>
+<pre><code>RULED, CONQUERED, FOUNDED, INFLUENCED, SUCCEEDED,
+PART_OF, LOCATED_IN, CONTEMPORARY_OF, ALLIED_WITH,
+OPPOSED, CAUSED, RESULTED_IN, DERIVED_FROM,
+CREATED, STUDIED_BY</code></pre>
+  <p>
+    Each predicate has a directional definition (e.g. <code>RULED: subject governed/controlled object</code>).
+    The LLM selects from this list rather than inventing relationship descriptions.
+  </p>
+
+  <h3>Change 2: Canonical ID convention</h3>
+  <p>
+    Instead of matching entities by case-insensitive name (fragile for "Alexander" vs "Alexander the Great"
+    vs "Alexander III of Macedon"), assign canonical IDs:
+  </p>
+<pre><code>PERSON:       firstname_lastname       (e.g. roger_ii_sicily)
+PLACE:        place_name_geography     (e.g. palermo_sicily)
+EVENT:        short_description_date   (e.g. norman_conquest_sicily_1061)
+CONCEPT:      descriptive_slug         (e.g. convivencia)
+ORGANIZATION: abbreviated_name        (e.g. fatimid_caliphate)</code></pre>
+  <p>
+    These IDs are stable across articles. When two articles both mention <code>roger_ii_sicily</code>,
+    they link automatically without fuzzy matching.
+  </p>
+
+  <h3>Change 3: Mentions array</h3>
+  <p>
+    Track all text variants encountered for each entity. Currently Petrarca has <code>{name, aliases}</code>.
+    Upgrade to a comprehensive <code>mentions</code> array populated from actual article text:
+  </p>
+<pre><code>{
+  "canonical_id": "roger_ii_sicily",
+  "name": "Roger II of Sicily",
+  "mentions": ["Roger II", "Roger", "the Norman king", "King Roger"],
+  "type": "PERSON",
+  "relationships": [
+    {"target": "kingdom_of_sicily", "type": "RULED"},
+    {"target": "fatimid_caliphate", "type": "OPPOSED"}
+  ]
+}</code></pre>
+
+  <h3>Change 4: Prescribed extraction workflow (from the Claude skill)</h3>
+  <p>
+    Add a step-by-step procedure to the extraction prompt instead of a single "extract entities" instruction:
+  </p>
+<pre><code>1. Read the article thoroughly
+2. Identify all named entities (people, places, events, concepts, organizations)
+3. Assign canonical_id to each using the convention above
+4. Collect all text mentions of each entity
+5. Record attributes (dates, type, description)
+6. Identify relationships using ONLY the predicate vocabulary
+7. Check: did you merge variants that refer to the same entity?</code></pre>
+
+  <h3>How to test</h3>
+  <p>
+    Run through the pipeline-eval framework: create a fixture with 5 articles from different domains,
+    extract entities with current prompt and new prompt, compare coverage and consistency.
+    Key metric: do the same entities get the same <code>canonical_id</code> across articles?
+  </p>
+
+  <div class="file-list">
+    <strong>Files to modify:</strong>
+    <code>scripts/extract_entity_concepts.py</code> (prompt changes),
+    <code>scripts/db.py</code> (add <code>canonical_id</code>, <code>mentions</code>, <code>relationship_type</code> columns)
+  </div>
+</div>
+
+<!-- ============================================================ -->
+<h2>3. Zotero Translation Server <span class="verdict maybe">Worth trying</span></h2>
+
+<div class="section caution">
+  <h3>The pitch</h3>
+  <p>
+    Zotero Translation Server is a standalone Docker service with 600+ community-maintained
+    site-specific extractors. It complements trafilatura &mdash; <strong>Zotero does metadata only,
+    trafilatura does content</strong>. Running both gives you richer article records.
+  </p>
+
+  <div class="effort">
+    <span><strong>Effort:</strong> ~100 lines + Docker setup</span>
+    <span><strong>Cost:</strong> ~500-700MB image, ~200MB RAM</span>
+    <span><strong>Latency:</strong> 1-5s per URL (parallel with trafilatura)</span>
+  </div>
+
+  <h3>What Zotero gives you that trafilatura doesn't</h3>
+  <table>
+    <tr><th>Field</th><th>Value for Petrarca</th></tr>
+    <tr><td><code>itemType</code></td><td>Semantic classification: <code>blogPost</code> vs <code>newspaperArticle</code> vs <code>journalArticle</code>. Much richer than hostname-based <code>content_type</code>.</td></tr>
+    <tr><td><code>creators[]</code></td><td>Structured first/last name + role (author vs editor vs translator). Better than raw author string.</td></tr>
+    <tr><td><code>abstractNote</code></td><td>Article abstract from meta tags. Free summary without LLM cost.</td></tr>
+    <tr><td><code>DOI</code> / <code>PMID</code></td><td>Unique identifiers for academic articles. Enables CrossRef/PubMed enrichment via <code>POST /search</code>.</td></tr>
+    <tr><td><code>publicationTitle</code></td><td>Publication name (journal, newspaper, blog name). More specific than hostname.</td></tr>
+    <tr><td><code>language</code></td><td>ISO language code from meta tags.</td></tr>
+    <tr><td><code>tags[]</code></td><td>Author-assigned keywords from meta tags. Free signal for entity matching.</td></tr>
+  </table>
+
+  <h3>Architecture</h3>
+<pre><code># docker-compose.yml addition:
+services:
+  zotero:
+    image: zotero/translation-server
+    ports: ["1969:1969"]
+    restart: unless-stopped
+
+# Python client (~20 lines):
+def zotero_metadata(url: str) -> dict | None:
+    try:
+        resp = requests.post("http://localhost:1969/web",
+                            data=url,
+                            headers={"Content-Type": "text/plain"},
+                            timeout=15)
+        if resp.status_code == 200:
+            items = resp.json()
+            return items[0] if items else None
+    except Exception:
+        return None  # graceful degradation</code></pre>
+
+  <h3>Integration pattern</h3>
+  <p>Run Zotero and trafilatura in parallel for each URL. Merge results:</p>
+  <ul>
+    <li>Content (markdown body): always from trafilatura</li>
+    <li>Title: prefer Zotero (site-specific extractors are smarter) with trafilatura fallback</li>
+    <li>Author: prefer Zotero (structured name parsing)</li>
+    <li>New fields: <code>item_type</code>, <code>abstract</code>, <code>doi</code>, <code>publication_name</code>, <code>language</code>, <code>meta_tags</code></li>
+  </ul>
+
+  <h3>Notable limitation</h3>
+  <p>
+    Zotero's Embedded Metadata translator does <strong>not parse JSON-LD</strong>
+    (<code>&lt;script type="application/ld+json"&gt;</code>). Many modern sites use JSON-LD
+    exclusively. PressForward's client-side parser does handle JSON-LD, but it requires
+    running in a browser context. For server-side processing, this is a gap.
+  </p>
+
+  <h3>Recommendation</h3>
+  <p>
+    Try it on 50 articles from different sources and measure how many fields Zotero fills
+    that trafilatura doesn't. If the hit rate is &gt;30%, deploy as a sidecar. If most articles
+    already have good metadata from trafilatura, skip it.
+  </p>
+
+  <div class="file-list">
+    <strong>Files to create/modify:</strong>
+    <code>docker-compose.yml</code> (add service),
+    <code>scripts/build_articles.py</code> (parallel metadata fetch + merge),
+    <code>scripts/db.py</code> (add metadata columns)
+  </div>
+</div>
+
+<!-- ============================================================ -->
+<h2>4. Discourser-style Semantic Vectors <span class="verdict maybe">Research spike</span></h2>
+
+<div class="section caution">
+  <h3>The idea</h3>
+  <p>
+    <a href="https://github.com/shawngraham/discourser">Discourser</a> defines custom semantic
+    dimensions by providing positive and negative term sets, then projects documents onto them.
+    For Petrarca, this could add continuous semantic coordinates to articles beyond discrete topic tags.
+  </p>
+
+  <h3>Example dimensions for Petrarca's historical domains</h3>
+<pre><code># Each dimension defined by positive/negative term sets:
+"primary_vs_secondary":
+  pos: ["chronicle", "inscription", "manuscript", "testimony", "decree"]
+  neg: ["argues", "interprets", "historiography", "scholarship", "analysis"]
+
+"military_vs_cultural":
+  pos: ["conquest", "siege", "army", "battle", "fortification"]
+  neg: ["art", "poetry", "mosque", "cathedral", "translation"]
+
+"technical_vs_narrative":
+  pos: ["data", "methodology", "analysis", "evidence", "quantitative"]
+  neg: ["story", "journey", "experience", "vivid", "dramatic"]</code></pre>
+
+  <p>
+    Articles get projected onto these axes, giving coordinates like
+    <code>{primary_vs_secondary: 0.73, military_vs_cultural: -0.2, technical_vs_narrative: 0.45}</code>.
+    This enriches feed ranking and could help the novelty system distinguish
+    "same topic, different angle" from "same topic, same angle."
+  </p>
+
+  <h3>Three methods from discourser</h3>
+  <table>
+    <tr><th>Method</th><th>How</th><th>Quality</th></tr>
+    <tr><td>Orthogonal projection</td><td>pos_centroid - neg_centroid, remove shared component</td><td>Best separation</td></tr>
+    <tr><td>Weighted difference</td><td>Simple centroid subtraction</td><td>Fast, decent</td></tr>
+    <tr><td>PCA axis</td><td>Max variance axis between pos/neg embeddings</td><td>Data-driven</td></tr>
+  </table>
+
+  <h3>Why this is a research spike, not an integration</h3>
+  <p>
+    Petrarca already has MiniLM embeddings via limbic. The computation is trivial.
+    The hard part is <strong>defining the right dimensions</strong> &mdash; this requires experimentation
+    to find axes that actually discriminate usefully between articles. A spike would:
+  </p>
+  <ol>
+    <li>Define 3-5 candidate dimensions with term sets</li>
+    <li>Project 100 existing articles onto them</li>
+    <li>Check: do the projections correlate with meaningful differences?</li>
+    <li>If yes, add to article metadata and feed ranking</li>
+  </ol>
+
+  <div class="effort">
+    <span><strong>Spike effort:</strong> ~2 hours, Jupyter notebook</span>
+    <span><strong>Full integration:</strong> ~150 lines if spike succeeds</span>
+    <span><strong>Dependencies:</strong> Already has MiniLM via limbic</span>
+  </div>
+</div>
+
+<!-- ============================================================ -->
+<h2>5. Dual-Model Verification <span class="verdict maybe">Consider later</span></h2>
+
+<div class="section caution">
+  <h3>What steamroller does</h3>
+  <p>
+    After initial entity/triplet extraction, two additional LLMs review the output:
+    Model 1 checks triplets against source text and suggests corrections,
+    Model 2 reviews Model 1's critique and produces final output.
+    This catches hallucinated entities and wrong relationships.
+  </p>
+
+  <h3>Adaptation for Petrarca</h3>
+  <p>
+    After entity extraction (Gemini Flash), run a verification pass (Claude Haiku via <code>claude -p</code>, free):
+  </p>
+<pre><code># Verification prompt:
+"Here is an article and the entities extracted from it.
+For each entity, verify:
+1. Is it actually mentioned in the article? (not hallucinated)
+2. Is the canonical_id consistent with other articles?
+3. Are the relationships supported by the text?
+Flag any issues."</code></pre>
+  <p>
+    This is cheap (Haiku, free via CLI) and catches the biggest failure mode: hallucinated entities
+    that pollute the knowledge graph. But it doubles the LLM calls per article.
+  </p>
+
+  <h3>When to do this</h3>
+  <p>
+    Wait until after the prompt engineering changes (#2 above). Constrained relationship types
+    and canonical IDs may reduce hallucination enough that verification isn't needed.
+    If entity quality is still an issue after those changes, add verification.
+  </p>
+</div>
+
+<!-- ============================================================ -->
+<h2>Dropped: PressForward Metadata Cascade <span class="verdict no">Skip</span></h2>
+
+<div class="section skip">
+  <h3>Why not</h3>
+  <p>
+    Deep-dive confirmed that trafilatura already covers everything PressForward does for content extraction,
+    and does it better (trafilatura's algorithm outperforms standalone Readability on edge cases).
+    PressForward's metadata cascade (OG &rarr; Twitter &rarr; JSON-LD &rarr; meta description) is well-structured
+    but trafilatura handles the same sources.
+  </p>
+  <p>
+    The interesting part of PressForward is its <strong>editorial workflow</strong> (feed &rarr; nomination &rarr; publication),
+    but Petrarca already has its own article lifecycle. Not worth the WordPress/PHP dependency.
+  </p>
+  <p><strong>One pattern worth stealing</strong> (no integration needed): the image fallback chain
+    (OG image &rarr; <code>link[rel=image_src]</code> &rarr; Twitter image &rarr; first large <code>&lt;img&gt;</code>).
+    Add to trafilatura post-processing if Petrarca needs featured images.
+  </p>
+</div>
+
+<!-- ============================================================ -->
+<h2>Implementation Order</h2>
+
+<div class="section">
+  <table>
+    <tr><th>#</th><th>What</th><th>Effort</th><th>Value</th><th>Dependencies</th></tr>
+    <tr>
+      <td>1</td>
+      <td><strong>Entity extraction prompt changes</strong><br>Constrained predicates, canonical IDs, mentions, prescribed workflow</td>
+      <td>1 session</td>
+      <td>High &mdash; fixes entity dedup, makes KG queryable</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>2</td>
+      <td><strong>Hypothesis integration</strong><br>Sync, claims, tags, auto-import</td>
+      <td>1-2 sessions</td>
+      <td>High &mdash; user-curated claims are the strongest signal</td>
+      <td>Hypothesis API key</td>
+    </tr>
+    <tr>
+      <td>3</td>
+      <td><strong>Semantic vectors spike</strong><br>Define dimensions, project 100 articles, evaluate</td>
+      <td>2 hours</td>
+      <td>Unknown &mdash; depends on spike results</td>
+      <td>limbic (already have)</td>
+    </tr>
+    <tr>
+      <td>4</td>
+      <td><strong>Zotero Translation Server trial</strong><br>Run on 50 articles, measure metadata delta</td>
+      <td>2 hours</td>
+      <td>Medium &mdash; depends on metadata gap</td>
+      <td>Docker</td>
+    </tr>
+    <tr>
+      <td>5</td>
+      <td><strong>Dual-model verification</strong><br>Add if entity quality is still an issue after #1</td>
+      <td>1 session</td>
+      <td>Medium &mdash; insurance against hallucination</td>
+      <td>claude -p (already have)</td>
+    </tr>
+  </table>
+</div>
+
+<!-- ============================================================ -->
+<h2>Source Repos Reference</h2>
+
+<div class="section">
+  <table>
+    <tr><th>Repo</th><th>Author</th><th>What to look at</th></tr>
+    <tr>
+      <td><a href="https://github.com/shawngraham/steamroller">steamroller</a></td>
+      <td>Graham</td>
+      <td><code>predicates.txt</code> (relationship vocabulary pattern), <code>results_evaluator.py</code> (dual-model verification)</td>
+    </tr>
+    <tr>
+      <td><a href="https://github.com/shawngraham/kg-hybrid">kg-hybrid</a></td>
+      <td>Graham</td>
+      <td><code>kg_extract.py</code> lines 272-506 (LLM refinement schema with canonical IDs)</td>
+    </tr>
+    <tr>
+      <td><a href="https://github.com/shawngraham/claude_antiquities_extractor_skill">claude_antiquities_extractor_skill</a></td>
+      <td>Graham</td>
+      <td>SKILL.md (extraction workflow, canonical ID conventions, mentions tracking)</td>
+    </tr>
+    <tr>
+      <td><a href="https://github.com/shawngraham/discourser">discourser</a></td>
+      <td>Graham</td>
+      <td><code>CustomVectorManager</code> class (semantic dimension definition + projection)</td>
+    </tr>
+    <tr>
+      <td><a href="https://github.com/zotero/translation-server">translation-server</a></td>
+      <td>Zotero</td>
+      <td>Docker setup, <code>POST /web</code> API</td>
+    </tr>
+    <tr>
+      <td><a href="https://github.com/zotero/translators">translators</a></td>
+      <td>Zotero</td>
+      <td><code>Embedded Metadata.js</code> (generic meta tag parsing)</td>
+    </tr>
+    <tr>
+      <td><a href="https://hypothes.is/api/">Hypothesis API</a></td>
+      <td>Hypothesis</td>
+      <td><code>GET /api/search</code> (annotation sync), <code>TextQuoteSelector</code> (highlighted text)</td>
+    </tr>
+    <tr>
+      <td><a href="https://github.com/out-of-cheese-error/gooseberry">gooseberry</a></td>
+      <td>out-of-cheese-error</td>
+      <td>Incremental sync pattern via <code>search_after</code> cursor</td>
+    </tr>
+  </table>
+</div>
+
+<footer>
+  Compiled April 2026 from deep-dive analysis of 15+ repos and APIs.
+  Based on Petrarca architecture as of April 2026 (trafilatura + Gemini Flash + MiniLM + atomic claims).
+</footer>
+
+</div>
+</body>
+</html>

--- a/research/quran-function-words.html
+++ b/research/quran-function-words.html
@@ -1,0 +1,1694 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Function Words of the Quran — حروف القرآن</title>
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=Scheherazade+New:wght@400;700&family=Inter:wght@300;400;500;600;700&family=Amiri:wght@400;700&display=swap');
+
+  :root {
+    --gold: #d4a056;
+    --gold-light: #f5e6c8;
+    --gold-dark: #b8862d;
+    --bg: #0f1419;
+    --bg-card: #1a2028;
+    --bg-card-hover: #1f2832;
+    --bg-verse: #141a22;
+    --text: #e8e0d4;
+    --text-muted: #8a9aad;
+    --text-dim: #5a6a7a;
+    --accent-blue: #4a9eed;
+    --accent-green: #5bb98c;
+    --accent-purple: #9b7ed8;
+    --accent-rose: #d47a8a;
+    --accent-teal: #4ab8a8;
+    --accent-orange: #d89a5e;
+    --border: rgba(212,160,86,0.15);
+    --border-strong: rgba(212,160,86,0.3);
+  }
+
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+
+  body {
+    font-family: 'Inter', system-ui, sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    line-height: 1.7;
+    min-height: 100vh;
+  }
+
+  /* Hero */
+  .hero {
+    text-align: center;
+    padding: 80px 24px 60px;
+    background: linear-gradient(180deg, rgba(212,160,86,0.08) 0%, transparent 100%);
+    border-bottom: 1px solid var(--border);
+  }
+  .hero-arabic {
+    font-family: 'Scheherazade New', serif;
+    font-size: 3.5rem;
+    color: var(--gold);
+    direction: rtl;
+    margin-bottom: 12px;
+    letter-spacing: 2px;
+  }
+  .hero h1 {
+    font-size: 2rem;
+    font-weight: 300;
+    color: var(--text);
+    letter-spacing: 1px;
+  }
+  .hero p {
+    max-width: 680px;
+    margin: 20px auto 0;
+    color: var(--text-muted);
+    font-size: 1.05rem;
+    line-height: 1.8;
+  }
+
+  /* Nav */
+  .toc {
+    max-width: 960px;
+    margin: 0 auto;
+    padding: 40px 24px 20px;
+  }
+  .toc h2 {
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 3px;
+    color: var(--text-dim);
+    margin-bottom: 16px;
+  }
+  .toc-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    gap: 8px;
+  }
+  .toc-grid a {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 14px;
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    text-decoration: none;
+    color: var(--text);
+    font-size: 0.9rem;
+    transition: all 0.2s;
+  }
+  .toc-grid a:hover {
+    background: var(--bg-card-hover);
+    border-color: var(--border-strong);
+  }
+  .toc-grid a .toc-ar {
+    font-family: 'Scheherazade New', serif;
+    font-size: 1.2rem;
+    color: var(--gold);
+    direction: rtl;
+  }
+
+  /* Main content */
+  .content {
+    max-width: 960px;
+    margin: 0 auto;
+    padding: 20px 24px 80px;
+  }
+
+  /* Section */
+  .section {
+    margin-top: 60px;
+  }
+  .section-header {
+    display: flex;
+    align-items: baseline;
+    gap: 16px;
+    margin-bottom: 8px;
+    padding-bottom: 12px;
+    border-bottom: 2px solid var(--border-strong);
+  }
+  .section-header h2 {
+    font-size: 1.5rem;
+    font-weight: 600;
+    color: var(--text);
+  }
+  .section-header .ar-title {
+    font-family: 'Amiri', serif;
+    font-size: 1.6rem;
+    color: var(--gold);
+    direction: rtl;
+  }
+  .section-intro {
+    color: var(--text-muted);
+    margin: 12px 0 24px;
+    font-size: 0.95rem;
+    line-height: 1.8;
+    max-width: 720px;
+  }
+
+  /* Word cards */
+  .word-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 16px;
+    margin-top: 20px;
+  }
+  .word-card {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 24px;
+    transition: all 0.25s;
+  }
+  .word-card:hover {
+    border-color: var(--border-strong);
+    background: var(--bg-card-hover);
+    transform: translateY(-1px);
+  }
+  .word-card .arabic {
+    font-family: 'Scheherazade New', serif;
+    font-size: 2.4rem;
+    color: var(--gold);
+    direction: rtl;
+    text-align: right;
+    line-height: 1.4;
+  }
+  .word-card .translit {
+    font-size: 0.85rem;
+    color: var(--accent-blue);
+    font-style: italic;
+    margin-top: 4px;
+    text-align: right;
+  }
+  .word-card .meaning {
+    font-size: 1.1rem;
+    font-weight: 500;
+    color: var(--text);
+    margin-top: 12px;
+  }
+  .word-card .grammar-tag {
+    display: inline-block;
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 1.5px;
+    padding: 3px 8px;
+    border-radius: 4px;
+    margin-top: 8px;
+    font-weight: 600;
+  }
+  .tag-prep { background: rgba(74,158,237,0.12); color: var(--accent-blue); }
+  .tag-conj { background: rgba(91,185,140,0.12); color: var(--accent-green); }
+  .tag-pron { background: rgba(155,126,216,0.12); color: var(--accent-purple); }
+  .tag-neg { background: rgba(212,122,138,0.12); color: var(--accent-rose); }
+  .tag-dem { background: rgba(74,184,168,0.12); color: var(--accent-teal); }
+  .tag-rel { background: rgba(216,154,94,0.12); color: var(--accent-orange); }
+  .tag-cond { background: rgba(155,126,216,0.12); color: var(--accent-purple); }
+  .tag-emph { background: rgba(212,160,86,0.15); color: var(--gold); }
+  .tag-mystery { background: rgba(212,160,86,0.2); color: var(--gold); }
+  .tag-obj { background: rgba(74,184,168,0.12); color: var(--accent-teal); }
+
+  /* Register badges */
+  .register-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    font-size: 0.68rem;
+    font-weight: 600;
+    letter-spacing: 0.5px;
+    padding: 3px 9px;
+    border-radius: 10px;
+    margin-top: 6px;
+    margin-left: 4px;
+    vertical-align: middle;
+  }
+  .register-badge .dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    display: inline-block;
+  }
+  .reg-all { background: rgba(91,185,140,0.1); color: var(--accent-green); }
+  .reg-all .dot { background: var(--accent-green); }
+  .reg-formal { background: rgba(74,158,237,0.1); color: var(--accent-blue); }
+  .reg-formal .dot { background: var(--accent-blue); }
+  .reg-quran { background: rgba(212,160,86,0.12); color: var(--gold); }
+  .reg-quran .dot { background: var(--gold); }
+
+  /* Register legend */
+  .legend {
+    max-width: 960px;
+    margin: 0 auto;
+    padding: 0 24px;
+  }
+  .legend-box {
+    display: flex;
+    gap: 24px;
+    flex-wrap: wrap;
+    padding: 16px 20px;
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+  }
+  .legend-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 0.85rem;
+    color: var(--text-muted);
+  }
+  .legend-item .register-badge { margin: 0; }
+  .legend-item span.desc { line-height: 1.4; }
+
+  /* Register column in suffix table */
+  .suffix-table .reg-cell { text-align: center; }
+
+  .word-card .explanation {
+    color: var(--text-muted);
+    font-size: 0.88rem;
+    margin-top: 10px;
+    line-height: 1.7;
+  }
+
+  /* Verse example */
+  .verse-example {
+    margin-top: 14px;
+    padding: 14px 16px;
+    background: var(--bg-verse);
+    border-left: 3px solid var(--gold-dark);
+    border-radius: 0 8px 8px 0;
+  }
+  .verse-example .verse-ar {
+    font-family: 'Scheherazade New', serif;
+    font-size: 1.5rem;
+    color: var(--gold-light);
+    direction: rtl;
+    text-align: right;
+    line-height: 2;
+  }
+  .verse-example .verse-ar .highlight {
+    color: #fff;
+    background: rgba(212,160,86,0.25);
+    padding: 2px 4px;
+    border-radius: 3px;
+  }
+  .verse-example .verse-en {
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    margin-top: 8px;
+    font-style: italic;
+  }
+  .verse-example .verse-ref {
+    font-size: 0.75rem;
+    color: var(--text-dim);
+    margin-top: 4px;
+  }
+
+  /* Full-width feature cards */
+  .feature-card {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 14px;
+    padding: 32px;
+    margin-top: 16px;
+  }
+  .feature-card .arabic {
+    font-family: 'Scheherazade New', serif;
+    font-size: 2.8rem;
+    color: var(--gold);
+    direction: rtl;
+    text-align: right;
+    line-height: 1.5;
+  }
+  .feature-card .translit {
+    font-size: 0.9rem;
+    color: var(--accent-blue);
+    font-style: italic;
+    text-align: right;
+    margin-top: 4px;
+  }
+  .feature-card .meaning {
+    font-size: 1.2rem;
+    font-weight: 500;
+    margin-top: 14px;
+  }
+  .feature-card .explanation {
+    color: var(--text-muted);
+    font-size: 0.92rem;
+    margin-top: 12px;
+    line-height: 1.8;
+  }
+
+  /* Clitic decomposition */
+  .decomp {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 8px;
+    direction: rtl;
+    margin: 12px 0;
+    flex-wrap: wrap;
+  }
+  .decomp-part {
+    text-align: center;
+    padding: 8px 14px;
+    background: rgba(212,160,86,0.08);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+  }
+  .decomp-part .ar {
+    font-family: 'Scheherazade New', serif;
+    font-size: 1.6rem;
+    color: var(--gold);
+  }
+  .decomp-part .en {
+    font-size: 0.72rem;
+    color: var(--text-muted);
+    margin-top: 2px;
+  }
+  .decomp-plus {
+    color: var(--text-dim);
+    font-size: 1.2rem;
+  }
+
+  /* Suffix table */
+  .suffix-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 16px;
+  }
+  .suffix-table th {
+    text-align: left;
+    padding: 10px 14px;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 2px;
+    color: var(--text-dim);
+    border-bottom: 1px solid var(--border-strong);
+  }
+  .suffix-table th:nth-child(1),
+  .suffix-table td:nth-child(1) {
+    text-align: right;
+    direction: rtl;
+  }
+  .suffix-table td {
+    padding: 10px 14px;
+    border-bottom: 1px solid var(--border);
+    font-size: 0.92rem;
+  }
+  .suffix-table td:first-child {
+    font-family: 'Scheherazade New', serif;
+    font-size: 1.4rem;
+    color: var(--gold);
+  }
+  .suffix-table tr:hover td {
+    background: rgba(212,160,86,0.04);
+  }
+
+  /* Concept boxes */
+  .concept-box {
+    background: linear-gradient(135deg, rgba(212,160,86,0.06), rgba(212,160,86,0.02));
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 24px;
+    margin: 24px 0;
+  }
+  .concept-box h3 {
+    font-size: 1rem;
+    color: var(--gold);
+    margin-bottom: 10px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .concept-box p {
+    color: var(--text-muted);
+    font-size: 0.92rem;
+    line-height: 1.8;
+  }
+
+  /* Responsive */
+  @media (max-width: 640px) {
+    .hero-arabic { font-size: 2.4rem; }
+    .hero h1 { font-size: 1.5rem; }
+    .word-grid { grid-template-columns: 1fr; }
+    .toc-grid { grid-template-columns: 1fr 1fr; }
+    .section-header { flex-direction: column; gap: 4px; }
+    .decomp { gap: 6px; }
+    .decomp-part { padding: 6px 10px; }
+    .decomp-part .ar { font-size: 1.3rem; }
+  }
+
+  /* Scroll padding for anchors */
+  [id] { scroll-margin-top: 20px; }
+
+  /* Back to top */
+  .back-top {
+    display: inline-block;
+    margin-top: 20px;
+    font-size: 0.8rem;
+    color: var(--text-dim);
+    text-decoration: none;
+  }
+  .back-top:hover { color: var(--gold); }
+</style>
+</head>
+<body>
+
+<div class="hero">
+  <div class="hero-arabic">حُروف القُرآن</div>
+  <h1>Function Words of the Quran</h1>
+  <p>
+    Arabic function words — particles, pronouns, prepositions, and conjunctions — are the connective tissue of Quranic Arabic.
+    They appear on almost every line, yet each carries precise grammatical meaning.
+    Mastering these ~100 words unlocks the structure of every verse you read.
+  </p>
+</div>
+
+<div class="toc">
+  <h2>Contents</h2>
+  <div class="toc-grid">
+    <a href="#iyyaka"><span class="toc-ar">إيّاكَ</span> Disconnected Objects</a>
+    <a href="#muqattaat"><span class="toc-ar">الٓمٓ</span> Mystery Letters</a>
+    <a href="#prepositions"><span class="toc-ar">حروف الجر</span> Prepositions</a>
+    <a href="#clitics"><span class="toc-ar">بِـ لِـ كَـ</span> Single-Letter Clitics</a>
+    <a href="#conjunctions"><span class="toc-ar">حروف العطف</span> Conjunctions</a>
+    <a href="#pronouns"><span class="toc-ar">الضمائر</span> Personal Pronouns</a>
+    <a href="#suffixes"><span class="toc-ar">ـهُ ـها ـهم</span> Pronoun Suffixes</a>
+    <a href="#demonstratives"><span class="toc-ar">أسماء الإشارة</span> Demonstratives</a>
+    <a href="#relative"><span class="toc-ar">الّذي الّذين</span> Relative Pronouns</a>
+    <a href="#negation"><span class="toc-ar">أدوات النفي</span> Negation</a>
+    <a href="#emphasis"><span class="toc-ar">إنَّ قَدْ</span> Emphasis</a>
+    <a href="#conditionals"><span class="toc-ar">إذا لو إنْ</span> Conditionals</a>
+  </div>
+</div>
+
+<div class="legend">
+  <div class="legend-box">
+    <div class="legend-item">
+      <span class="register-badge reg-all"><span class="dot"></span>All Arabic</span>
+      <span class="desc">Universal — used across spoken dialects, MSA, classical, and Quran alike</span>
+    </div>
+    <div class="legend-item">
+      <span class="register-badge reg-formal"><span class="dot"></span>Classical &amp; Formal MSA</span>
+      <span class="desc">Standard in written MSA (news, literature) and Quran/classical, but rare in casual speech</span>
+    </div>
+    <div class="legend-item">
+      <span class="register-badge reg-quran"><span class="dot"></span>Quranic / Classical</span>
+      <span class="desc">Essentially confined to the Quran, classical poetry, and elevated literary prose</span>
+    </div>
+  </div>
+</div>
+
+<div class="content">
+
+  <!-- ═══════════════════════════════════════ -->
+  <!-- SECTION 1: إيّاك — Disconnected Object Pronouns -->
+  <!-- ═══════════════════════════════════════ -->
+  <div class="section" id="iyyaka">
+    <div class="section-header">
+      <h2>Disconnected Object Pronouns</h2>
+      <span class="ar-title">الضمائر المنفصلة المنصوبة</span>
+    </div>
+    <p class="section-intro">
+      These are among the most theologically powerful words in the Quran. While normal object pronouns attach as suffixes (e.g. <em>-hu</em> "him", <em>-ka</em> "you"),
+      the <strong>إيّا</strong> (iyyā-) forms stand alone as separate words. In Arabic grammar, this <strong>fronting</strong> creates exclusive emphasis:
+      "You <em>alone</em>" — not just "you." When you hear <em>إيّاكَ نعبد</em>, the structure itself means worship belongs exclusively to God.
+    </p>
+
+    <div class="feature-card">
+      <div class="arabic">إِيَّاكَ نَعْبُدُ وَإِيَّاكَ نَسْتَعِينُ</div>
+      <div class="translit">iyyāka naʿbudu wa-iyyāka nastaʿīn</div>
+      <div class="meaning">"You alone we worship, and You alone we ask for help."</div>
+      <div class="explanation">
+        This is verse 5 of <strong>Al-Fātiḥah</strong> (The Opening), recited by Muslims in every unit of prayer — making <em>إيّاك</em> possibly the most frequently spoken Arabic word in history.
+        The normal word order would be <em>نعبدك</em> ("we worship you") with the pronoun as a suffix. By fronting <em>إيّاك</em> to the beginning,
+        the verse creates <strong>حصر</strong> (ḥaṣr) — grammatical restriction — meaning "You and <em>no one else</em>."
+      </div>
+      <div class="verse-example">
+        <div class="verse-ref">Sūrat al-Fātiḥah (1:5)</div>
+      </div>
+    </div>
+
+    <div class="word-grid" style="margin-top: 20px;">
+      <div class="word-card">
+        <div class="arabic">إيَّاكَ</div>
+        <div class="translit">iyyāka</div>
+        <div class="meaning">You alone (masc. singular)</div>
+        <span class="grammar-tag tag-obj">Object pronoun</span>
+        <span class="register-badge reg-formal"><span class="dot"></span>Classical &amp; Formal MSA</span>
+        <div class="explanation">Addresses a single male. In the Quran, always addresses God. Technically valid in modern formal Arabic but almost never used outside religious or literary contexts.</div>
+      </div>
+      <div class="word-card">
+        <div class="arabic">إيَّاكُم</div>
+        <div class="translit">iyyākum</div>
+        <div class="meaning">You all alone (masc. plural)</div>
+        <span class="grammar-tag tag-obj">Object pronoun</span>
+        <span class="register-badge reg-formal"><span class="dot"></span>Classical &amp; Formal MSA</span>
+        <div class="explanation">Addresses a group. Used when God speaks to humanity or a community.</div>
+      </div>
+      <div class="word-card">
+        <div class="arabic">إيَّاهُ</div>
+        <div class="translit">iyyāhu</div>
+        <div class="meaning">Him alone</div>
+        <span class="grammar-tag tag-obj">Object pronoun</span>
+        <span class="register-badge reg-formal"><span class="dot"></span>Classical &amp; Formal MSA</span>
+        <div class="explanation">Third person — "Him and no one else."</div>
+        <div class="verse-example">
+          <div class="verse-ar">أَلَّا تَعْبُدُوا إِلَّا <span class="highlight">إِيَّاهُ</span></div>
+          <div class="verse-en">"that you worship none but Him alone"</div>
+          <div class="verse-ref">Yūsuf (12:40)</div>
+        </div>
+      </div>
+      <div class="word-card">
+        <div class="arabic">إيَّاهُم</div>
+        <div class="translit">iyyāhum</div>
+        <div class="meaning">Them alone</div>
+        <span class="grammar-tag tag-obj">Object pronoun</span>
+        <span class="register-badge reg-formal"><span class="dot"></span>Classical &amp; Formal MSA</span>
+        <div class="explanation">Emphasizes exclusivity of a group being referenced.</div>
+      </div>
+      <div class="word-card">
+        <div class="arabic">إيَّايَ</div>
+        <div class="translit">iyyāya</div>
+        <div class="meaning">Me alone</div>
+        <span class="grammar-tag tag-obj">Object pronoun</span>
+        <span class="register-badge reg-quran"><span class="dot"></span>Quranic / Classical</span>
+        <div class="explanation">God referring to Himself as exclusive object of worship or fear. Extremely rare outside the Quran and classical poetry.</div>
+        <div class="verse-example">
+          <div class="verse-ar">فَ<span class="highlight">إِيَّايَ</span> فَارْهَبُونِ</div>
+          <div class="verse-en">"then it is Me alone you should fear"</div>
+          <div class="verse-ref">Al-Baqarah (2:40)</div>
+        </div>
+      </div>
+      <div class="word-card">
+        <div class="arabic">إيَّانا</div>
+        <div class="translit">iyyānā</div>
+        <div class="meaning">Us alone</div>
+        <span class="grammar-tag tag-obj">Object pronoun</span>
+        <span class="register-badge reg-quran"><span class="dot"></span>Quranic / Classical</span>
+        <div class="explanation">First person plural — rare even in the Quran and essentially absent from modern Arabic.</div>
+      </div>
+    </div>
+
+    <div class="concept-box">
+      <h3>💡 Why does fronting create exclusivity?</h3>
+      <p>
+        In Arabic, the default verb-subject-object order (VSO) is <em>نعبدك</em> — "we worship you."
+        Moving the object before the verb (<em>إيّاك نعبد</em>) is grammatically marked. Arabic grammarians call this
+        <strong>تقديم ما حقّه التأخير</strong> — "fronting what by right should come later." This marked structure
+        signals that the fronted element is the exclusive focus. It's as if the sentence says: "As for You — <em>that's</em> who we worship, no one else."
+        The same device is used in legal Arabic for exclusivity clauses.
+      </p>
+    </div>
+
+    <a href="#" class="back-top">↑ Back to top</a>
+  </div>
+
+  <!-- ═══════════════════════════════════════ -->
+  <!-- SECTION 2: Mystery Letters -->
+  <!-- ═══════════════════════════════════════ -->
+  <div class="section" id="muqattaat">
+    <div class="section-header">
+      <h2>The Mystery Letters</h2>
+      <span class="ar-title">الحروف المقطّعة</span>
+    </div>
+    <p class="section-intro">
+      Twenty-nine surahs of the Quran open with combinations of Arabic letters that are not words in any known sense.
+      They are recited as individual letter names: <em>alif, lām, mīm</em> — not as a word. Their meaning has been debated
+      for 1400 years. Some scholars say they are divine secrets; others suggest they are acoustic hooks that grab attention
+      before revelation begins. No definitive explanation exists — which is itself part of their mystique.
+    </p>
+
+    <div class="word-grid">
+      <div class="word-card">
+        <div class="arabic">الٓمٓ</div>
+        <div class="translit">alif lām mīm</div>
+        <div class="meaning">Alif Lam Mim</div>
+        <span class="grammar-tag tag-mystery">Muqaṭṭaʿāt</span>
+        <span class="register-badge reg-quran"><span class="dot"></span>Quranic only</span>
+        <div class="explanation">Opens 6 surahs including Al-Baqarah, Āl ʿImrān, and Al-ʿAnkabūt. The most frequent combination.</div>
+        <div class="verse-example">
+          <div class="verse-ar"><span class="highlight">الٓمٓ</span> ۚ ذَٰلِكَ الْكِتَابُ لَا رَيْبَ ۛ فِيهِ</div>
+          <div class="verse-en">"Alif Lam Mim. This is the Book about which there is no doubt."</div>
+          <div class="verse-ref">Al-Baqarah (2:1–2)</div>
+        </div>
+      </div>
+      <div class="word-card">
+        <div class="arabic">الٓر</div>
+        <div class="translit">alif lām rā</div>
+        <div class="meaning">Alif Lam Ra</div>
+        <span class="grammar-tag tag-mystery">Muqaṭṭaʿāt</span>
+        <span class="register-badge reg-quran"><span class="dot"></span>Quranic only</span>
+        <div class="explanation">Opens 5 surahs: Yūnus, Hūd, Yūsuf, Ibrāhīm, and Al-Ḥijr.</div>
+      </div>
+      <div class="word-card">
+        <div class="arabic">حمٓ</div>
+        <div class="translit">ḥā mīm</div>
+        <div class="meaning">Ha Mim</div>
+        <span class="grammar-tag tag-mystery">Muqaṭṭaʿāt</span>
+        <span class="register-badge reg-quran"><span class="dot"></span>Quranic only</span>
+        <div class="explanation">Opens 7 consecutive surahs (40–46), known collectively as the "Ḥawāmīm" family.</div>
+      </div>
+      <div class="word-card">
+        <div class="arabic">طه</div>
+        <div class="translit">ṭā hā</div>
+        <div class="meaning">Ta Ha</div>
+        <span class="grammar-tag tag-mystery">Muqaṭṭaʿāt</span>
+        <span class="register-badge reg-quran"><span class="dot"></span>Quranic only</span>
+        <div class="explanation">Opens Surah 20 (Ṭā Hā). Some say it means "O man" in an ancient dialect. Often used as a name for Prophet Muhammad.</div>
+      </div>
+      <div class="word-card">
+        <div class="arabic">يسٓ</div>
+        <div class="translit">yā sīn</div>
+        <div class="meaning">Ya Sin</div>
+        <span class="grammar-tag tag-mystery">Muqaṭṭaʿāt</span>
+        <span class="register-badge reg-quran"><span class="dot"></span>Quranic only</span>
+        <div class="explanation">Opens Surah 36. Called "the Heart of the Quran." Some interpret it as "O human being."</div>
+      </div>
+      <div class="word-card">
+        <div class="arabic">صٓ</div>
+        <div class="translit">ṣād</div>
+        <div class="meaning">Sad</div>
+        <span class="grammar-tag tag-mystery">Muqaṭṭaʿāt</span>
+        <span class="register-badge reg-quran"><span class="dot"></span>Quranic only</span>
+        <div class="explanation">A single letter opening Surah 38. Immediately followed by "By the Quran full of remembrance."</div>
+      </div>
+    </div>
+
+    <div class="concept-box">
+      <h3>💡 Theories about the mystery letters</h3>
+      <p>
+        <strong>1. Divine secret</strong> — Many classical scholars (including Ibn ʿAbbās) said these are among the secrets of the Quran that God alone knows.<br>
+        <strong>2. Attention device</strong> — The unexpected letter sounds interrupt the listener, creating attention before the message begins — like a clearing of the throat.<br>
+        <strong>3. Proof of inimitability</strong> — "Here are the same letters you use every day, yet you cannot produce anything like this Book."<br>
+        <strong>4. Surah names</strong> — Some may simply serve as names for their surahs, the way we might title a chapter "Q" or "X."
+      </p>
+    </div>
+
+    <a href="#" class="back-top">↑ Back to top</a>
+  </div>
+
+  <!-- ═══════════════════════════════════════ -->
+  <!-- SECTION 3: Prepositions -->
+  <!-- ═══════════════════════════════════════ -->
+  <div class="section" id="prepositions">
+    <div class="section-header">
+      <h2>Prepositions</h2>
+      <span class="ar-title">حروف الجرّ</span>
+    </div>
+    <p class="section-intro">
+      Prepositions in Arabic (حروف الجرّ, ḥurūf al-jarr — literally "letters of pulling") put the following noun into the genitive case (مجرور).
+      Some are standalone words; others are single-letter clitics that attach directly to the next word. The Quran's prepositions often carry theological weight
+      — <em>فِي</em> (in) versus <em>عَلَى</em> (upon) can change the meaning of a verse significantly.
+    </p>
+
+    <div class="word-grid">
+      <div class="word-card">
+        <div class="arabic">فِي</div>
+        <div class="translit">fī</div>
+        <div class="meaning">In / within</div>
+        <span class="grammar-tag tag-prep">Preposition</span>
+        <span class="register-badge reg-all"><span class="dot"></span>All Arabic</span>
+        <div class="explanation">One of the most common words in the Quran. Indicates location, time, or state.</div>
+        <div class="verse-example">
+          <div class="verse-ar">وَ<span class="highlight">فِي</span> أَنفُسِكُمْ ۚ أَفَلَا تُبْصِرُونَ</div>
+          <div class="verse-en">"And within yourselves — will you not then see?"</div>
+          <div class="verse-ref">Adh-Dhāriyāt (51:21)</div>
+        </div>
+      </div>
+      <div class="word-card">
+        <div class="arabic">مِنْ</div>
+        <div class="translit">min</div>
+        <div class="meaning">From / of / some of</div>
+        <span class="grammar-tag tag-prep">Preposition</span>
+        <span class="register-badge reg-all"><span class="dot"></span>All Arabic</span>
+        <div class="explanation">Indicates origin, partitive meaning ("some of"), or starting point. The most frequent preposition in the Quran.</div>
+        <div class="verse-example">
+          <div class="verse-ar">خَلَقَ الْإِنسَانَ <span class="highlight">مِنْ</span> عَلَقٍ</div>
+          <div class="verse-en">"Created man from a clinging substance"</div>
+          <div class="verse-ref">Al-ʿAlaq (96:2)</div>
+        </div>
+      </div>
+      <div class="word-card">
+        <div class="arabic">عَلَى</div>
+        <div class="translit">ʿalā</div>
+        <div class="meaning">On / upon / over</div>
+        <span class="grammar-tag tag-prep">Preposition</span>
+        <span class="register-badge reg-all"><span class="dot"></span>All Arabic</span>
+        <div class="explanation">Physical or abstract "upon." Often expresses obligation or mastery.</div>
+        <div class="verse-example">
+          <div class="verse-ar">خَتَمَ اللَّهُ <span class="highlight">عَلَىٰ</span> قُلُوبِهِمْ</div>
+          <div class="verse-en">"God has set a seal upon their hearts"</div>
+          <div class="verse-ref">Al-Baqarah (2:7)</div>
+        </div>
+      </div>
+      <div class="word-card">
+        <div class="arabic">إلَى</div>
+        <div class="translit">ilā</div>
+        <div class="meaning">To / toward / until</div>
+        <span class="grammar-tag tag-prep">Preposition</span>
+        <span class="register-badge reg-all"><span class="dot"></span>All Arabic</span>
+        <div class="explanation">Indicates direction, destination, or endpoint. Often paired with مِن for "from...to."</div>
+      </div>
+      <div class="word-card">
+        <div class="arabic">عَنْ</div>
+        <div class="translit">ʿan</div>
+        <div class="meaning">About / away from</div>
+        <span class="grammar-tag tag-prep">Preposition</span>
+        <span class="register-badge reg-all"><span class="dot"></span>All Arabic</span>
+        <div class="explanation">Indicates separation or topic. يسألونك عن — "They ask you about..."</div>
+      </div>
+      <div class="word-card">
+        <div class="arabic">مَعَ</div>
+        <div class="translit">maʿa</div>
+        <div class="meaning">With / together with</div>
+        <span class="grammar-tag tag-prep">Preposition</span>
+        <span class="register-badge reg-all"><span class="dot"></span>All Arabic</span>
+        <div class="explanation">Companionship or accompaniment. إنَّ اللهَ مَعَ الصابرين — "God is with the patient."</div>
+      </div>
+      <div class="word-card">
+        <div class="arabic">بَيْنَ</div>
+        <div class="translit">bayna</div>
+        <div class="meaning">Between / among</div>
+        <span class="grammar-tag tag-prep">Preposition</span>
+        <span class="register-badge reg-all"><span class="dot"></span>All Arabic</span>
+        <div class="explanation">Spatial or relational "between." Often doubled: بينهم — "among them."</div>
+      </div>
+      <div class="word-card">
+        <div class="arabic">حَتَّى</div>
+        <div class="translit">ḥattā</div>
+        <div class="meaning">Until / even</div>
+        <span class="grammar-tag tag-prep">Preposition</span>
+        <span class="register-badge reg-all"><span class="dot"></span>All Arabic</span>
+        <div class="explanation">Marks an endpoint. Can also mean "even" (inclusive emphasis). One of the few Arabic words that can be a preposition, conjunction, or particle.</div>
+      </div>
+      <div class="word-card">
+        <div class="arabic">عِنْدَ</div>
+        <div class="translit">ʿinda</div>
+        <div class="meaning">At / in the possession of</div>
+        <span class="grammar-tag tag-prep">Preposition</span>
+        <span class="register-badge reg-all"><span class="dot"></span>All Arabic</span>
+        <div class="explanation">Proximity or possession. عِندَ اللهِ — "with God / in God's sight."</div>
+      </div>
+    </div>
+
+    <a href="#" class="back-top">↑ Back to top</a>
+  </div>
+
+  <!-- ═══════════════════════════════════════ -->
+  <!-- SECTION 4: Single-Letter Clitics -->
+  <!-- ═══════════════════════════════════════ -->
+  <div class="section" id="clitics">
+    <div class="section-header">
+      <h2>Single-Letter Clitics</h2>
+      <span class="ar-title">الحروف المتّصلة</span>
+    </div>
+    <p class="section-intro">
+      These are the invisible architecture of Quranic Arabic. Single-letter prepositions and conjunctions attach directly to the following word
+      with no space — <em>بِسْمِ</em> is actually <strong>بِ + اسْم</strong> ("in/by + name"). Recognizing these clitics is the single most important
+      skill for reading the Quran, because almost every phrase contains at least one.
+    </p>
+
+    <div class="feature-card">
+      <div class="arabic">بِسْمِ اللَّهِ الرَّحْمَٰنِ الرَّحِيمِ</div>
+      <div class="translit">bi-smi llāhi r-raḥmāni r-raḥīm</div>
+      <div class="meaning">"In the name of God, the Most Gracious, the Most Merciful"</div>
+      <div class="explanation">
+        The Basmala — the most recited Arabic phrase on Earth. Notice: <strong>بِسْمِ</strong> is a contraction.
+        The بِـ is the clitic preposition "in/by," attached to اسْم ("name"). When hamzat al-waṣl (ٱ) is preceded by a clitic,
+        the initial alef drops entirely, leaving بِسْمِ instead of *بِاسْمِ.
+      </div>
+      <div class="decomp">
+        <div class="decomp-part">
+          <div class="ar">بِـ</div>
+          <div class="en">in / by</div>
+        </div>
+        <span class="decomp-plus">+</span>
+        <div class="decomp-part">
+          <div class="ar">اسْم</div>
+          <div class="en">name</div>
+        </div>
+        <span class="decomp-plus">+</span>
+        <div class="decomp-part">
+          <div class="ar">الله</div>
+          <div class="en">God</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="word-grid" style="margin-top: 20px;">
+      <div class="word-card">
+        <div class="arabic">بِـ</div>
+        <div class="translit">bi-</div>
+        <div class="meaning">In / by / with</div>
+        <span class="grammar-tag tag-prep">Clitic preposition</span>
+        <span class="register-badge reg-all"><span class="dot"></span>All Arabic</span>
+        <div class="explanation">
+          The Swiss Army knife of Arabic prepositions: means "in" (بالمدينة — "in the city"),
+          "by" (بالله — "by God"), or "with" (instrumental — بالسيف — "with the sword").
+        </div>
+      </div>
+      <div class="word-card">
+        <div class="arabic">لِـ</div>
+        <div class="translit">li-</div>
+        <div class="meaning">For / to / belonging to</div>
+        <span class="grammar-tag tag-prep">Clitic preposition</span>
+        <span class="register-badge reg-all"><span class="dot"></span>All Arabic</span>
+        <div class="explanation">
+          Indicates possession (لِلّه — "belonging to God"), purpose (لِيَعْلَمَ — "so that He knows"),
+          or benefit (لَكُم — "for you").
+        </div>
+        <div class="verse-example">
+          <div class="verse-ar"><span class="highlight">لِ</span>إِيلَافِ قُرَيْشٍ</div>
+          <div class="verse-en">"For the accustomed security of the Quraysh"</div>
+          <div class="verse-ref">Quraysh (106:1)</div>
+        </div>
+      </div>
+      <div class="word-card">
+        <div class="arabic">كَـ</div>
+        <div class="translit">ka-</div>
+        <div class="meaning">Like / as</div>
+        <span class="grammar-tag tag-prep">Clitic preposition</span>
+        <span class="register-badge reg-all"><span class="dot"></span>All Arabic</span>
+        <div class="explanation">
+          Comparison. كَمَثَلِ — "like the example of." Very common in Quranic parables.
+        </div>
+        <div class="verse-example">
+          <div class="verse-ar">لَيْسَ <span class="highlight">كَ</span>مِثْلِهِ شَيْءٌ</div>
+          <div class="verse-en">"There is nothing like unto Him"</div>
+          <div class="verse-ref">Ash-Shūrā (42:11)</div>
+        </div>
+      </div>
+      <div class="word-card">
+        <div class="arabic">وَ</div>
+        <div class="translit">wa-</div>
+        <div class="meaning">And / by (oath)</div>
+        <span class="grammar-tag tag-conj">Clitic conjunction</span>
+        <span class="register-badge reg-all"><span class="dot"></span>All Arabic</span>
+        <div class="explanation">
+          As a conjunction, simply "and." The oath usage (وَالله) is common across all registers. But at the start of a verse/oath, it means "By...!" — وَالْفَجْرِ ("By the dawn!").
+          The most frequent word in the Quran.
+        </div>
+        <div class="verse-example">
+          <div class="verse-ar"><span class="highlight">وَ</span>الْعَصْرِ ۝ إِنَّ الْإِنسَانَ لَفِي خُسْرٍ</div>
+          <div class="verse-en">"By time! Indeed, mankind is in loss."</div>
+          <div class="verse-ref">Al-ʿAṣr (103:1–2)</div>
+        </div>
+      </div>
+      <div class="word-card">
+        <div class="arabic">فَـ</div>
+        <div class="translit">fa-</div>
+        <div class="meaning">So / then / and so</div>
+        <span class="grammar-tag tag-conj">Clitic conjunction</span>
+        <span class="register-badge reg-all"><span class="dot"></span>All Arabic</span>
+        <div class="explanation">
+          Unlike وَ (simple "and"), فَ implies <strong>sequence or consequence</strong>: "and <em>then</em>," "and <em>so</em>."
+          فَسَجَدُوا — "and so they prostrated." Often marks cause→effect.
+        </div>
+      </div>
+    </div>
+
+    <div class="concept-box">
+      <h3>💡 How clitics stack</h3>
+      <p>
+        Arabic clitics can stack on both sides of a word. A single "word" like <strong>أَفَبِعَهْدِهِمْ</strong> decomposes into
+        five meaningful parts:
+      </p>
+      <div class="decomp" style="margin-top: 12px; justify-content: center;">
+        <div class="decomp-part">
+          <div class="ar">أَ</div>
+          <div class="en">? (question)</div>
+        </div>
+        <span class="decomp-plus">+</span>
+        <div class="decomp-part">
+          <div class="ar">فَـ</div>
+          <div class="en">so/then</div>
+        </div>
+        <span class="decomp-plus">+</span>
+        <div class="decomp-part">
+          <div class="ar">بِـ</div>
+          <div class="en">in/with</div>
+        </div>
+        <span class="decomp-plus">+</span>
+        <div class="decomp-part">
+          <div class="ar">عَهْد</div>
+          <div class="en">covenant</div>
+        </div>
+        <span class="decomp-plus">+</span>
+        <div class="decomp-part">
+          <div class="ar">ـهِمْ</div>
+          <div class="en">their</div>
+        </div>
+      </div>
+      <p style="margin-top: 10px;">
+        "Is it then by their covenant...?" — Five morphemes, written as one word. This is why clitic awareness is essential for Quran reading.
+      </p>
+    </div>
+
+    <a href="#" class="back-top">↑ Back to top</a>
+  </div>
+
+  <!-- ═══════════════════════════════════════ -->
+  <!-- SECTION 5: Conjunctions -->
+  <!-- ═══════════════════════════════════════ -->
+  <div class="section" id="conjunctions">
+    <div class="section-header">
+      <h2>Conjunctions</h2>
+      <span class="ar-title">حروف العطف</span>
+    </div>
+    <p class="section-intro">
+      Arabic conjunctions (حروف العطف, ḥurūf al-ʿaṭf — "letters of coordination") link words, phrases, or clauses. Each carries a different nuance:
+      <em>وَ</em> is neutral "and," <em>فَ</em> implies sequence, <em>ثُمَّ</em> implies a time gap, and <em>بَلْ</em> corrects or contradicts.
+      The Quran uses these distinctions with precision.
+    </p>
+
+    <div class="word-grid">
+      <div class="word-card">
+        <div class="arabic">ثُمَّ</div>
+        <div class="translit">thumma</div>
+        <div class="meaning">Then / and then (after a delay)</div>
+        <span class="grammar-tag tag-conj">Conjunction</span>
+        <span class="register-badge reg-all"><span class="dot"></span>All Arabic</span>
+        <div class="explanation">
+          Unlike فَ (immediate sequence), ثُمَّ implies a <strong>gap in time</strong>. "God created you, <em>thumma</em> He will cause you to die" — creation and death are separated by a lifetime.
+        </div>
+      </div>
+      <div class="word-card">
+        <div class="arabic">أَوْ</div>
+        <div class="translit">aw</div>
+        <div class="meaning">Or</div>
+        <span class="grammar-tag tag-conj">Conjunction</span>
+        <span class="register-badge reg-all"><span class="dot"></span>All Arabic</span>
+        <div class="explanation">Choice between alternatives. In legal verses, distinguishes options for expiation or worship.</div>
+      </div>
+      <div class="word-card">
+        <div class="arabic">لٰكِنَّ / لٰكِنْ</div>
+        <div class="translit">lākinna / lākin</div>
+        <div class="meaning">But / however</div>
+        <span class="grammar-tag tag-conj">Conjunction</span>
+        <span class="register-badge reg-all"><span class="dot"></span>All Arabic</span>
+        <div class="explanation">
+          Adversative — introduces a contrast. لٰكِنَّ (with shadda) is a "sister of إنَّ" that takes a noun in the accusative.
+          لٰكِنْ (without shadda) is a simple conjunction.
+        </div>
+      </div>
+      <div class="word-card">
+        <div class="arabic">بَلْ</div>
+        <div class="translit">bal</div>
+        <div class="meaning">Rather / nay / but instead</div>
+        <span class="grammar-tag tag-conj">Conjunction</span>
+        <span class="register-badge reg-formal"><span class="dot"></span>Classical &amp; Formal MSA</span>
+        <div class="explanation">
+          Correction or escalation. Negates what came before and replaces it. بَلْ هُمْ قَوْمٌ يَعْدِلُونَ — "Rather, they are a people who deviate."
+        </div>
+      </div>
+      <div class="word-card">
+        <div class="arabic">أَنَّ / أَنْ</div>
+        <div class="translit">anna / an</div>
+        <div class="meaning">That (content clause)</div>
+        <span class="grammar-tag tag-conj">Conjunction</span>
+        <span class="register-badge reg-formal"><span class="dot"></span>Classical &amp; Formal MSA</span>
+        <div class="explanation">
+          Introduces noun clauses. أَنَّ (with shadda): "that" after verbs of knowledge. أَنْ (without): "to" before subjunctive verbs. يُرِيدُ أَنْ يُخْرِجَكُم — "He wants to expel you."
+        </div>
+      </div>
+      <div class="word-card">
+        <div class="arabic">إِنَّ</div>
+        <div class="translit">inna</div>
+        <div class="meaning">Indeed / verily</div>
+        <span class="grammar-tag tag-emph">Emphatic particle</span>
+        <span class="register-badge reg-formal"><span class="dot"></span>Classical &amp; Formal MSA</span>
+        <div class="explanation">
+          The great emphasizer. Opens hundreds of Quranic statements. Puts the following noun in accusative. إِنَّ اللهَ عَزِيزٌ حَكِيمٌ — "Indeed God is Mighty, Wise."
+        </div>
+        <div class="verse-example">
+          <div class="verse-ar"><span class="highlight">إِنَّ</span> مَعَ الْعُسْرِ يُسْرًا</div>
+          <div class="verse-en">"Indeed, with hardship comes ease."</div>
+          <div class="verse-ref">Ash-Sharḥ (94:6)</div>
+        </div>
+      </div>
+    </div>
+
+    <a href="#" class="back-top">↑ Back to top</a>
+  </div>
+
+  <!-- ═══════════════════════════════════════ -->
+  <!-- SECTION 6: Personal Pronouns -->
+  <!-- ═══════════════════════════════════════ -->
+  <div class="section" id="pronouns">
+    <div class="section-header">
+      <h2>Personal Pronouns</h2>
+      <span class="ar-title">الضمائر المنفصلة</span>
+    </div>
+    <p class="section-intro">
+      Arabic distinguishes 12 personal pronouns: 3 persons × 2 genders × 2 numbers (singular, plural), plus a dual form.
+      These are the independent/subject forms. In the Quran, God refers to Himself as <em>أنا</em> (I), <em>نحن</em> (We — the royal "We," not plural),
+      or in the third person <em>هو</em> (He). The choice carries theological meaning.
+    </p>
+
+    <div class="word-grid">
+      <div class="word-card">
+        <div class="arabic">هُوَ</div>
+        <div class="translit">huwa</div>
+        <div class="meaning">He / it</div>
+        <span class="grammar-tag tag-pron">Pronoun — 3rd m. sg.</span>
+        <span class="register-badge reg-all"><span class="dot"></span>All Arabic</span>
+        <div class="explanation">
+          Often refers to God. قُلْ هُوَ اللهُ أَحَدٌ — "Say: He is God, the One." Surah Al-Ikhlāṣ opens with this word.
+        </div>
+      </div>
+      <div class="word-card">
+        <div class="arabic">هِيَ</div>
+        <div class="translit">hiya</div>
+        <div class="meaning">She / it (f.)</div>
+        <span class="grammar-tag tag-pron">Pronoun — 3rd f. sg.</span>
+        <span class="register-badge reg-all"><span class="dot"></span>All Arabic</span>
+        <div class="explanation">
+          Also used for non-gendered "it" when referring to feminine nouns (most abstract nouns in Arabic are grammatically feminine).
+        </div>
+      </div>
+      <div class="word-card">
+        <div class="arabic">هُمْ</div>
+        <div class="translit">hum</div>
+        <div class="meaning">They (m.)</div>
+        <span class="grammar-tag tag-pron">Pronoun — 3rd m. pl.</span>
+        <span class="register-badge reg-all"><span class="dot"></span>All Arabic</span>
+        <div class="explanation">Extremely frequent. أُولٰئِكَ هُمُ الْمُفْلِحُونَ — "Those are the successful ones."</div>
+      </div>
+      <div class="word-card">
+        <div class="arabic">نَحْنُ</div>
+        <div class="translit">naḥnu</div>
+        <div class="meaning">We</div>
+        <span class="grammar-tag tag-pron">Pronoun — 1st pl.</span>
+        <span class="register-badge reg-all"><span class="dot"></span>All Arabic</span>
+        <div class="explanation">
+          When God says نَحْنُ, it is the <strong>royal "We"</strong> (تعظيم), not a plurality of gods.
+          إِنَّا نَحْنُ نَزَّلْنَا الذِّكْرَ — "Indeed, it is We who sent down the Reminder."
+        </div>
+      </div>
+      <div class="word-card">
+        <div class="arabic">أَنْتَ</div>
+        <div class="translit">anta</div>
+        <div class="meaning">You (m. singular)</div>
+        <span class="grammar-tag tag-pron">Pronoun — 2nd m. sg.</span>
+        <span class="register-badge reg-all"><span class="dot"></span>All Arabic</span>
+        <div class="explanation">Addresses a single male. Often addresses the Prophet: إِنَّكَ أَنْتَ العَلِيمُ — "Indeed, You are the All-Knowing."</div>
+      </div>
+      <div class="word-card">
+        <div class="arabic">أَنَا</div>
+        <div class="translit">anā</div>
+        <div class="meaning">I</div>
+        <span class="grammar-tag tag-pron">Pronoun — 1st sg.</span>
+        <span class="register-badge reg-all"><span class="dot"></span>All Arabic</span>
+        <div class="explanation">
+          When God says أَنَا, it signals intimate, direct speech. إِنَّنِي أَنَا اللهُ — "Indeed, I am God" (Ṭā Hā 20:14).
+        </div>
+      </div>
+    </div>
+
+    <a href="#" class="back-top">↑ Back to top</a>
+  </div>
+
+  <!-- ═══════════════════════════════════════ -->
+  <!-- SECTION 7: Pronoun Suffixes -->
+  <!-- ═══════════════════════════════════════ -->
+  <div class="section" id="suffixes">
+    <div class="section-header">
+      <h2>Pronoun Suffixes</h2>
+      <span class="ar-title">الضمائر المتّصلة</span>
+    </div>
+    <p class="section-intro">
+      While independent pronouns stand alone, <strong>attached pronouns</strong> (الضمائر المتّصلة) fuse onto the end of verbs, nouns, and prepositions.
+      They're the most compact way Arabic expresses "his," "their," "you," "us," etc. A single suffix turns <em>كتاب</em> (book) into
+      <em>كتابهم</em> (their book) — no separate word needed. You'll see these on nearly every line of the Quran.
+    </p>
+
+    <table class="suffix-table">
+      <thead>
+        <tr>
+          <th>Suffix</th>
+          <th>Transliteration</th>
+          <th>Meaning</th>
+          <th>Example</th>
+          <th>Register</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>ـهُ</td>
+          <td>-hu</td>
+          <td>him / his / it</td>
+          <td>رَبُّهُ — "his Lord"</td>
+          <td class="reg-cell"><span class="register-badge reg-all"><span class="dot"></span>All</span></td>
+        </tr>
+        <tr>
+          <td>ـها</td>
+          <td>-hā</td>
+          <td>her / its</td>
+          <td>أَهْلَها — "its people"</td>
+          <td class="reg-cell"><span class="register-badge reg-all"><span class="dot"></span>All</span></td>
+        </tr>
+        <tr>
+          <td>ـهُمْ</td>
+          <td>-hum</td>
+          <td>them / their</td>
+          <td>قُلُوبِهِمْ — "their hearts"</td>
+          <td class="reg-cell"><span class="register-badge reg-all"><span class="dot"></span>All</span></td>
+        </tr>
+        <tr>
+          <td>ـهُنَّ</td>
+          <td>-hunna</td>
+          <td>them (f.) / their (f.)</td>
+          <td>أَجَلُهُنَّ — "their (f.) term"</td>
+          <td class="reg-cell"><span class="register-badge reg-formal"><span class="dot"></span>Formal</span></td>
+        </tr>
+        <tr>
+          <td>ـهُما</td>
+          <td>-humā</td>
+          <td>them (dual) / their (dual)</td>
+          <td>بَيْنَهُما — "between them two"</td>
+          <td class="reg-cell"><span class="register-badge reg-formal"><span class="dot"></span>Formal</span></td>
+        </tr>
+        <tr>
+          <td>ـكَ</td>
+          <td>-ka</td>
+          <td>you (m. sg.) / your</td>
+          <td>رَبُّكَ — "your Lord"</td>
+          <td class="reg-cell"><span class="register-badge reg-all"><span class="dot"></span>All</span></td>
+        </tr>
+        <tr>
+          <td>ـكُمْ</td>
+          <td>-kum</td>
+          <td>you (pl.) / your</td>
+          <td>رَبُّكُمْ — "your (pl.) Lord"</td>
+          <td class="reg-cell"><span class="register-badge reg-all"><span class="dot"></span>All</span></td>
+        </tr>
+        <tr>
+          <td>ـكُما</td>
+          <td>-kumā</td>
+          <td>you (dual)</td>
+          <td>رَبُّكُما — "Lord of you two"</td>
+          <td class="reg-cell"><span class="register-badge reg-formal"><span class="dot"></span>Formal</span></td>
+        </tr>
+        <tr>
+          <td>ـنا</td>
+          <td>-nā</td>
+          <td>us / our</td>
+          <td>رَبَّنا — "our Lord"</td>
+          <td class="reg-cell"><span class="register-badge reg-all"><span class="dot"></span>All</span></td>
+        </tr>
+        <tr>
+          <td>ـي / ـنِي</td>
+          <td>-ī / -nī</td>
+          <td>me / my</td>
+          <td>رَبِّي — "my Lord"</td>
+          <td class="reg-cell"><span class="register-badge reg-all"><span class="dot"></span>All</span></td>
+        </tr>
+      </tbody>
+    </table>
+
+    <div class="concept-box">
+      <h3>💡 One word, three pieces of information</h3>
+      <p>
+        When a suffix attaches to a preposition + noun, you get a complete phrase in one written word:
+        <strong>عَلَيْهِمْ</strong> = عَلَى (upon) + هِمْ (them) → "upon them."
+        <strong>بِرَبِّهِمْ</strong> = بِـ (in/by) + رَبّ (Lord) + هِمْ (their) → "in their Lord."
+        This density is why Quranic Arabic packs so much meaning into so few words — and why recognizing suffixes
+        is essential for reading fluency.
+      </p>
+    </div>
+
+    <a href="#" class="back-top">↑ Back to top</a>
+  </div>
+
+  <!-- ═══════════════════════════════════════ -->
+  <!-- SECTION 8: Demonstratives -->
+  <!-- ═══════════════════════════════════════ -->
+  <div class="section" id="demonstratives">
+    <div class="section-header">
+      <h2>Demonstrative Pronouns</h2>
+      <span class="ar-title">أسماء الإشارة</span>
+    </div>
+    <p class="section-intro">
+      Arabic demonstratives distinguish gender, number, AND proximity (near vs. far). In the Quran, <em>ذٰلِكَ</em> ("that," distant)
+      often refers to God's Book or decree with a tone of reverence and grandeur, while <em>هٰذا</em> ("this," near) refers to present, tangible things.
+    </p>
+
+    <div class="word-grid">
+      <div class="word-card">
+        <div class="arabic">هٰذَا</div>
+        <div class="translit">hādhā</div>
+        <div class="meaning">This (m.)</div>
+        <span class="grammar-tag tag-dem">Near demonstrative</span>
+        <span class="register-badge reg-all"><span class="dot"></span>All Arabic</span>
+        <div class="explanation">Points to something present or close. هٰذَا بَلَاغٌ لِلنَّاسِ — "This is a message for the people."</div>
+      </div>
+      <div class="word-card">
+        <div class="arabic">هٰذِهِ</div>
+        <div class="translit">hādhihi</div>
+        <div class="meaning">This (f.)</div>
+        <span class="grammar-tag tag-dem">Near demonstrative</span>
+        <span class="register-badge reg-all"><span class="dot"></span>All Arabic</span>
+        <div class="explanation">For feminine nouns. هٰذِهِ جَهَنَّمُ — "This is Hell."</div>
+      </div>
+      <div class="word-card">
+        <div class="arabic">ذٰلِكَ</div>
+        <div class="translit">dhālika</div>
+        <div class="meaning">That (m.)</div>
+        <span class="grammar-tag tag-dem">Far demonstrative</span>
+        <span class="register-badge reg-all"><span class="dot"></span>All Arabic</span>
+        <div class="explanation">
+          Distance can be physical or reverential. The Quran's second verse uses it grandly:
+        </div>
+        <div class="verse-example">
+          <div class="verse-ar"><span class="highlight">ذَٰلِكَ</span> الْكِتَابُ لَا رَيْبَ فِيهِ</div>
+          <div class="verse-en">"That is the Book — no doubt in it."</div>
+          <div class="verse-ref">Al-Baqarah (2:2)</div>
+        </div>
+      </div>
+      <div class="word-card">
+        <div class="arabic">تِلْكَ</div>
+        <div class="translit">tilka</div>
+        <div class="meaning">That (f.)</div>
+        <span class="grammar-tag tag-dem">Far demonstrative</span>
+        <span class="register-badge reg-all"><span class="dot"></span>All Arabic</span>
+        <div class="explanation">
+          For feminine distant reference. تِلْكَ الدَّارُ الْآخِرَةُ — "That is the home of the Hereafter."
+        </div>
+      </div>
+      <div class="word-card">
+        <div class="arabic">هٰؤُلَاءِ</div>
+        <div class="translit">hāʾulāʾi</div>
+        <div class="meaning">These (pl.)</div>
+        <span class="grammar-tag tag-dem">Near demonstrative</span>
+        <span class="register-badge reg-all"><span class="dot"></span>All Arabic</span>
+        <div class="explanation">Plural demonstrative for both genders.</div>
+      </div>
+      <div class="word-card">
+        <div class="arabic">أُولٰئِكَ</div>
+        <div class="translit">ulāʾika</div>
+        <div class="meaning">Those (pl.)</div>
+        <span class="grammar-tag tag-dem">Far demonstrative</span>
+        <span class="register-badge reg-all"><span class="dot"></span>All Arabic</span>
+        <div class="explanation">
+          One of the most common words in the Quran. أُولٰئِكَ عَلَى هُدًى مِّن رَّبِّهِمْ — "Those are upon guidance from their Lord."
+        </div>
+      </div>
+    </div>
+
+    <a href="#" class="back-top">↑ Back to top</a>
+  </div>
+
+  <!-- ═══════════════════════════════════════ -->
+  <!-- SECTION 9: Relative Pronouns -->
+  <!-- ═══════════════════════════════════════ -->
+  <div class="section" id="relative">
+    <div class="section-header">
+      <h2>Relative Pronouns</h2>
+      <span class="ar-title">الأسماء الموصولة</span>
+    </div>
+    <p class="section-intro">
+      Relative pronouns connect a noun to a descriptive clause: "those <em>who</em> believe," "the book <em>which</em> was sent down."
+      Arabic relative pronouns agree in gender and number with the noun they refer to — so <em>الَّذِي</em> is for masculine singular,
+      <em>الَّتِي</em> for feminine singular, and <em>الَّذِينَ</em> for masculine plural. This is the "Ladheena" you encounter
+      on almost every page of the Quran.
+    </p>
+
+    <div class="feature-card">
+      <div class="arabic">الَّذِينَ آمَنُوا وَعَمِلُوا الصَّالِحَاتِ</div>
+      <div class="translit">alladhīna āmanū wa-ʿamilū ṣ-ṣāliḥāt</div>
+      <div class="meaning">"Those who believed and did righteous deeds"</div>
+      <div class="explanation">
+        This phrase appears <strong>over 60 times</strong> in the Quran — it's the single most repeated description of the believers.
+        <em>الَّذِينَ</em> (alladhīna) is the masculine plural relative pronoun "those who / who."
+        Whenever the Quran describes a group, this is the word that introduces them.
+      </div>
+    </div>
+
+    <div class="word-grid" style="margin-top: 20px;">
+      <div class="word-card">
+        <div class="arabic">الَّذِي</div>
+        <div class="translit">alladhī</div>
+        <div class="meaning">Who / which / that (m. sg.)</div>
+        <span class="grammar-tag tag-rel">Relative pronoun</span>
+        <span class="register-badge reg-all"><span class="dot"></span>All Arabic</span>
+        <div class="explanation">
+          Masculine singular. الحَمْدُ لِلَّهِ الَّذِي خَلَقَ السَّمَاوَاتِ — "Praise to God who created the heavens."
+        </div>
+      </div>
+      <div class="word-card">
+        <div class="arabic">الَّتِي</div>
+        <div class="translit">allatī</div>
+        <div class="meaning">Who / which / that (f. sg.)</div>
+        <span class="grammar-tag tag-rel">Relative pronoun</span>
+        <span class="register-badge reg-all"><span class="dot"></span>All Arabic</span>
+        <div class="explanation">Feminine singular. الجَنَّةَ الَّتِي وُعِدَ المُتَّقُونَ — "The Garden which the righteous were promised."</div>
+      </div>
+      <div class="word-card">
+        <div class="arabic">الَّذِينَ</div>
+        <div class="translit">alladhīna</div>
+        <div class="meaning">Those who / who (m. pl.)</div>
+        <span class="grammar-tag tag-rel">Relative pronoun</span>
+        <span class="register-badge reg-all"><span class="dot"></span>All Arabic</span>
+        <div class="explanation">
+          The most frequent relative pronoun in the Quran. Appears in hundreds of verses. Introduces believers, disbelievers, and every group in between.
+        </div>
+        <div class="verse-example">
+          <div class="verse-ar">صِرَاطَ <span class="highlight">الَّذِينَ</span> أَنْعَمْتَ عَلَيْهِمْ</div>
+          <div class="verse-en">"The path of those You have blessed"</div>
+          <div class="verse-ref">Al-Fātiḥah (1:7)</div>
+        </div>
+      </div>
+      <div class="word-card">
+        <div class="arabic">اللَّذَانِ</div>
+        <div class="translit">alladhāni</div>
+        <div class="meaning">Who / which (m. dual)</div>
+        <span class="grammar-tag tag-rel">Relative pronoun</span>
+        <span class="register-badge reg-formal"><span class="dot"></span>Classical &amp; Formal MSA</span>
+        <div class="explanation">Masculine dual — for exactly two male referents. Rare even in written MSA; the dual relative is one of the least-used forms in modern Arabic.</div>
+      </div>
+      <div class="word-card">
+        <div class="arabic">اللَّتَانِ</div>
+        <div class="translit">allatāni</div>
+        <div class="meaning">Who / which (f. dual)</div>
+        <span class="grammar-tag tag-rel">Relative pronoun</span>
+        <span class="register-badge reg-formal"><span class="dot"></span>Classical &amp; Formal MSA</span>
+        <div class="explanation">Feminine dual — for exactly two female referents. Like اللَّذانِ, this form is largely confined to formal written Arabic and classical texts.</div>
+      </div>
+      <div class="word-card">
+        <div class="arabic">مَا</div>
+        <div class="translit">mā</div>
+        <div class="meaning">What / that which</div>
+        <span class="grammar-tag tag-rel">Relative pronoun</span>
+        <span class="register-badge reg-all"><span class="dot"></span>All Arabic</span>
+        <div class="explanation">
+          Used for non-human / abstract referents. وَلَا تَقْفُ مَا لَيْسَ لَكَ بِهِ عِلْمٌ — "And do not pursue that of which you have no knowledge."
+          Also doubles as a question word ("what?") and a negation particle.
+        </div>
+      </div>
+      <div class="word-card">
+        <div class="arabic">مَنْ</div>
+        <div class="translit">man</div>
+        <div class="meaning">Who / whoever</div>
+        <span class="grammar-tag tag-rel">Relative pronoun</span>
+        <span class="register-badge reg-all"><span class="dot"></span>All Arabic</span>
+        <div class="explanation">
+          For human referents (both genders). مَنْ يَتَّقِ اللهَ يَجْعَلْ لَهُ مَخْرَجًا — "Whoever fears God, He will make a way out for him." Also a question word ("who?").
+        </div>
+      </div>
+    </div>
+
+    <a href="#" class="back-top">↑ Back to top</a>
+  </div>
+
+  <!-- ═══════════════════════════════════════ -->
+  <!-- SECTION 10: Negation -->
+  <!-- ═══════════════════════════════════════ -->
+  <div class="section" id="negation">
+    <div class="section-header">
+      <h2>Negation Particles</h2>
+      <span class="ar-title">أدوات النفي</span>
+    </div>
+    <p class="section-intro">
+      Arabic has a rich negation system where each particle operates in a specific tense and grammatical environment.
+      This is one area where Arabic is more precise than English — instead of one "not," there are distinct words
+      for negating past, present, future, and existential statements.
+    </p>
+
+    <div class="word-grid">
+      <div class="word-card">
+        <div class="arabic">لَا</div>
+        <div class="translit">lā</div>
+        <div class="meaning">No / not</div>
+        <span class="grammar-tag tag-neg">General negation</span>
+        <span class="register-badge reg-all"><span class="dot"></span>All Arabic</span>
+        <div class="explanation">
+          The Swiss Army knife of negation. Negates present/future verbs, or functions as an absolute negation (لَا إِلٰهَ إِلَّا اللهُ — "there is no god but God").
+        </div>
+        <div class="verse-example">
+          <div class="verse-ar"><span class="highlight">لَا</span> إِكْرَاهَ فِي الدِّينِ</div>
+          <div class="verse-en">"There is no compulsion in religion."</div>
+          <div class="verse-ref">Al-Baqarah (2:256)</div>
+        </div>
+      </div>
+      <div class="word-card">
+        <div class="arabic">لَمْ</div>
+        <div class="translit">lam</div>
+        <div class="meaning">Did not (past negation)</div>
+        <span class="grammar-tag tag-neg">Past negation</span>
+        <span class="register-badge reg-formal"><span class="dot"></span>Classical &amp; Formal MSA</span>
+        <div class="explanation">
+          Negates the past tense but takes a <strong>present-tense (jussive) verb</strong>. لَمْ يَلِدْ وَلَمْ يُولَدْ — "He neither begot nor was begotten." This is the standard past-tense negation in the Quran.
+        </div>
+      </div>
+      <div class="word-card">
+        <div class="arabic">لَنْ</div>
+        <div class="translit">lan</div>
+        <div class="meaning">Will not (emphatic future negation)</div>
+        <span class="grammar-tag tag-neg">Future negation</span>
+        <span class="register-badge reg-formal"><span class="dot"></span>Classical &amp; Formal MSA</span>
+        <div class="explanation">
+          Negates the future emphatically. Takes a subjunctive verb. لَنْ تَنَالُوا الْبِرَّ حَتَّىٰ تُنفِقُوا — "You will never attain righteousness until you spend."
+        </div>
+      </div>
+      <div class="word-card">
+        <div class="arabic">لَيْسَ</div>
+        <div class="translit">laysa</div>
+        <div class="meaning">Is not / are not</div>
+        <span class="grammar-tag tag-neg">Existential negation</span>
+        <span class="register-badge reg-all"><span class="dot"></span>All Arabic</span>
+        <div class="explanation">
+          Negates identity or existence in the present. Grammatically a verb but functions like "is not." لَيْسَ كَمِثْلِهِ شَيْءٌ — "There is nothing like Him."
+        </div>
+      </div>
+      <div class="word-card">
+        <div class="arabic">مَا</div>
+        <div class="translit">mā</div>
+        <div class="meaning">Not (present/past negation)</div>
+        <span class="grammar-tag tag-neg">Negation particle</span>
+        <span class="register-badge reg-all"><span class="dot"></span>All Arabic</span>
+        <div class="explanation">
+          Versatile negator. Negates past verbs: مَا كَذَبَ — "he did not lie." Also negates nominal sentences in Ḥijāzī dialect (used in Quran): مَا هٰذَا بَشَرًا — "this is not a human."
+        </div>
+      </div>
+    </div>
+
+    <div class="concept-box">
+      <h3>💡 Tense encoded in the negation word</h3>
+      <p>
+        English uses "not" for all tenses and relies on the verb to show when: "did not go," "will not go," "does not go."
+        Arabic encodes the tense <em>in the negation particle itself</em>:<br><br>
+        <strong>مَا ذَهَبَ</strong> — "he did not go" (past, using past verb)<br>
+        <strong>لَمْ يَذْهَبْ</strong> — "he did not go" (past, using jussive present verb — more formal)<br>
+        <strong>لَا يَذْهَبُ</strong> — "he does not go" (present)<br>
+        <strong>لَنْ يَذْهَبَ</strong> — "he will not go" (future, emphatic)<br><br>
+        Once you internalize which particle goes with which tense, negation in Arabic becomes more precise than in English.
+      </p>
+    </div>
+
+    <a href="#" class="back-top">↑ Back to top</a>
+  </div>
+
+  <!-- ═══════════════════════════════════════ -->
+  <!-- SECTION 11: Emphasis Particles -->
+  <!-- ═══════════════════════════════════════ -->
+  <div class="section" id="emphasis">
+    <div class="section-header">
+      <h2>Emphasis & Assertion Particles</h2>
+      <span class="ar-title">أدوات التوكيد</span>
+    </div>
+    <p class="section-intro">
+      These particles add layers of emphasis, certainty, or contrast. The Quran uses them extensively to mark
+      statements of absolute truth, divine promises, and solemn oaths. Recognizing them helps you feel the <em>weight</em>
+      of a verse — whether it's a gentle reminder or an emphatic declaration.
+    </p>
+
+    <div class="word-grid">
+      <div class="word-card">
+        <div class="arabic">إِنَّ</div>
+        <div class="translit">inna</div>
+        <div class="meaning">Indeed / verily</div>
+        <span class="grammar-tag tag-emph">Emphatic particle</span>
+        <span class="register-badge reg-formal"><span class="dot"></span>Classical &amp; Formal MSA</span>
+        <div class="explanation">
+          The queen of Arabic emphasis. Opens assertions of fact. One of the "sisters of إنَّ" — a group of particles that take a noun in accusative + a predicate.
+          Appears in virtually every page of the Quran.
+        </div>
+      </div>
+      <div class="word-card">
+        <div class="arabic">قَدْ</div>
+        <div class="translit">qad</div>
+        <div class="meaning">Indeed (past) / may (present)</div>
+        <span class="grammar-tag tag-emph">Emphasis / possibility</span>
+        <span class="register-badge reg-formal"><span class="dot"></span>Classical &amp; Formal MSA</span>
+        <div class="explanation">
+          With past verbs: certainty — قَدْ أَفْلَحَ ("he has certainly succeeded"). With present verbs: possibility — قَدْ يَعْلَمُ ("He may well know"). Context determines which.
+        </div>
+        <div class="verse-example">
+          <div class="verse-ar"><span class="highlight">قَدْ</span> أَفْلَحَ الْمُؤْمِنُونَ</div>
+          <div class="verse-en">"Certainly the believers have succeeded."</div>
+          <div class="verse-ref">Al-Muʾminūn (23:1)</div>
+        </div>
+      </div>
+      <div class="word-card">
+        <div class="arabic">لَقَدْ</div>
+        <div class="translit">laqad</div>
+        <div class="meaning">Indeed / certainly (emphatic past)</div>
+        <span class="grammar-tag tag-emph">Double emphasis</span>
+        <span class="register-badge reg-formal"><span class="dot"></span>Classical &amp; Formal MSA</span>
+        <div class="explanation">
+          لَـ (emphatic lām) + قَدْ = double emphasis. The strongest way to assert that something happened. لَقَدْ خَلَقْنَا الْإِنسَانَ — "We have certainly created mankind."
+        </div>
+      </div>
+      <div class="word-card">
+        <div class="arabic">أَلَا</div>
+        <div class="translit">alā</div>
+        <div class="meaning">Verily! / Unquestionably!</div>
+        <span class="grammar-tag tag-emph">Attention particle</span>
+        <span class="register-badge reg-quran"><span class="dot"></span>Quranic / Classical</span>
+        <div class="explanation">
+          A rhetorical attention-grabber. Essentially confined to the Quran and classical poetry — you would never hear this in modern conversation or even most formal writing.. Calls the listener to pay close attention to an incontestable fact.
+        </div>
+        <div class="verse-example">
+          <div class="verse-ar"><span class="highlight">أَلَا</span> إِنَّ أَوْلِيَاءَ اللَّهِ لَا خَوْفٌ عَلَيْهِمْ</div>
+          <div class="verse-en">"Unquestionably, the allies of God — no fear will there be on them."</div>
+          <div class="verse-ref">Yūnus (10:62)</div>
+        </div>
+      </div>
+      <div class="word-card">
+        <div class="arabic">إِلَّا</div>
+        <div class="translit">illā</div>
+        <div class="meaning">Except / unless / but</div>
+        <span class="grammar-tag tag-emph">Exception particle</span>
+        <span class="register-badge reg-formal"><span class="dot"></span>Classical &amp; Formal MSA</span>
+        <div class="explanation">
+          Creates exception clauses. لَا إِلٰهَ إِلَّا اللهُ — "There is no god except God." The engine of the Islamic declaration of faith.
+        </div>
+      </div>
+      <div class="word-card">
+        <div class="arabic">أَمَّا</div>
+        <div class="translit">ammā</div>
+        <div class="meaning">As for...</div>
+        <span class="grammar-tag tag-emph">Topic marker</span>
+        <span class="register-badge reg-formal"><span class="dot"></span>Classical &amp; Formal MSA</span>
+        <div class="explanation">
+          Introduces a topic for comment, always followed by فَـ. فَأَمَّا الَّذِينَ آمَنُوا فَيَعْلَمُونَ — "As for those who believed, they know..."
+          Used to structure parallel comparisons (believers vs. disbelievers).
+        </div>
+      </div>
+    </div>
+
+    <a href="#" class="back-top">↑ Back to top</a>
+  </div>
+
+  <!-- ═══════════════════════════════════════ -->
+  <!-- SECTION 12: Conditionals -->
+  <!-- ═══════════════════════════════════════ -->
+  <div class="section" id="conditionals">
+    <div class="section-header">
+      <h2>Conditional & Temporal Particles</h2>
+      <span class="ar-title">أدوات الشرط والزمان</span>
+    </div>
+    <p class="section-intro">
+      Arabic conditional particles specify whether a condition is likely, unlikely, or purely hypothetical — a distinction English
+      makes clumsily through verb tense ("if he goes" vs. "if he were to go") but Arabic makes explicitly through the choice of particle.
+    </p>
+
+    <div class="word-grid">
+      <div class="word-card">
+        <div class="arabic">إِذَا</div>
+        <div class="translit">idhā</div>
+        <div class="meaning">When / if (likely)</div>
+        <span class="grammar-tag tag-cond">Conditional — likely</span>
+        <span class="register-badge reg-all"><span class="dot"></span>All Arabic</span>
+        <div class="explanation">
+          For conditions expected to happen. إِذَا جَاءَ نَصْرُ اللهِ — "When the victory of God comes" (not "if" — it <em>will</em> come). Takes past-tense verb for future meaning.
+        </div>
+        <div class="verse-example">
+          <div class="verse-ar"><span class="highlight">إِذَا</span> جَاءَ نَصْرُ اللَّهِ وَالْفَتْحُ</div>
+          <div class="verse-en">"When the victory of God has come and the conquest..."</div>
+          <div class="verse-ref">An-Naṣr (110:1)</div>
+        </div>
+      </div>
+      <div class="word-card">
+        <div class="arabic">إِنْ</div>
+        <div class="translit">in</div>
+        <div class="meaning">If (uncertain)</div>
+        <span class="grammar-tag tag-cond">Conditional — uncertain</span>
+        <span class="register-badge reg-all"><span class="dot"></span>All Arabic</span>
+        <div class="explanation">
+          For uncertain conditions — the outcome is unknown. وَإِنْ تَعُدُّوا نِعْمَةَ اللهِ لَا تُحْصُوهَا — "And if you should count the favors of God, you could not enumerate them."
+        </div>
+      </div>
+      <div class="word-card">
+        <div class="arabic">لَوْ</div>
+        <div class="translit">law</div>
+        <div class="meaning">If (hypothetical / contrary to fact)</div>
+        <span class="grammar-tag tag-cond">Conditional — counterfactual</span>
+        <span class="register-badge reg-all"><span class="dot"></span>All Arabic</span>
+        <div class="explanation">
+          For conditions that did NOT happen (counterfactual). لَوْ كُنتُ أَعْلَمُ الْغَيْبَ — "If I had known the unseen..." (but I don't).
+        </div>
+      </div>
+      <div class="word-card">
+        <div class="arabic">لَوْلَا</div>
+        <div class="translit">lawlā</div>
+        <div class="meaning">If not for / were it not for</div>
+        <span class="grammar-tag tag-cond">Conditional — but-for</span>
+        <span class="register-badge reg-formal"><span class="dot"></span>Classical &amp; Formal MSA</span>
+        <div class="explanation">
+          Counterfactual with a preventing element. لَوْلَا أَنتُمْ لَكُنَّا مُؤْمِنِينَ — "If not for you, we would have been believers."
+        </div>
+      </div>
+      <div class="word-card">
+        <div class="arabic">حَيْثُ</div>
+        <div class="translit">ḥaythu</div>
+        <div class="meaning">Where / wherever</div>
+        <span class="grammar-tag tag-cond">Locative</span>
+        <span class="register-badge reg-formal"><span class="dot"></span>Classical &amp; Formal MSA</span>
+        <div class="explanation">
+          Indicates location. وَحَيْثُ مَا كُنتُمْ فَوَلُّوا وُجُوهَكُمْ شَطْرَهُ — "Wherever you are, turn your faces toward it."
+        </div>
+      </div>
+      <div class="word-card">
+        <div class="arabic">كَيْ / لِكَيْ</div>
+        <div class="translit">kay / li-kay</div>
+        <div class="meaning">In order to / so that</div>
+        <span class="grammar-tag tag-cond">Purpose</span>
+        <span class="register-badge reg-formal"><span class="dot"></span>Classical &amp; Formal MSA</span>
+        <div class="explanation">
+          Introduces purpose clauses. كَيْ لَا يَكُونَ دُولَةً — "so that it does not become a perpetual distribution."
+          Takes subjunctive verb.
+        </div>
+      </div>
+    </div>
+
+    <div class="concept-box">
+      <h3>💡 The إذا / إنْ / لَوْ spectrum</h3>
+      <p>
+        These three conditionals form a probability spectrum that the Quran uses with precision:<br><br>
+        <strong>إِذَا</strong> — "When" (expected to happen). Used for resurrection, Day of Judgment, inevitable events.<br>
+        <strong>إِنْ</strong> — "If" (genuinely uncertain). Used for human choices, moral tests.<br>
+        <strong>لَوْ</strong> — "If" (didn't/won't happen). Used for counterfactuals, impossible scenarios.<br><br>
+        When the Quran says <strong>إِذَا</strong> السَّمَاءُ انشَقَّتْ ("When the sky splits open"), the choice of إِذَا tells you: this <em>will</em> happen.
+        It's not a question of "if."
+      </p>
+    </div>
+
+    <a href="#" class="back-top">↑ Back to top</a>
+  </div>
+
+  <!-- Footer -->
+  <div style="margin-top: 80px; padding-top: 32px; border-top: 1px solid var(--border); text-align: center; color: var(--text-dim); font-size: 0.85rem;">
+    <p>Generated for the Alif Arabic Learning Project</p>
+    <p style="margin-top: 8px; font-family: 'Scheherazade New', serif; font-size: 1.2rem; color: var(--gold-dark);">
+      رَبِّ زِدْنِي عِلْمًا
+    </p>
+    <p style="font-style: italic; margin-top: 4px;">"My Lord, increase me in knowledge." — Ṭā Hā 20:114</p>
+  </div>
+
+</div>
+
+</body>
+</html>

--- a/scripts/build_research_hub.py
+++ b/scripts/build_research_hub.py
@@ -1,0 +1,1349 @@
+#!/usr/bin/env python3
+"""
+Build the research hub HTML from all markdown files in research/.
+
+Walks research/ recursively, collects all .md files, extracts metadata,
+builds cross-reference graph + backlinks, and generates a single self-contained
+HTML file with embedded markdown rendered client-side via marked.js.
+
+Usage:
+    python3 scripts/build_research_hub.py
+"""
+
+import json
+import os
+import re
+import sys
+from datetime import datetime
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parent.parent
+RESEARCH_DIR = ROOT_DIR / "research"
+OUTPUT_FILE = RESEARCH_DIR / "research-hub.html"
+
+# ── Category rules: slug substring → category ────────────────────────────────
+CATEGORY_RULES = [
+    ("learner-profile", "algorithm"),
+    ("learning-algorithm-redesign", "algorithm"),
+    ("deep-research-compilation", "algorithm"),
+    ("experiment-log", "algorithm"),
+    ("vocabulary-acquisition", "science"),
+    ("cognitive-load", "science"),
+    ("algorithm-implications", "science"),
+    ("arabic-learning-challenges", "science"),
+    ("learning-analysis", "analytics"),
+    ("acquisition-rate", "analytics"),
+    ("vocabulary-thresholds", "analytics"),
+    ("analysis-2026", "analytics"),
+    ("sentence-investigation", "generation"),
+    ("story-benchmark", "generation"),
+    ("corpus-vs-llm", "generation"),
+    ("arabic-sentence-corpora", "generation"),
+    ("arabic-morphology", "nlp"),
+    ("arabic-datasets", "nlp"),
+    ("arabic-diacritization", "nlp"),
+    ("arabic-apis", "nlp"),
+    ("arabic-learning-architecture", "nlp"),
+    ("lemma-mapping", "quality"),
+    ("variant-detection", "quality"),
+    ("per-word-contextual", "quality"),
+    ("llm-cost", "cost"),
+    ("hosting", "cost"),
+    ("elevenlabs", "cost"),
+    ("arabic-teaching", "education"),
+    ("arabic-textbook", "education"),
+    ("arabic-education", "education"),
+    ("arabic-children", "education"),
+    ("norwegian-arabic", "education"),
+    ("inn-arabic", "external"),
+    ("agent-knowledge", "agent-knowledge"),
+    ("research-knowledge-system", "agent-knowledge"),
+]
+
+CATEGORY_META = {
+    "algorithm": {"label": "Algorithm Redesign", "color": "blue"},
+    "science": {"label": "Learning Science", "color": "green"},
+    "analytics": {"label": "Production Analytics", "color": "amber"},
+    "generation": {"label": "Sentence & Story Gen", "color": "purple"},
+    "nlp": {"label": "NLP & Infrastructure", "color": "cyan"},
+    "quality": {"label": "Data Quality", "color": "red"},
+    "cost": {"label": "Cost & Infrastructure", "color": "orange"},
+    "education": {"label": "Arabic Education Landscape", "color": "green"},
+    "external": {"label": "External References", "color": "pink"},
+    "agent-knowledge": {"label": "Agent Knowledge Systems", "color": "purple"},
+}
+
+CATEGORY_ORDER = [
+    "algorithm", "science", "analytics", "generation",
+    "nlp", "quality", "cost", "education", "agent-knowledge", "external",
+]
+
+# ── Status overrides ─────────────────────────────────────────────────────────
+STATUS_OVERRIDES = {
+    "learner-profile-2026-02-12": "deployed",
+    "learning-algorithm-redesign-2026-02-12": "deployed",
+    "deep-research-compilation-2026-02-12": "deployed",
+    "experiment-log": "active",
+    "algorithm-implications": "deployed",
+    "learning-analysis-2026-02-20": "deployed",
+    "analysis-2026-02-09": "archived",
+    "analysis-2026-02-10": "archived",
+    "analysis-2026-02-11": "archived",
+    "lemma-mapping-audit-2026-02-17": "deployed",
+    "variant-detection-spec": "deployed",
+    "per-word-contextual-translations": "todo",
+    "llm-cost-investigation-2026-02-19": "deployed",
+    "hosting-options": "deployed",
+    "elevenlabs-arabic-voice": "deployed",
+    "sentence-investigation-2026-02-13/README": "deployed",
+    "sentence-investigation-2026-02-13/corpus_evaluation": "deployed",
+    "sentence-investigation-2026-02-13/generation_benchmark": "deployed",
+    "sentence-investigation-2026-02-13/recommendations": "deployed",
+    "story-benchmark-2026-02-14/benchmark_report": "deployed",
+    "story-benchmark-2026-02-14/recommendations": "deployed",
+}
+
+# ── Key findings (curated) ───────────────────────────────────────────────────
+KEY_FINDINGS = [
+    {
+        "title": "Three-Phase Lifecycle",
+        "text": "Encountered → Acquiring (Leitner 3-box) → FSRS-6. Bridges the gap between \"seen once\" and \"scheduled for review.\"",
+        "color": "blue",
+    },
+    {
+        "title": "Morphological Awareness #1",
+        "text": "Root+pattern decomposition is the single strongest predictor of Arabic reading comprehension. Explicit decomposition > implicit exposure.",
+        "color": "green",
+    },
+    {
+        "title": "8–12 Encounters Needed",
+        "text": "Nation's research: words need 8-12 meaningful encounters before acquisition. Sleep consolidation matters — space across days.",
+        "color": "purple",
+    },
+    {
+        "title": "85% Comprehension Sweet Spot",
+        "text": "Krashen's i+1 operationalized: sessions at ~85% known words optimize the balance of challenge and acquisition.",
+        "color": "amber",
+    },
+    {
+        "title": "Sentence-Centric SRS",
+        "text": "Reviewing words in sentence context is more effective than isolated flashcards. Greedy set cover maximizes due-word coverage.",
+        "color": "cyan",
+    },
+    {
+        "title": "Semantic Clustering Hurts",
+        "text": "Introducing similar/related words together causes interference. Space root family members 2-4 days apart, not simultaneously.",
+        "color": "red",
+    },
+    {
+        "title": "10–20 Words/Day Max",
+        "text": "Sustainable introduction rate consensus: 10-20 new words/day. The \"10x rule\" means 10 new = 100 daily reviews within weeks.",
+        "color": "orange",
+    },
+    {
+        "title": "High-Productivity Patterns",
+        "text": "3 patterns show robust priming: fa'il (doer), maf'ul (object), masdar (verbal noun). Low-productivity patterns stored as whole words.",
+        "color": "pink",
+    },
+]
+
+# ── Timeline milestones (curated) ────────────────────────────────────────────
+TIMELINE = [
+    {"date": "Feb 8", "title": "Project Inception", "desc": "Hosting research, initial architecture decisions", "milestone": True},
+    {"date": "Feb 9", "title": "First Production Analysis", "desc": "Day 1: 59 sentence reviews, 390 selections, 217 FSRS reviews"},
+    {"date": "Feb 10", "title": "Early Metrics", "desc": "481 word reviews, 85 textbook imports, 107 words at 30d+ stability"},
+    {"date": "Feb 11", "title": "Sentence Diversity Audit", "desc": "Found 24.2% of sentences start with hal. 2075 total sentences."},
+    {"date": "Feb 12", "title": "Algorithm Redesign", "desc": "8-agent deep research. Three-phase lifecycle designed. Learner profile captured.", "milestone": True},
+    {"date": "Feb 13", "title": "Sentence Benchmark", "desc": "213 sentences, 3 models x 6 strategies. Gemini Flash selected."},
+    {"date": "Feb 14", "title": "Story Benchmark", "desc": "32 stories, 4 models x 4 strategies. Opus selected for production."},
+    {"date": "Feb 17", "title": "Data Quality Crisis", "desc": "Lemma mapping audit: false al-prefix matching, 24+ wrong assignments found and fixed."},
+    {"date": "Feb 19", "title": "LLM Cost Migration", "desc": "Background tasks switched to Claude CLI (free). Two-tier architecture deployed."},
+    {"date": "Feb 20", "title": "Production Analytics", "desc": "13 days of data analyzed. 209 known words (28.8%), acquisition rates validated."},
+    {"date": "Feb 21", "title": "Morphological Patterns", "desc": "Wazn system implemented. Pattern decomposition in UI. 83% backfill coverage.", "milestone": True},
+]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Metadata extraction
+# ─────────────────────────────────────────────────────────────────────────────
+
+def slug_from_path(rel_path: str) -> str:
+    """Convert relative path to slug: 'foo/bar.md' -> 'foo/bar'."""
+    return rel_path.removesuffix(".md")
+
+
+def extract_title(content: str, slug: str) -> str:
+    """Extract title from first H1, fallback to slug."""
+    m = re.search(r"^#\s+(.+)", content, re.MULTILINE)
+    if m:
+        title = m.group(1).strip()
+        # Strip markdown links from title
+        title = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", title)
+        # Strip bold/italic markers
+        title = re.sub(r"[*_]+", "", title)
+        return title
+    return slug.split("/")[-1].replace("-", " ").title()
+
+
+def extract_date(content: str, slug: str) -> str | None:
+    """Extract date from filename (YYYY-MM-DD) or content."""
+    m = re.search(r"(\d{4}-\d{2}-\d{2})", slug)
+    if m:
+        try:
+            dt = datetime.strptime(m.group(1), "%Y-%m-%d")
+            return dt.strftime("%b %d").replace(" 0", " ")
+        except ValueError:
+            pass
+    # Fallback: look for date in content frontmatter
+    m = re.search(r"(?:Date|date|Created|created):\s*(\d{4}-\d{2}-\d{2})", content)
+    if m:
+        try:
+            dt = datetime.strptime(m.group(1), "%Y-%m-%d")
+            return dt.strftime("%b %d").replace(" 0", " ")
+        except ValueError:
+            pass
+    return None
+
+
+def extract_summary(content: str) -> str:
+    """Extract first non-heading, non-frontmatter paragraph, truncate to 200 chars."""
+    lines = content.split("\n")
+    buf = []
+    in_frontmatter = False
+    in_table = False
+    for line in lines:
+        stripped = line.strip()
+        # Skip frontmatter (> ... blocks at top)
+        if stripped.startswith(">"):
+            in_frontmatter = True
+            continue
+        if in_frontmatter and not stripped:
+            in_frontmatter = False
+            continue
+        if in_frontmatter:
+            continue
+        # Skip headings, horizontal rules, empty lines
+        if stripped.startswith("#") or stripped.startswith("---") or not stripped:
+            if buf:
+                break
+            continue
+        # Skip tables
+        if stripped.startswith("|"):
+            in_table = True
+            continue
+        if in_table and not stripped.startswith("|"):
+            in_table = False
+        if in_table:
+            continue
+        # Skip list items at start
+        if stripped.startswith("- ") or stripped.startswith("* ") or re.match(r"^\d+\.", stripped):
+            if not buf:
+                buf.append(re.sub(r"^[-*\d.]+\s*", "", stripped))
+                continue
+            else:
+                break
+        buf.append(stripped)
+    text = " ".join(buf)
+    # Clean markdown formatting
+    text = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", text)
+    text = re.sub(r"[*_`]+", "", text)
+    text = re.sub(r"\s+", " ", text).strip()
+    if len(text) > 200:
+        text = text[:197] + "..."
+    return text
+
+
+def extract_cross_refs(content: str, doc_slug: str) -> list[str]:
+    """Extract cross-references to other .md files, resolved relative to doc."""
+    refs = []
+    doc_dir = os.path.dirname(doc_slug)
+    for m in re.finditer(r"\[([^\]]*)\]\(([^)]+\.md)\)", content):
+        target = m.group(2)
+        # Strip leading ./
+        target = target.removeprefix("./")
+        # Resolve relative paths
+        if doc_dir:
+            resolved = os.path.normpath(os.path.join(doc_dir, target))
+        else:
+            resolved = os.path.normpath(target)
+        refs.append(slug_from_path(resolved))
+    return list(dict.fromkeys(refs))  # dedup preserving order
+
+
+def assign_category(slug: str) -> str:
+    """Assign category via pattern matching on slug."""
+    for pattern, category in CATEGORY_RULES:
+        if pattern in slug:
+            return category
+    return "uncategorized"
+
+
+def assign_status(slug: str, content: str) -> str:
+    """Assign status via override dict or heuristic."""
+    if slug in STATUS_OVERRIDES:
+        return STATUS_OVERRIDES[slug]
+    lower = content.lower()
+    if "deployed" in lower or "status: deployed" in lower:
+        return "deployed"
+    if "todo" in lower or "status: todo" in lower:
+        return "todo"
+    if "active" in lower or "status: active" in lower:
+        return "active"
+    return "reference"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Collect docs
+# ─────────────────────────────────────────────────────────────────────────────
+
+def collect_docs() -> list[dict]:
+    """Walk research/ and collect all .md files with metadata."""
+    docs = []
+    for path in sorted(RESEARCH_DIR.rglob("*.md")):
+        rel = path.relative_to(RESEARCH_DIR)
+        rel_str = str(rel)
+
+        # Skip README.md at root (redundant with hub)
+        if rel_str == "README.md":
+            continue
+
+        slug = slug_from_path(rel_str)
+        content = path.read_text(encoding="utf-8")
+
+        doc = {
+            "slug": slug,
+            "path": f"research/{rel_str}",
+            "title": extract_title(content, slug),
+            "date": extract_date(content, slug),
+            "summary": extract_summary(content),
+            "category": assign_category(slug),
+            "status": assign_status(slug, content),
+            "cross_refs": extract_cross_refs(content, slug),
+            "backlinks": [],  # populated later
+            "content": content,
+            "is_subdir_readme": rel.name == "README.md" and len(rel.parts) > 1,
+            "parent_dir": str(rel.parent) if len(rel.parts) > 1 else None,
+        }
+        docs.append(doc)
+
+    # Build backlinks
+    slug_set = {d["slug"] for d in docs}
+    for doc in docs:
+        for ref_slug in doc["cross_refs"]:
+            if ref_slug in slug_set:
+                for target in docs:
+                    if target["slug"] == ref_slug and doc["slug"] not in target["backlinks"]:
+                        target["backlinks"].append(doc["slug"])
+
+    return docs
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# HTML generation
+# ─────────────────────────────────────────────────────────────────────────────
+
+def build_html(docs: list[dict]) -> str:
+    """Build the complete HTML string."""
+    # Group docs by category
+    by_category: dict[str, list[dict]] = {cat: [] for cat in CATEGORY_ORDER}
+    uncategorized = []
+    for doc in docs:
+        cat = doc["category"]
+        if cat in by_category:
+            by_category[cat].append(doc)
+        else:
+            uncategorized.append(doc)
+
+    # Group subdirectory docs under their README
+    def sort_docs(cat_docs):
+        """Sort docs: subdir READMEs first within their dir, then alpha."""
+        primary = []
+        sub_children = {}
+        for d in cat_docs:
+            if d["parent_dir"] and not d["is_subdir_readme"]:
+                sub_children.setdefault(d["parent_dir"], []).append(d)
+            else:
+                primary.append(d)
+        # For subdirs without a README, promote the first child to primary
+        primary_dirs = {d["parent_dir"] for d in primary if d["parent_dir"]}
+        for dir_name, children in list(sub_children.items()):
+            if dir_name not in primary_dirs:
+                promoted = children.pop(0)
+                primary.append(promoted)
+                if not children:
+                    del sub_children[dir_name]
+        return primary, sub_children
+
+    # Compute KPIs
+    total_docs = len(docs)
+    num_categories = len([c for c in CATEGORY_ORDER if by_category.get(c)])
+    dates = [d["date"] for d in docs if d["date"]]
+    date_range = f"Feb 8–21" if dates else "—"
+
+    # Unique dates from filenames for "days of research"
+    date_strs = set()
+    for doc in docs:
+        m = re.search(r"(\d{4}-\d{2}-\d{2})", doc["slug"])
+        if m:
+            date_strs.add(m.group(1))
+    research_days = len(date_strs) if date_strs else "—"
+
+    # Build docs JSON for embedding
+    docs_json = {}
+    for doc in docs:
+        docs_json[doc["slug"]] = {
+            "title": doc["title"],
+            "content": doc["content"],
+            "date": doc["date"],
+            "category": doc["category"],
+            "status": doc["status"],
+            "cross_refs": doc["cross_refs"],
+            "backlinks": doc["backlinks"],
+            "path": doc["path"],
+        }
+
+    # Build category sections HTML
+    category_sections = []
+    for cat in CATEGORY_ORDER:
+        cat_docs = by_category.get(cat, [])
+        if not cat_docs:
+            continue
+        meta = CATEGORY_META[cat]
+        primary, sub_children = sort_docs(cat_docs)
+        rows_html = []
+        for doc in primary:
+            children = []
+            if doc["parent_dir"]:
+                children = sub_children.get(doc["parent_dir"], [])
+
+            sub_html = ""
+            if children:
+                sub_items = []
+                for child in children:
+                    child_name = child["slug"].split("/")[-1]
+                    sub_items.append(
+                        f'<div class="sub-doc" onclick="showDoc(\'{_esc_attr(child["slug"])}\')" '
+                        f'style="cursor:pointer">'
+                        f'<code>{_esc(child_name)}.md</code> — {_esc(child["summary"][:80])}</div>'
+                    )
+                sub_html = f'<div class="sub-docs">{"".join(sub_items)}</div>'
+
+            badge_class = f"badge-{doc['status']}"
+            date_html = f'<span class="doc-date">{_esc(doc["date"])}</span>' if doc["date"] else ""
+
+            rows_html.append(
+                f'<div class="doc-row" data-status="{_esc_attr(doc["status"])}" '
+                f'data-searchable="{_esc_attr(doc["title"] + " " + doc["summary"])}" '
+                f'onclick="showDoc(\'{_esc_attr(doc["slug"])}\')" style="cursor:pointer">'
+                f'  <div class="doc-icon" style="background:var(--accent-{meta["color"]}-dim);color:var(--accent-{meta["color"]})">'
+                f'    <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M2 1.75C2 .784 2.784 0 3.75 0h6.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0 1 13.25 16h-9.5A1.75 1.75 0 0 1 2 14.25Zm1.75-.25a.25.25 0 0 0-.25.25v12.5c0 .138.112.25.25.25h9.5a.25.25 0 0 0 .25-.25V6h-2.75A1.75 1.75 0 0 1 9 4.25V1.5Zm6.75.062V4.25c0 .138.112.25.25.25h2.688l-.011-.013-2.914-2.914-.013-.011Z"/></svg>'
+                f'  </div>'
+                f'  <div class="doc-info">'
+                f'    <div class="doc-title-row">'
+                f'      <span class="doc-title">{_esc(doc["title"])}</span>'
+                f'      <span class="badge {badge_class}">{_esc(doc["status"].title())}</span>'
+                f'      {date_html}'
+                f'    </div>'
+                f'    <div class="doc-summary">{_esc(doc["summary"])}</div>'
+                f'    {sub_html}'
+                f'    <div class="doc-path">{_esc(doc["path"])}</div>'
+                f'  </div>'
+                f'</div>'
+            )
+
+        category_sections.append(
+            f'<section class="category-section" id="cat-{cat}" data-category="{cat}">'
+            f'  <div class="category-header" onclick="toggleCategory(this)">'
+            f'    <span class="category-dot" style="background:var(--accent-{meta["color"]})"></span>'
+            f'    <span class="category-title">{_esc(meta["label"])}</span>'
+            f'    <span class="category-count">{len(cat_docs)} docs</span>'
+            f'    <svg class="category-chevron" width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M12.78 6.22a.75.75 0 0 1 0 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L3.22 7.28a.75.75 0 0 1 1.06-1.06L8 9.94l3.72-3.72a.75.75 0 0 1 1.06 0Z"/></svg>'
+            f'  </div>'
+            f'  <div class="category-body">'
+            f'    {"".join(rows_html)}'
+            f'  </div>'
+            f'</section>'
+        )
+
+    # Build sidebar nav links
+    sidebar_links = []
+    for cat in CATEGORY_ORDER:
+        cat_docs = by_category.get(cat, [])
+        if not cat_docs:
+            continue
+        meta = CATEGORY_META[cat]
+        sidebar_links.append(
+            f'<a class="nav-link" data-nav="cat-{cat}" onclick="scrollToSection(\'cat-{cat}\')">'
+            f'  <span class="dot" style="background:var(--accent-{meta["color"]})"></span>'
+            f'  {_esc(meta["label"])}'
+            f'  <span class="count">{len(cat_docs)}</span>'
+            f'</a>'
+        )
+
+    # Build findings HTML
+    findings_html = []
+    for f in KEY_FINDINGS:
+        findings_html.append(
+            f'<div class="finding-card" style="border-color:var(--accent-{f["color"]})">'
+            f'  <div class="finding-title" style="color:var(--accent-{f["color"]})">{_esc(f["title"])}</div>'
+            f'  <div class="finding-text">{_esc(f["text"])}</div>'
+            f'</div>'
+        )
+
+    # Build timeline HTML
+    timeline_html = []
+    for t in TIMELINE:
+        cls = "tl-entry milestone" if t.get("milestone") else "tl-entry"
+        timeline_html.append(
+            f'<div class="{cls}">'
+            f'  <div class="tl-date">{_esc(t["date"])}</div>'
+            f'  <div class="tl-title">{_esc(t["title"])}</div>'
+            f'  <div class="tl-desc">{_esc(t["desc"])}</div>'
+            f'</div>'
+        )
+
+    # Mobile nav
+    mobile_links = ['<a onclick="scrollToSection(\'hero\')">Dashboard</a>']
+    mobile_links.append('<a onclick="scrollToSection(\'findings\')">Findings</a>')
+    mobile_links.append('<a onclick="scrollToSection(\'timeline\')">Timeline</a>')
+    for cat in CATEGORY_ORDER:
+        if by_category.get(cat):
+            meta = CATEGORY_META[cat]
+            short = meta["label"].split("&")[0].split(" ")[0]
+            mobile_links.append(f'<a onclick="scrollToSection(\'cat-{cat}\')">{_esc(short)}</a>')
+
+    now = datetime.now().strftime("%B %d, %Y")
+
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Alif Research Hub</title>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400;500;600;700&family=IBM+Plex+Mono:wght@400;500&family=Amiri:wght@400;700&display=swap" rel="stylesheet">
+  <style>
+{CSS}
+  </style>
+</head>
+<body>
+
+<div class="page-wrap">
+
+  <!-- Sidebar -->
+  <nav class="sidebar" id="sidebar" role="navigation">
+    <div class="sidebar-brand" onclick="showHub()" style="cursor:pointer">
+      <span class="alif">ا</span>
+      <div>
+        <div class="title">Research Hub</div>
+        <div class="subtitle">Alif Arabic Learning</div>
+      </div>
+    </div>
+    <div class="nav-section">
+      <div class="nav-section-label">Overview</div>
+      <a class="nav-link" data-nav="hero" onclick="showHub(); scrollToSection('hero')">
+        <span class="dot" style="background:var(--accent-blue)"></span>
+        Dashboard
+      </a>
+      <a class="nav-link" data-nav="findings" onclick="showHub(); scrollToSection('findings')">
+        <span class="dot" style="background:var(--accent-green)"></span>
+        Key Findings
+      </a>
+      <a class="nav-link" data-nav="timeline" onclick="showHub(); scrollToSection('timeline')">
+        <span class="dot" style="background:var(--accent-purple)"></span>
+        Timeline
+      </a>
+    </div>
+    <div class="nav-section">
+      <div class="nav-section-label">Categories</div>
+      {"".join(sidebar_links)}
+    </div>
+  </nav>
+
+  <!-- Mobile nav -->
+  <div class="mobile-nav" role="navigation">
+    {"".join(mobile_links)}
+  </div>
+
+  <!-- Hub view -->
+  <main class="main" id="hubView">
+    <section class="hero" id="hero">
+      <h1>Research Hub <span class="arabic">بحث</span></h1>
+      <p class="tagline">All research documents, experiments, and findings for the Alif Arabic learning project.</p>
+      <div class="kpi-strip">
+        <div class="kpi">
+          <div class="number" style="color:var(--accent-blue)">{total_docs}</div>
+          <div class="label">Research Documents</div>
+        </div>
+        <div class="kpi">
+          <div class="number" style="color:var(--accent-green)">{num_categories}</div>
+          <div class="label">Categories</div>
+        </div>
+        <div class="kpi">
+          <div class="number" style="color:var(--accent-purple)">{research_days}</div>
+          <div class="label">Days of Research</div>
+        </div>
+        <div class="kpi">
+          <div class="number" style="color:var(--accent-amber)">{_esc(date_range)}</div>
+          <div class="label">Date Range, 2026</div>
+        </div>
+      </div>
+      <div class="search-wrap">
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M11.5 7a4.5 4.5 0 1 1-9 0 4.5 4.5 0 0 1 9 0Zm-.82 4.74a6 6 0 1 1 1.06-1.06l3.04 3.04a.75.75 0 1 1-1.06 1.06l-3.04-3.04Z"/></svg>
+        <input class="search-input" type="text" id="searchInput" placeholder="Search documents, topics, keywords..." aria-label="Search research documents">
+        <span class="search-count" id="searchCount">{total_docs} docs</span>
+      </div>
+      <div class="filter-chips" id="filterChips">
+        <button class="filter-chip active" data-filter="all">All</button>
+        <button class="filter-chip" data-filter="deployed">Deployed</button>
+        <button class="filter-chip" data-filter="active">Active</button>
+        <button class="filter-chip" data-filter="reference">Reference</button>
+        <button class="filter-chip" data-filter="todo">TODO</button>
+      </div>
+    </section>
+
+    <section class="findings" id="findings">
+      <h2>
+        <svg width="18" height="18" viewBox="0 0 16 16" fill="var(--accent-green)"><path d="M8 1.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm11.28-1.78a.75.75 0 0 0-1.06-1.06L7 8.38 5.78 7.16a.75.75 0 0 0-1.06 1.06l1.75 1.75a.75.75 0 0 0 1.06 0l3.75-3.75Z"/></svg>
+        Key Research Findings
+      </h2>
+      <div class="findings-grid">
+        {"".join(findings_html)}
+      </div>
+    </section>
+
+    <section class="timeline-section" id="timeline">
+      <h2>Research Timeline</h2>
+      <div class="timeline">
+        {"".join(timeline_html)}
+      </div>
+    </section>
+
+    {"".join(category_sections)}
+
+    <footer class="footer">
+      <div>Last updated: {now}</div>
+      <div>Auto-generated by <code>scripts/build_research_hub.py</code>. <a href="#" onclick="showDoc('README'); return false">README</a></div>
+    </footer>
+  </main>
+
+  <!-- Document viewer -->
+  <main class="main doc-viewer" id="docView" style="display:none">
+    <div class="doc-nav">
+      <button class="back-btn" onclick="history.back()">
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M7.78 12.53a.75.75 0 0 1-1.06 0L2.47 8.28a.75.75 0 0 1 0-1.06l4.25-4.25a.751.751 0 0 1 1.042.018.751.751 0 0 1 .018 1.042L4.81 7h7.44a.75.75 0 0 1 0 1.5H4.81l2.97 2.97a.75.75 0 0 1 0 1.06Z"/></svg>
+        Back to Hub
+      </button>
+      <span class="doc-breadcrumb" id="docBreadcrumb"></span>
+    </div>
+    <article class="doc-content" id="docContent"></article>
+    <div class="doc-backlinks" id="docBacklinks"></div>
+    <footer class="footer">
+      <div>Auto-generated by <code>scripts/build_research_hub.py</code></div>
+    </footer>
+  </main>
+
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/marked@15/marked.min.js"></script>
+<script>
+// Embedded document data
+const DOCS = {json.dumps(docs_json, ensure_ascii=False).replace("</script>", "<\\/script>")};
+
+{JS}
+</script>
+
+</body>
+</html>"""
+
+
+def _esc(s: str) -> str:
+    """Escape HTML entities."""
+    return (s or "").replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace('"', "&quot;")
+
+
+def _esc_attr(s: str) -> str:
+    """Escape for use in HTML attributes and JS strings."""
+    return (s or "").replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace('"', "&quot;").replace("'", "\\'")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# CSS
+# ─────────────────────────────────────────────────────────────────────────────
+
+CSS = """\
+    :root {
+      --bg: #0d1117;
+      --bg-gradient: linear-gradient(135deg, #0d1117 0%, #161b22 50%, #0d1117 100%);
+      --surface: #161b22;
+      --surface-raised: #1c2333;
+      --surface-hover: #21283b;
+      --border: rgba(139, 148, 158, 0.12);
+      --border-accent: rgba(88, 166, 255, 0.2);
+      --text: #e6edf3;
+      --text-dim: #8b949e;
+      --text-muted: #6e7681;
+      --accent-blue: #58a6ff;
+      --accent-blue-dim: rgba(88, 166, 255, 0.15);
+      --accent-green: #3fb950;
+      --accent-green-dim: rgba(63, 185, 80, 0.15);
+      --accent-amber: #d29922;
+      --accent-amber-dim: rgba(210, 153, 34, 0.15);
+      --accent-purple: #bc8cff;
+      --accent-purple-dim: rgba(188, 140, 255, 0.15);
+      --accent-red: #f85149;
+      --accent-red-dim: rgba(248, 81, 73, 0.15);
+      --accent-cyan: #39d2c0;
+      --accent-cyan-dim: rgba(57, 210, 192, 0.15);
+      --accent-orange: #f0883e;
+      --accent-orange-dim: rgba(240, 136, 62, 0.15);
+      --accent-pink: #f778ba;
+      --accent-pink-dim: rgba(247, 120, 186, 0.15);
+      --radius: 8px;
+      --radius-lg: 12px;
+      --shadow-sm: 0 1px 2px rgba(0,0,0,0.3);
+      --shadow-md: 0 4px 12px rgba(0,0,0,0.4);
+      --shadow-lg: 0 8px 24px rgba(0,0,0,0.5);
+      --font-sans: 'IBM Plex Sans', -apple-system, sans-serif;
+      --font-mono: 'IBM Plex Mono', 'Menlo', monospace;
+      --font-arabic: 'Amiri', serif;
+    }
+
+    @media (prefers-color-scheme: light) {
+      :root {
+        --bg: #f6f8fa;
+        --bg-gradient: linear-gradient(135deg, #f6f8fa 0%, #ffffff 50%, #f6f8fa 100%);
+        --surface: #ffffff;
+        --surface-raised: #f6f8fa;
+        --surface-hover: #eef1f5;
+        --border: rgba(31, 35, 40, 0.1);
+        --border-accent: rgba(9, 105, 218, 0.2);
+        --text: #1f2328;
+        --text-dim: #656d76;
+        --text-muted: #8b949e;
+        --accent-blue: #0969da;
+        --accent-blue-dim: rgba(9, 105, 218, 0.1);
+        --accent-green: #1a7f37;
+        --accent-green-dim: rgba(26, 127, 55, 0.1);
+        --accent-amber: #9a6700;
+        --accent-amber-dim: rgba(154, 103, 0, 0.1);
+        --accent-purple: #8250df;
+        --accent-purple-dim: rgba(130, 80, 223, 0.1);
+        --accent-red: #cf222e;
+        --accent-red-dim: rgba(207, 34, 46, 0.1);
+        --accent-cyan: #0d8a7e;
+        --accent-cyan-dim: rgba(13, 138, 126, 0.1);
+        --accent-orange: #bc4c00;
+        --accent-orange-dim: rgba(188, 76, 0, 0.1);
+        --accent-pink: #bf3989;
+        --accent-pink-dim: rgba(191, 57, 137, 0.1);
+        --shadow-sm: 0 1px 2px rgba(0,0,0,0.06);
+        --shadow-md: 0 4px 12px rgba(0,0,0,0.08);
+        --shadow-lg: 0 8px 24px rgba(0,0,0,0.12);
+      }
+    }
+
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+
+    body {
+      font-family: var(--font-sans);
+      background: var(--bg);
+      color: var(--text);
+      line-height: 1.6;
+      min-height: 100vh;
+    }
+
+    body::before {
+      content: '';
+      position: fixed;
+      inset: 0;
+      background:
+        radial-gradient(ellipse 800px 600px at 20% 10%, rgba(88, 166, 255, 0.04), transparent),
+        radial-gradient(ellipse 600px 500px at 80% 80%, rgba(188, 140, 255, 0.03), transparent),
+        var(--bg-gradient);
+      z-index: -1;
+    }
+
+    .page-wrap { display: flex; min-height: 100vh; }
+
+    .sidebar {
+      position: sticky; top: 0; height: 100vh; width: 260px; min-width: 260px;
+      padding: 24px 16px; border-right: 1px solid var(--border);
+      background: var(--surface); overflow-y: auto; z-index: 10;
+    }
+
+    .sidebar-brand {
+      display: flex; align-items: center; gap: 10px;
+      padding: 0 8px 20px; border-bottom: 1px solid var(--border); margin-bottom: 16px;
+    }
+    .sidebar-brand .alif { font-family: var(--font-arabic); font-size: 28px; color: var(--accent-blue); line-height: 1; }
+    .sidebar-brand .title { font-size: 14px; font-weight: 600; color: var(--text); line-height: 1.3; }
+    .sidebar-brand .subtitle { font-size: 11px; color: var(--text-dim); }
+
+    .nav-section { margin-bottom: 8px; }
+    .nav-section-label { font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.08em; color: var(--text-muted); padding: 8px 8px 4px; }
+
+    .nav-link {
+      display: flex; align-items: center; gap: 8px; padding: 6px 8px;
+      border-radius: 6px; font-size: 13px; color: var(--text-dim);
+      text-decoration: none; cursor: pointer; transition: all 0.15s;
+    }
+    .nav-link:hover { background: var(--surface-hover); color: var(--text); }
+    .nav-link.active { background: var(--accent-blue-dim); color: var(--accent-blue); font-weight: 500; }
+    .nav-link .dot { width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0; }
+    .nav-link .count { margin-left: auto; font-size: 11px; font-family: var(--font-mono); color: var(--text-muted); }
+
+    .main { flex: 1; min-width: 0; padding: 32px 40px 80px; max-width: 960px; }
+
+    .mobile-nav {
+      display: none; position: sticky; top: 0; z-index: 20;
+      background: var(--surface); border-bottom: 1px solid var(--border);
+      padding: 12px 16px; overflow-x: auto; white-space: nowrap;
+    }
+    .mobile-nav a {
+      display: inline-block; padding: 4px 12px; border-radius: 20px;
+      font-size: 12px; font-weight: 500; color: var(--text-dim);
+      text-decoration: none; cursor: pointer; transition: all 0.15s;
+    }
+    .mobile-nav a:hover, .mobile-nav a.active { background: var(--accent-blue-dim); color: var(--accent-blue); }
+
+    @media (max-width: 768px) {
+      .sidebar { display: none; }
+      .mobile-nav { display: block; }
+      .main { padding: 20px 16px 60px; }
+    }
+
+    /* Hero */
+    .hero { margin-bottom: 32px; }
+    .hero h1 { font-size: 28px; font-weight: 700; margin-bottom: 6px; }
+    .hero h1 .arabic { font-family: var(--font-arabic); color: var(--accent-blue); }
+    .hero .tagline { font-size: 15px; color: var(--text-dim); margin-bottom: 20px; }
+
+    .kpi-strip { display: flex; gap: 16px; flex-wrap: wrap; margin-bottom: 24px; }
+    .kpi {
+      background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius);
+      padding: 14px 20px; min-width: 140px; flex: 1; box-shadow: var(--shadow-sm);
+      animation: fadeUp 0.5s ease-out both;
+    }
+    .kpi:nth-child(2) { animation-delay: 0.05s; }
+    .kpi:nth-child(3) { animation-delay: 0.1s; }
+    .kpi:nth-child(4) { animation-delay: 0.15s; }
+    .kpi .number { font-size: 28px; font-weight: 700; font-family: var(--font-mono); font-variant-numeric: tabular-nums; line-height: 1.1; }
+    .kpi .label { font-size: 12px; color: var(--text-dim); margin-top: 2px; }
+
+    .search-wrap { position: relative; margin-bottom: 28px; }
+    .search-wrap svg { position: absolute; left: 14px; top: 50%; transform: translateY(-50%); color: var(--text-muted); }
+    .search-input {
+      width: 100%; padding: 10px 14px 10px 40px; background: var(--surface);
+      border: 1px solid var(--border); border-radius: var(--radius); color: var(--text);
+      font-family: var(--font-sans); font-size: 14px; outline: none; transition: border-color 0.2s;
+    }
+    .search-input::placeholder { color: var(--text-muted); }
+    .search-input:focus { border-color: var(--accent-blue); box-shadow: 0 0 0 3px var(--accent-blue-dim); }
+    .search-count { position: absolute; right: 14px; top: 50%; transform: translateY(-50%); font-size: 12px; font-family: var(--font-mono); color: var(--text-muted); }
+
+    .filter-chips { display: flex; gap: 6px; flex-wrap: wrap; margin-bottom: 24px; }
+    .filter-chip {
+      padding: 4px 12px; border-radius: 20px; font-size: 12px; font-weight: 500;
+      border: 1px solid var(--border); background: transparent; color: var(--text-dim);
+      cursor: pointer; transition: all 0.15s; font-family: var(--font-sans);
+    }
+    .filter-chip:hover { border-color: var(--accent-blue); color: var(--accent-blue); }
+    .filter-chip.active { background: var(--accent-blue-dim); border-color: var(--accent-blue); color: var(--accent-blue); }
+
+    /* Findings */
+    .findings {
+      background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-lg);
+      padding: 24px; margin-bottom: 32px; box-shadow: var(--shadow-sm);
+      animation: fadeUp 0.5s ease-out 0.2s both;
+    }
+    .findings h2 { font-size: 16px; font-weight: 600; margin-bottom: 16px; display: flex; align-items: center; gap: 8px; }
+    .findings-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 12px; }
+    .finding-card { padding: 12px 16px; border-radius: var(--radius); border-left: 3px solid; background: var(--surface-raised); }
+    .finding-card .finding-title { font-size: 13px; font-weight: 600; margin-bottom: 4px; }
+    .finding-card .finding-text { font-size: 12px; color: var(--text-dim); line-height: 1.5; }
+
+    /* Timeline */
+    .timeline-section { margin-bottom: 32px; animation: fadeUp 0.5s ease-out 0.3s both; }
+    .timeline-section h2 { font-size: 16px; font-weight: 600; margin-bottom: 16px; }
+    .timeline { position: relative; padding: 0 0 0 24px; }
+    .timeline::before {
+      content: ''; position: absolute; left: 7px; top: 4px; bottom: 4px; width: 2px;
+      background: linear-gradient(to bottom, var(--accent-blue), var(--accent-purple), var(--accent-green));
+      border-radius: 1px;
+    }
+    .tl-entry { position: relative; margin-bottom: 16px; padding-left: 16px; }
+    .tl-entry::before {
+      content: ''; position: absolute; left: -20px; top: 8px; width: 10px; height: 10px;
+      border-radius: 50%; background: var(--surface); border: 2px solid var(--accent-blue);
+    }
+    .tl-entry.milestone::before { width: 12px; height: 12px; left: -21px; background: var(--accent-blue); box-shadow: 0 0 8px var(--accent-blue-dim); }
+    .tl-date { font-size: 12px; font-family: var(--font-mono); color: var(--accent-blue); font-weight: 500; }
+    .tl-title { font-size: 13px; font-weight: 500; }
+    .tl-desc { font-size: 12px; color: var(--text-dim); }
+
+    /* Category sections */
+    .category-section { margin-bottom: 24px; animation: fadeUp 0.5s ease-out both; }
+    .category-header {
+      display: flex; align-items: center; gap: 10px; padding: 12px 16px;
+      background: var(--surface); border: 1px solid var(--border);
+      border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+      cursor: pointer; user-select: none; transition: background 0.15s;
+    }
+    .category-header:hover { background: var(--surface-hover); }
+    .category-section.collapsed .category-header { border-radius: var(--radius-lg); }
+    .category-dot { width: 10px; height: 10px; border-radius: 50%; flex-shrink: 0; }
+    .category-title { font-size: 15px; font-weight: 600; flex: 1; }
+    .category-count { font-size: 12px; font-family: var(--font-mono); color: var(--text-muted); background: var(--surface-raised); padding: 2px 8px; border-radius: 10px; }
+    .category-chevron { color: var(--text-muted); transition: transform 0.2s; }
+    .category-section.collapsed .category-chevron { transform: rotate(-90deg); }
+    .category-body { border: 1px solid var(--border); border-top: none; border-radius: 0 0 var(--radius-lg) var(--radius-lg); overflow: hidden; }
+    .category-section.collapsed .category-body { display: none; }
+
+    /* Doc rows */
+    .doc-row {
+      display: flex; align-items: flex-start; gap: 12px; padding: 12px 16px;
+      border-bottom: 1px solid var(--border); transition: background 0.15s;
+    }
+    .doc-row:last-child { border-bottom: none; }
+    .doc-row:hover { background: var(--surface-hover); }
+    .doc-row.hidden { display: none; }
+
+    .doc-icon { width: 32px; height: 32px; border-radius: 6px; display: flex; align-items: center; justify-content: center; font-size: 14px; flex-shrink: 0; margin-top: 2px; }
+    .doc-info { flex: 1; min-width: 0; }
+    .doc-title-row { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+    .doc-title { font-size: 14px; font-weight: 500; }
+    .doc-date { font-size: 11px; font-family: var(--font-mono); color: var(--text-muted); }
+    .doc-summary { font-size: 12px; color: var(--text-dim); margin-top: 3px; line-height: 1.5; }
+    .doc-path { font-size: 11px; font-family: var(--font-mono); color: var(--text-muted); margin-top: 4px; opacity: 0.7; }
+
+    .badge { display: inline-flex; align-items: center; gap: 4px; padding: 1px 8px; border-radius: 10px; font-size: 11px; font-weight: 500; flex-shrink: 0; white-space: nowrap; }
+    .badge-deployed { background: var(--accent-green-dim); color: var(--accent-green); }
+    .badge-active { background: var(--accent-blue-dim); color: var(--accent-blue); }
+    .badge-reference { background: var(--accent-purple-dim); color: var(--accent-purple); }
+    .badge-todo { background: var(--accent-amber-dim); color: var(--accent-amber); }
+    .badge-archived { background: var(--surface-raised); color: var(--text-muted); }
+    .badge::before { content: ''; width: 5px; height: 5px; border-radius: 50%; background: currentColor; }
+
+    .sub-docs { margin-top: 6px; padding-left: 12px; border-left: 2px solid var(--border); }
+    .sub-doc { font-size: 12px; color: var(--text-dim); padding: 3px 0; }
+    .sub-doc:hover { color: var(--accent-blue); }
+    .sub-doc code { font-family: var(--font-mono); font-size: 11px; background: var(--surface-raised); padding: 1px 5px; border-radius: 3px; }
+
+    .footer {
+      margin-top: 48px; padding-top: 24px; border-top: 1px solid var(--border);
+      font-size: 12px; color: var(--text-muted); text-align: center; line-height: 1.8;
+    }
+    .footer a { color: var(--accent-blue); text-decoration: none; }
+    .footer code { font-family: var(--font-mono); font-size: 11px; background: var(--surface-raised); padding: 1px 5px; border-radius: 3px; }
+
+    @keyframes fadeUp {
+      from { opacity: 0; transform: translateY(12px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after { animation-duration: 0.01ms !important; transition-duration: 0.01ms !important; }
+    }
+
+    ::-webkit-scrollbar { width: 6px; }
+    ::-webkit-scrollbar-track { background: transparent; }
+    ::-webkit-scrollbar-thumb { background: var(--border); border-radius: 3px; }
+    ::-webkit-scrollbar-thumb:hover { background: var(--text-muted); }
+
+    /* ====== Document viewer ====== */
+    .doc-viewer { display: none; }
+
+    .doc-nav {
+      display: flex; align-items: center; gap: 12px;
+      margin-bottom: 24px; padding-bottom: 16px; border-bottom: 1px solid var(--border);
+    }
+    .back-btn {
+      display: inline-flex; align-items: center; gap: 6px; padding: 6px 12px;
+      background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius);
+      color: var(--text-dim); font-family: var(--font-sans); font-size: 13px;
+      cursor: pointer; transition: all 0.15s;
+    }
+    .back-btn:hover { background: var(--surface-hover); color: var(--text); border-color: var(--accent-blue); }
+
+    .doc-breadcrumb { font-size: 12px; color: var(--text-muted); font-family: var(--font-mono); }
+
+    /* Article typography */
+    .doc-content {
+      line-height: 1.7; font-size: 15px;
+    }
+    .doc-content h1 { font-size: 26px; font-weight: 700; margin: 0 0 16px; padding-bottom: 8px; border-bottom: 1px solid var(--border); }
+    .doc-content h2 { font-size: 20px; font-weight: 600; margin: 32px 0 12px; padding-bottom: 6px; border-bottom: 1px solid var(--border); }
+    .doc-content h3 { font-size: 17px; font-weight: 600; margin: 24px 0 8px; }
+    .doc-content h4 { font-size: 15px; font-weight: 600; margin: 20px 0 6px; }
+    .doc-content p { margin: 0 0 12px; }
+    .doc-content ul, .doc-content ol { margin: 0 0 12px; padding-left: 24px; }
+    .doc-content li { margin-bottom: 4px; }
+    .doc-content a { color: var(--accent-blue); text-decoration: none; }
+    .doc-content a:hover { text-decoration: underline; }
+    .doc-content a.internal-ref { border-bottom: 1.5px dotted var(--accent-blue); text-decoration: none; }
+    .doc-content a.internal-ref:hover { border-bottom-style: solid; }
+
+    .doc-content blockquote {
+      margin: 0 0 12px; padding: 8px 16px; border-left: 3px solid var(--accent-blue);
+      background: var(--surface-raised); border-radius: 0 var(--radius) var(--radius) 0;
+      color: var(--text-dim); font-size: 14px;
+    }
+    .doc-content blockquote p:last-child { margin-bottom: 0; }
+
+    .doc-content code {
+      font-family: var(--font-mono); font-size: 0.88em;
+      background: var(--surface-raised); padding: 2px 6px; border-radius: 4px;
+    }
+    .doc-content pre {
+      margin: 0 0 12px; padding: 16px; background: var(--surface-raised);
+      border: 1px solid var(--border); border-radius: var(--radius);
+      overflow-x: auto; font-size: 13px; line-height: 1.5;
+    }
+    .doc-content pre code { background: none; padding: 0; border-radius: 0; font-size: inherit; }
+
+    .doc-content table {
+      width: 100%; margin: 0 0 12px; border-collapse: collapse;
+      font-size: 13px;
+    }
+    .doc-content th, .doc-content td {
+      padding: 8px 12px; border: 1px solid var(--border); text-align: left;
+    }
+    .doc-content th { background: var(--surface-raised); font-weight: 600; }
+    .doc-content tr:hover td { background: var(--surface-hover); }
+
+    .doc-content hr { border: none; border-top: 1px solid var(--border); margin: 24px 0; }
+    .doc-content img { max-width: 100%; border-radius: var(--radius); }
+    .doc-content strong { font-weight: 600; }
+
+    /* Arabic text detection */
+    .doc-content :lang(ar), .doc-content [dir="rtl"] { font-family: var(--font-arabic); }
+
+    /* Backlinks */
+    .doc-backlinks {
+      margin-top: 32px; padding: 16px; background: var(--surface);
+      border: 1px solid var(--border); border-radius: var(--radius-lg);
+    }
+    .doc-backlinks h3 { font-size: 14px; font-weight: 600; margin-bottom: 8px; color: var(--text-dim); }
+    .doc-backlinks a {
+      display: inline-block; margin: 2px 4px; padding: 2px 10px;
+      background: var(--surface-raised); border-radius: 12px;
+      font-size: 12px; color: var(--accent-blue); text-decoration: none;
+      border: 1px solid var(--border); transition: all 0.15s;
+    }
+    .doc-backlinks a:hover { background: var(--accent-blue-dim); border-color: var(--accent-blue); }
+    .doc-backlinks.empty { display: none; }"""
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# JavaScript
+# ─────────────────────────────────────────────────────────────────────────────
+
+JS = """\
+// ====== Basic markdown renderer (fallback when marked.js CDN unavailable) ======
+function renderMarkdownBasic(md) {
+  let h = escapeHtml(md);
+  // Code blocks (``` ... ```)
+  h = h.replace(/```(\\w*)\\n([\\s\\S]*?)```/g, function(_, lang, code) {
+    return '<pre><code>' + code + '</code></pre>';
+  });
+  // Inline code
+  h = h.replace(/`([^`]+)`/g, '<code>$1</code>');
+  // Headings
+  h = h.replace(/^#### (.+)$/gm, '<h4>$1</h4>');
+  h = h.replace(/^### (.+)$/gm, '<h3>$1</h3>');
+  h = h.replace(/^## (.+)$/gm, '<h2>$1</h2>');
+  h = h.replace(/^# (.+)$/gm, '<h1>$1</h1>');
+  // Bold and italic
+  h = h.replace(/\\*\\*([^*]+)\\*\\*/g, '<strong>$1</strong>');
+  h = h.replace(/\\*([^*]+)\\*/g, '<em>$1</em>');
+  // Links
+  h = h.replace(/\\[([^\\]]+)\\]\\(([^)]+)\\)/g, '<a href="$2">$1</a>');
+  // Blockquotes
+  h = h.replace(/^&gt; (.+)$/gm, '<blockquote>$1</blockquote>');
+  // Horizontal rules
+  h = h.replace(/^---+$/gm, '<hr>');
+  // Unordered lists
+  h = h.replace(/^- (.+)$/gm, '<li>$1</li>');
+  h = h.replace(/(<li>.*<\\/li>\\n?)+/g, '<ul>$&</ul>');
+  // Tables (basic)
+  h = h.replace(/^\\|(.+)\\|$/gm, function(line) {
+    if (line.match(/^\\|[\\s-:|]+\\|$/)) return '';
+    const cells = line.split('|').filter(c => c.trim());
+    const tag = 'td';
+    return '<tr>' + cells.map(c => '<' + tag + '>' + c.trim() + '</' + tag + '>').join('') + '</tr>';
+  });
+  h = h.replace(/(<tr>.*<\\/tr>\\n?)+/g, '<table>$&</table>');
+  // Paragraphs
+  h = h.replace(/\\n\\n+/g, '</p><p>');
+  h = '<p>' + h + '</p>';
+  // Clean up empty paragraphs
+  h = h.replace(/<p>\\s*<\\/p>/g, '');
+  h = h.replace(/<p>\\s*(<h[1-4]>)/g, '$1');
+  h = h.replace(/(<\\/h[1-4]>)\\s*<\\/p>/g, '$1');
+  h = h.replace(/<p>\\s*(<pre>)/g, '$1');
+  h = h.replace(/(<\\/pre>)\\s*<\\/p>/g, '$1');
+  h = h.replace(/<p>\\s*(<ul>)/g, '$1');
+  h = h.replace(/(<\\/ul>)\\s*<\\/p>/g, '$1');
+  h = h.replace(/<p>\\s*(<table>)/g, '$1');
+  h = h.replace(/(<\\/table>)\\s*<\\/p>/g, '$1');
+  h = h.replace(/<p>\\s*(<hr>)/g, '$1');
+  h = h.replace(/(<hr>)\\s*<\\/p>/g, '$1');
+  h = h.replace(/<p>\\s*(<blockquote>)/g, '$1');
+  h = h.replace(/(<\\/blockquote>)\\s*<\\/p>/g, '$1');
+  return h;
+}
+
+// ====== Hash routing ======
+function showHub() {
+  if (location.hash.startsWith('#doc:')) {
+    location.hash = '';
+  }
+  document.getElementById('hubView').style.display = 'block';
+  document.getElementById('docView').style.display = 'none';
+  document.title = 'Alif Research Hub';
+}
+
+function showDoc(slug) {
+  const doc = DOCS[slug];
+  if (!doc) {
+    // Try partial match (e.g. README -> first README match)
+    const match = Object.keys(DOCS).find(k => k.endsWith('/' + slug) || k === slug);
+    if (match) return showDoc(match);
+    console.warn('Doc not found:', slug);
+    return;
+  }
+
+  location.hash = 'doc:' + slug;
+
+  document.getElementById('hubView').style.display = 'none';
+  document.getElementById('docView').style.display = 'block';
+
+  // Breadcrumb
+  const cat = doc.category;
+  const catMeta = {
+    algorithm: 'Algorithm Redesign', science: 'Learning Science',
+    analytics: 'Production Analytics', generation: 'Sentence & Story Gen',
+    nlp: 'NLP & Infrastructure', quality: 'Data Quality',
+    cost: 'Cost & Infrastructure', education: 'Arabic Education',
+    external: 'External References'
+  };
+  document.getElementById('docBreadcrumb').textContent =
+    (catMeta[cat] || cat) + ' / ' + doc.title;
+
+  // Render markdown
+  let html = '';
+  if (typeof marked !== 'undefined') {
+    html = marked.parse(doc.content);
+  } else {
+    html = renderMarkdownBasic(doc.content);
+  }
+
+  // Rewrite internal .md links to showDoc() calls
+  html = html.replace(
+    /href="([^"]*\\.md)"/g,
+    function(match, href) {
+      // Resolve relative paths
+      let target = href.replace(/^\\.\\//,'');
+      const docDir = slug.includes('/') ? slug.substring(0, slug.lastIndexOf('/')) : '';
+      if (docDir && !target.includes('/')) {
+        target = docDir + '/' + target;
+      }
+      // Normalize ../
+      const parts = target.split('/');
+      const resolved = [];
+      for (const p of parts) {
+        if (p === '..') resolved.pop();
+        else if (p !== '.') resolved.push(p);
+      }
+      target = resolved.join('/').replace(/\\.md$/, '');
+      if (DOCS[target]) {
+        return 'href="#doc:' + target + '" class="internal-ref" onclick="showDoc(\\'' + target.replace(/'/g, "\\\\'") + '\\'); return false;"';
+      }
+      return match;
+    }
+  );
+
+  document.getElementById('docContent').innerHTML = html;
+  document.title = doc.title + ' — Alif Research Hub';
+
+  // Backlinks
+  const bl = document.getElementById('docBacklinks');
+  if (doc.backlinks && doc.backlinks.length > 0) {
+    bl.classList.remove('empty');
+    let blHtml = '<h3>Referenced by ' + doc.backlinks.length + ' document' + (doc.backlinks.length > 1 ? 's' : '') + '</h3>';
+    for (const ref of doc.backlinks) {
+      const refDoc = DOCS[ref];
+      if (refDoc) {
+        blHtml += '<a href="#doc:' + ref + '" onclick="showDoc(\\'' + ref.replace(/'/g, "\\\\'") + '\\'); return false;">' + escapeHtml(refDoc.title) + '</a>';
+      }
+    }
+    bl.innerHTML = blHtml;
+  } else {
+    bl.classList.add('empty');
+    bl.innerHTML = '';
+  }
+
+  // Highlight active sidebar category
+  document.querySelectorAll('.nav-link').forEach(l => l.classList.remove('active'));
+  const catNav = document.querySelector('[data-nav="cat-' + cat + '"]');
+  if (catNav) catNav.classList.add('active');
+
+  window.scrollTo(0, 0);
+}
+
+function escapeHtml(s) {
+  return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+}
+
+// Hash change listener
+window.addEventListener('hashchange', function() {
+  const hash = location.hash;
+  if (hash.startsWith('#doc:')) {
+    showDoc(hash.substring(5));
+  } else {
+    showHub();
+  }
+});
+
+// Initial route
+if (location.hash.startsWith('#doc:')) {
+  showDoc(location.hash.substring(5));
+}
+
+// ====== Section scrolling ======
+function scrollToSection(id) {
+  const el = document.getElementById(id);
+  if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+}
+
+// ====== Category toggle ======
+function toggleCategory(header) {
+  header.parentElement.classList.toggle('collapsed');
+}
+
+// ====== Search ======
+const searchInput = document.getElementById('searchInput');
+const searchCount = document.getElementById('searchCount');
+
+searchInput.addEventListener('input', function() {
+  const query = this.value.toLowerCase().trim();
+  const rows = document.querySelectorAll('#hubView .doc-row');
+  let visible = 0;
+
+  if (!query) {
+    // Also search in embedded content
+    rows.forEach(row => { row.classList.remove('hidden'); visible++; });
+  } else {
+    // Search in displayed text AND in embedded markdown content
+    rows.forEach(row => {
+      const searchable = (row.dataset.searchable || '') + ' ' +
+        (row.querySelector('.doc-title')?.textContent || '') + ' ' +
+        (row.querySelector('.doc-summary')?.textContent || '') + ' ' +
+        (row.querySelector('.doc-path')?.textContent || '');
+
+      // Also search embedded content via slug from onclick
+      const onclick = row.getAttribute('onclick') || '';
+      const slugMatch = onclick.match(/showDoc\\('([^']+)'\\)/);
+      let contentMatch = false;
+      if (slugMatch && DOCS[slugMatch[1]]) {
+        contentMatch = DOCS[slugMatch[1]].content.toLowerCase().includes(query);
+      }
+
+      if (searchable.toLowerCase().includes(query) || contentMatch) {
+        row.classList.remove('hidden');
+        visible++;
+      } else {
+        row.classList.add('hidden');
+      }
+    });
+  }
+
+  searchCount.textContent = visible + ' doc' + (visible !== 1 ? 's' : '');
+
+  if (query) {
+    document.querySelectorAll('.category-section').forEach(section => {
+      const hasVisible = section.querySelector('.doc-row:not(.hidden)');
+      if (hasVisible) section.classList.remove('collapsed');
+      else section.classList.add('collapsed');
+    });
+  }
+});
+
+// ====== Filter chips ======
+document.querySelectorAll('.filter-chip').forEach(chip => {
+  chip.addEventListener('click', function() {
+    document.querySelectorAll('.filter-chip').forEach(c => c.classList.remove('active'));
+    this.classList.add('active');
+    const filter = this.dataset.filter;
+    const rows = document.querySelectorAll('#hubView .doc-row');
+    let visible = 0;
+    rows.forEach(row => {
+      if (filter === 'all' || row.dataset.status === filter) {
+        row.classList.remove('hidden');
+        visible++;
+      } else {
+        row.classList.add('hidden');
+      }
+    });
+    searchCount.textContent = visible + ' doc' + (visible !== 1 ? 's' : '');
+    searchInput.value = '';
+    document.querySelectorAll('.category-section').forEach(section => {
+      const hasVisible = section.querySelector('.doc-row:not(.hidden)');
+      if (hasVisible) section.classList.remove('collapsed');
+      else if (filter !== 'all') section.classList.add('collapsed');
+    });
+  });
+});
+
+// ====== Scroll spy ======
+function updateActiveNav() {
+  if (document.getElementById('hubView').style.display === 'none') return;
+  let current = '';
+  document.querySelectorAll('[id]').forEach(section => {
+    const rect = section.getBoundingClientRect();
+    if (rect.top <= 100) current = section.id;
+  });
+  document.querySelectorAll('.nav-link[data-nav]').forEach(link => {
+    link.classList.toggle('active', link.dataset.nav === current);
+  });
+}
+window.addEventListener('scroll', updateActiveNav, { passive: true });
+updateActiveNav();"""
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Main
+# ─────────────────────────────────────────────────────────────────────────────
+
+def main():
+    docs = collect_docs()
+
+    # Report
+    categories = {}
+    uncategorized = []
+    for doc in docs:
+        if doc["category"] == "uncategorized":
+            uncategorized.append(doc["slug"])
+        categories.setdefault(doc["category"], []).append(doc["slug"])
+
+    print(f"Collected {len(docs)} documents across {len(categories)} categories")
+    for cat in CATEGORY_ORDER:
+        if cat in categories:
+            print(f"  {cat}: {len(categories[cat])} docs")
+    if uncategorized:
+        print(f"\n  WARNING: {len(uncategorized)} uncategorized docs:")
+        for slug in uncategorized:
+            print(f"    - {slug}")
+
+    # Cross-ref stats
+    total_refs = sum(len(d["cross_refs"]) for d in docs)
+    total_backlinks = sum(len(d["backlinks"]) for d in docs)
+    print(f"\nCross-references: {total_refs} outgoing, {total_backlinks} backlinks")
+
+    html = build_html(docs)
+    OUTPUT_FILE.write_text(html, encoding="utf-8")
+    size_kb = len(html.encode("utf-8")) / 1024
+    print(f"\nWrote {OUTPUT_FILE} ({size_kb:.0f} KB)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/pre-deploy.sh
+++ b/scripts/pre-deploy.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Alif-specific pre-deploy checks
+# Called by ~/src/expo/scripts/deploy.sh before the common deploy steps
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Check for known Expo Router incompatibilities
+# href + tabBarButton on same screen crashes Expo Router
+if python3 -c "
+import re
+text = open('$ROOT/frontend/app/_layout.tsx').read()
+blocks = re.findall(r'options=\{\{(.*?)\}\}', text, re.DOTALL)
+bad = [b for b in blocks if 'href' in b and 'tabBarButton' in b]
+exit(1 if bad else 0)
+"; then
+    echo "  Layout config OK"
+else
+    echo "FAIL: _layout.tsx has both href and tabBarButton on the same screen"
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Brings into git a batch of files that have been sitting untracked in the working tree, and extends `.gitignore` so generated/runtime artefacts stop appearing in `git status`.

### What's added (new files)

**Source code**
- `backend/app/services/soniox_service.py` — Soniox STT wrapper used by the Michel Thomas importer
- `backend/app/simulation/` — simulation framework already referenced from `CLAUDE.md` (Testing § Simulation Framework)
- `backend/scripts/`: `audit_sentences_claude.py`, `benchmark_verification.py`, `generate_experiment_passages.py`, `import_michel_thomas.py`, `investigate_mapping_flags.py`, `simulate_sessions.py`, `validate_sentence_cli.py`
- `backend/tests/test_n_plus_one.py`, `backend/tests/test_simulation.py`
- `scripts/build_research_hub.py`, `scripts/pre-deploy.sh`

**Docs / memory**
- `CLAUDE.md` — new "Periodic Maintenance Checks" section with the fork check recipe (logged 2026-04-24: 1 fork, 0 ahead)
- `.claude/memory/feedback_gh_sandbox_tls.md`, `feedback_pr_self_review_merge.md` (+ `MEMORY.md` pointer)

**Research artefacts** (matches `research/*.html` convention)
- `history-pkm-people.html`, `petrarca-integration-plan.html`, `quran-function-words.html`, `learning-analysis-2026-04-23.json`

### What's removed
- `backend/hello.txt` — empty stray (`hello world`)
- `data/` (top-level) — duplicate of `backend/data/` paths created by running scripts from the wrong cwd. ScheherazadeNew fonts and 3 textbook-upload dirs all have authoritative copies under `backend/data/`.

### `.gitignore` additions
- `*.db-shm`, `*.db-wal`, `*.db.pre-*` (SQLite WAL/SHM transients + pre-fix backup convention)
- `.review-venv/`, `data-gym-cache/`, `backend/uv.lock` (project doesn't use uv)
- `backend/data/{podcasts,story-gen-tmp,textbook-uploads,corpora}/`
- `backend/data/benchmarks/benchmark_*.json` — TSV ground truths stay tracked
- `backend/experiments/results/*.json` — `results.tsv` stays tracked
- `/data/` (anchored — only the stray top-level dir, not `backend/data/`)

### Intentionally **not** committed
- `mockups/` (10 stale HTML files at repo root, no code references — left untracked pending decision)
- `linear-import.csv` (one-off Linear migration artefact)
- `backend/scripts/_audit_known.py` (`_` prefix, references `data/kalila_dove.json` input that no longer exists — looks like a one-off)
- `backend/data/kalila_dove.{html,bilingual.html,glossary.html,pdf}` — generated outputs; `kalila_dove.*` family has mixed tracked/untracked siblings, so broad gitignore here would be risky
- `.claude/next-session-prompt.md` — session handoff scratch