### PR TITLE
Phase 2 Step 4a-prime: re-gate + delete 22 bogus Step 3 canonicals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,8 @@ backend/data/MSA_freq_lists.tsv
 
 # Resumable-script progress files
 backend/data/decomposition_backfill_progress.json
+backend/data/decomposition_regate_progress.json
+backend/data/decomposition_regate_apply_progress.json
 
 # Test artifacts
 backend/pytest-of-*/

--- a/backend/scripts/apply_step4a_regate_deletions.py
+++ b/backend/scripts/apply_step4a_regate_deletions.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Phase 2 Step 4a, Phase A: delete the 22 bogus canonicals flagged by re-gate.
+
+Reads ``backend/data/decomposition_regate_progress.json``, finds entries with
+outcome ``bogus_mle_error``, re-verifies each target lemma has zero downstream
+references (paranoid double-check — they shouldn't have any, but 5–30 minutes
+may have elapsed since regate ran), then deletes the lemma row. Also deletes
+any Root row that was created solely to hold this lemma (orphan root).
+
+Does NOT modify the orphan compounds themselves — they stay in the DB as
+orphans with ``canonical_lemma_id = NULL``. Tagging them with
+``decomposition_note = {"mle_misanalysis": true, ...}`` is Step 4b's job
+(after the schema migration lands).
+
+Usage
+-----
+    python3 scripts/apply_step4a_regate_deletions.py --dry-run
+    python3 scripts/apply_step4a_regate_deletions.py
+
+Environment
+-----------
+    DATABASE_URL    override DB path (default backend/data/alif.db).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+BACKEND_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(BACKEND_ROOT))
+
+from sqlalchemy import text
+
+from app.database import SessionLocal
+from app.models import Lemma
+
+
+# Read from tracked research/ copy (checked into git) so prod runs use the same
+# frozen regate decisions as local dry-runs. The backend/data/ path is the
+# intermediate in-flight file used while regate was still running.
+REGATE_PROGRESS_TRACKED = BACKEND_ROOT.parent / "research" / "decomposition-regate-2026-04-24.json"
+REGATE_PROGRESS_LOCAL = BACKEND_ROOT / "data" / "decomposition_regate_progress.json"
+APPLY_PROGRESS = BACKEND_ROOT / "data" / "decomposition_regate_apply_progress.json"
+
+
+def load_regate() -> dict[str, Any]:
+    path = REGATE_PROGRESS_TRACKED if REGATE_PROGRESS_TRACKED.exists() else REGATE_PROGRESS_LOCAL
+    print(f"Reading regate verdicts from {path}", flush=True)
+    return json.loads(path.read_text())
+
+
+def verify_no_refs(db, lemma_id: int) -> dict[str, int]:
+    rows = db.execute(text("""
+        SELECT
+          (SELECT COUNT(*) FROM sentence_words WHERE lemma_id = :id)          AS sw,
+          (SELECT COUNT(*) FROM review_log    WHERE lemma_id = :id)           AS rl,
+          (SELECT COUNT(*) FROM sentences     WHERE target_lemma_id = :id)    AS st,
+          (SELECT COUNT(*) FROM user_lemma_knowledge WHERE lemma_id = :id)    AS ulk,
+          (SELECT COUNT(*) FROM lemmas WHERE canonical_lemma_id = :id)        AS vars
+    """), {"id": lemma_id}).fetchone()
+    return {"sentence_words": rows[0], "review_log": rows[1], "sent_targets": rows[2], "ulk": rows[3], "variants": rows[4]}
+
+
+def root_is_orphan_after_delete(db, root_id: int, about_to_delete_lemma_id: int) -> bool:
+    """True iff this root would be referenced by zero OTHER lemmas after deletion."""
+    if root_id is None:
+        return False
+    remaining = db.execute(
+        text("SELECT COUNT(*) FROM lemmas WHERE root_id = :r AND lemma_id != :l"),
+        {"r": root_id, "l": about_to_delete_lemma_id},
+    ).scalar()
+    return remaining == 0
+
+
+def load_apply_progress() -> dict[str, Any]:
+    if not APPLY_PROGRESS.exists():
+        return {"entries": {}, "started_at": None, "completed_at": None}
+    return json.loads(APPLY_PROGRESS.read_text())
+
+
+def save_apply_progress(progress: dict[str, Any]) -> None:
+    tmp = APPLY_PROGRESS.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(progress, indent=2, ensure_ascii=False))
+    tmp.replace(APPLY_PROGRESS)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Report what would be deleted without committing.")
+    args = parser.parse_args()
+
+    regate = load_regate()
+    bogus_entries = [
+        (int(k), v) for k, v in regate["entries"].items()
+        if v["outcome"] == "bogus_mle_error"
+    ]
+    print(f"Loaded {len(bogus_entries)} bogus_mle_error entries from regate", flush=True)
+
+    apply_prog = load_apply_progress()
+    if apply_prog.get("started_at") is None:
+        apply_prog["started_at"] = time.strftime("%Y-%m-%dT%H:%M:%S")
+
+    db = SessionLocal()
+    try:
+        deleted_lemmas: list[int] = []
+        deleted_roots: list[int] = []
+        blocked: list[dict[str, Any]] = []
+
+        for orphan_id, entry in sorted(bogus_entries, key=lambda x: x[1]["new_canonical_id"]):
+            new_id = entry["new_canonical_id"]
+
+            if str(orphan_id) in apply_prog["entries"] and apply_prog["entries"][str(orphan_id)].get("outcome") == "deleted":
+                print(f"  skip #{orphan_id} — already applied (canonical #{new_id})", flush=True)
+                continue
+
+            lemma = db.get(Lemma, new_id)
+            if lemma is None:
+                apply_prog["entries"][str(orphan_id)] = {
+                    "outcome": "missing",
+                    "new_canonical_id": new_id,
+                    "note": "Lemma row not found — possibly already deleted in a prior run.",
+                }
+                print(f"  miss #{new_id} (orphan {orphan_id}) — lemma row gone", flush=True)
+                continue
+
+            refs = verify_no_refs(db, new_id)
+            total_refs = sum(refs.values())
+            if total_refs > 0:
+                blocked.append({
+                    "orphan_id": orphan_id,
+                    "new_canonical_id": new_id,
+                    "canonical_ar": lemma.lemma_ar,
+                    "refs": refs,
+                })
+                apply_prog["entries"][str(orphan_id)] = {
+                    "outcome": "blocked_has_refs",
+                    "new_canonical_id": new_id,
+                    "canonical_ar": lemma.lemma_ar,
+                    "refs": refs,
+                }
+                print(f"  ⚠️ BLOCKED #{new_id} {lemma.lemma_ar} (orphan {orphan_id}) — refs: {refs}", flush=True)
+                continue
+
+            root_id = lemma.root_id
+            will_orphan_root = root_is_orphan_after_delete(db, root_id, new_id) if root_id else False
+
+            if args.dry_run:
+                apply_prog["entries"][str(orphan_id)] = {
+                    "outcome": "dry_run",
+                    "new_canonical_id": new_id,
+                    "canonical_ar": lemma.lemma_ar,
+                    "would_delete_root_id": root_id if will_orphan_root else None,
+                }
+                print(f"  dry-run would delete lemma #{new_id} {lemma.lemma_ar}" + (f" + root #{root_id}" if will_orphan_root else ""), flush=True)
+                continue
+
+            # Real delete.
+            db.delete(lemma)
+            deleted_lemmas.append(new_id)
+            if will_orphan_root:
+                db.execute(text("DELETE FROM roots WHERE root_id = :r"), {"r": root_id})
+                deleted_roots.append(root_id)
+
+            apply_prog["entries"][str(orphan_id)] = {
+                "outcome": "deleted",
+                "new_canonical_id": new_id,
+                "canonical_ar": lemma.lemma_ar,
+                "deleted_root_id": root_id if will_orphan_root else None,
+                "deleted_at": time.strftime("%Y-%m-%dT%H:%M:%S"),
+            }
+            print(f"  deleted #{new_id} {lemma.lemma_ar}" + (f" + root #{root_id}" if will_orphan_root else ""), flush=True)
+
+        if args.dry_run:
+            print("\n[DRY RUN] No commits issued.", flush=True)
+        else:
+            db.commit()
+            print(f"\nCommitted: deleted {len(deleted_lemmas)} lemmas, {len(deleted_roots)} orphan roots", flush=True)
+
+        apply_prog["completed_at"] = time.strftime("%Y-%m-%dT%H:%M:%S")
+        save_apply_progress(apply_prog)
+
+        if blocked:
+            print(f"\n⚠️ {len(blocked)} deletions blocked by downstream refs — inspect progress file.")
+            for b in blocked:
+                print(f"    #{b['new_canonical_id']} {b['canonical_ar']}: {b['refs']}")
+            return 2
+    finally:
+        db.close()
+
+    print(f"\nApply progress: {APPLY_PROGRESS}", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/scripts/regate_step3_created_canonicals.py
+++ b/backend/scripts/regate_step3_created_canonicals.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+"""Phase 2 Step 4a-prime: re-gate Step 3's 33 "created" canonicals.
+
+Step 3 created 33 new canonical lemmas (source='backfill_decomposition_audit',
+ids #3139–#3171) for orphan compounds whose canonical bare forms were not in
+the DB. Post-hoc inspection revealed a systematic CAMeL MLE failure that the
+original LLM verdict gate missed:
+
+  feminine ة (tā marbūṭa) misread as 3ms possessive pronoun ـه
+
+Pattern: a feminine noun ending in ـَة gets decomposed by CAMeL into its
+masculine stem + fake `enc0: 3ms_poss`. The resulting "canonical" is a
+DIFFERENT Arabic lemma — often same root with related meaning — which the
+original LLM gate rationalized as valid by drafting a bridging gloss.
+
+21 of the 33 created entries match this failure pattern exactly
+(lemma_ar_bare ends in ه/ة AND clitic_signals == {"enc0": "3ms_poss"}). Manual
+spot-check of those 21 shows majority are bogus.
+
+This script re-gates all 33 with a STRICTER prompt that:
+1. Explicitly names the ة→3ms_poss failure mode with worked examples.
+2. Shows the original orphan + proposed canonical side-by-side.
+3. Instructs the LLM to lean `bogus_mle_error` when in doubt.
+
+For each Step 3 "created" entry the re-gate writes to
+``backend/data/decomposition_regate_progress.json`` one of:
+- ``confirmed_valid`` — orphan IS a real compound of proposed canonical + clitics
+- ``bogus_mle_error`` — orphan is NOT a compound of proposed canonical
+
+This script does NOT mutate the DB. Apply decisions via
+``apply_regate_decisions.py`` (separate step) which:
+- For ``bogus_mle_error``: DELETE the new canonical lemma row (zero downstream
+  refs verified at time of regate run), tag orphan with decomposition_note
+  mle_misanalysis (see Step 4b schema).
+- For ``confirmed_valid``: leave canonical in place; orphan linking happens
+  in Step 4a-link script.
+
+Usage
+-----
+    python3 scripts/regate_step3_created_canonicals.py --dry-run
+    python3 scripts/regate_step3_created_canonicals.py
+    python3 scripts/regate_step3_created_canonicals.py --resume
+
+Environment
+-----------
+    DATABASE_URL   override the DB path. Default is backend/data/alif.db.
+                   For a local dry-run:
+                   DATABASE_URL=sqlite:///$(pwd)/data/alif.prod.db
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+BACKEND_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(BACKEND_ROOT))
+
+from sqlalchemy import text
+
+from app.database import SessionLocal
+from app.services.llm import LLMError, generate_completion
+
+
+STEP3_PROGRESS = BACKEND_ROOT.parent / "research" / "decomposition-backfill-progress-2026-04-24.json"
+AUDIT_JSON = BACKEND_ROOT.parent / "research" / "decomposition-classification-2026-04-24.json"
+REGATE_PROGRESS = BACKEND_ROOT / "data" / "decomposition_regate_progress.json"
+BATCH_SIZE = 10
+LLM_TIMEOUT_S = 120
+
+
+REGATE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "results": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {"type": "integer"},
+                    "verdict": {
+                        "type": "string",
+                        "enum": ["confirmed_valid", "bogus_mle_error"],
+                    },
+                    "reason": {"type": "string"},
+                },
+                "required": ["id", "verdict", "reason"],
+                "additionalProperties": False,
+            },
+        },
+    },
+    "required": ["results"],
+    "additionalProperties": False,
+}
+
+
+SYSTEM_PROMPT = """You are re-auditing canonical-form assignments for Arabic lemmas.
+
+Each entry contains:
+- `orphan_ar`: Arabic lemma as stored in vocabulary (was thought to be a compound = canonical + stripped clitics)
+- `orphan_gloss`: English gloss stored for the orphan
+- `proposed_canonical_ar`: CAMeL-MLE's proposed canonical form after clitic stripping
+- `proposed_canonical_gloss`: LLM-generated gloss for the proposed canonical (from Step 3's original gate)
+- `clitic_signals`: clitics CAMeL claims were stripped
+
+CRITICAL KNOWN FAILURE MODE you MUST check for:
+
+CAMeL MLE frequently misreads the feminine-noun ending ة (tā marbūṭa, U+0629) as a 3ms possessive pronoun suffix ـه. This produces a false decomposition: a feminine noun X-ة gets split into a masculine stem X + fake `enc0: 3ms_poss`. The resulting "canonical" is then a DIFFERENT Arabic lemma — often same root with a related-but-distinct meaning. The previous verdict gate rationalized these by writing bridging glosses. You must NOT do that.
+
+Concrete examples of this failure (verdict: bogus_mle_error):
+- orphan سِتَارَة (curtain) → proposed سَتّار (one who conceals). WRONG: سِتَارَة is itself a canonical feminine noun; the ة is the feminine ending, not a clitic.
+- orphan سَجَّادَة (carpet) → proposed سَجّاد (prostrator/carpet-seller). WRONG: same failure.
+- orphan نَامُوسِيَّة (mosquito net) → proposed نامُوس (law). WRONG: different lemma, different meaning entirely.
+- orphan شَارِحَة (colon mark ":") → proposed شارِح (explainer). WRONG: different word that happens to share a root.
+- orphan تِينَة (one fig) → proposed تِين (figs, collective). WRONG: singulative/collective are separate dictionary lemmas.
+- orphan حِكَّة (an itch, noun) → proposed حَكّ (itching/scratching, verbal noun). WRONG: different forms.
+
+Legitimate decompositions (verdict: confirmed_valid) look like:
+- orphan بِسُرْعة (quickly, "with speed") → proposed سُرْعَة (speed). Prefix clitic بِ (bi- "with") stripped. Real compound.
+- orphan لِأَحْمَد ((name) for Ahmed) → proposed أَحْمَد (Ahmed). Prefix clitic لِ (li- "for"). Real compound.
+- orphan وَأَذْكَى (and smarter) → proposed أَذْكَى (smarter). Prefix clitic وَ (wa- "and"). Real compound.
+- orphan أَصَبِعَهُم (their fingers) → proposed إِصْبَع (finger). Genuine 3mp possessive suffix هُم.
+- orphan وَتَرَكَهُم (and left them) → proposed تَرَك (left). Prefix وَ + verb object suffix هُم.
+
+Decision rules:
+1. If the orphan ends in ـَة AND the only clitic is `enc0: 3ms_poss`, treat as HIGH SUSPICION for the ة-misread failure. The orphan is almost certainly a feminine noun that is itself the canonical; verdict should default to `bogus_mle_error` unless you are genuinely confident it's a real 3ms possessive form (e.g. something like "ابنه" his son — but even then, the DB would usually store the canonical form ابن, not the inflected one).
+2. If the proposed canonical is a different dictionary lemma from the orphan (different meaning, even if same root), verdict = `bogus_mle_error`. Gender pairs of adjectives (masc/fem nisba like إسبانِيّ / إسبانِيّة) are SEPARATE lemmas in this system — verdict = `bogus_mle_error`.
+3. Singulative/collective pairs (تِين / تِينَة, نَعام / نَعامَة) are separate dictionary lemmas — verdict = `bogus_mle_error`.
+4. Only verdict = `confirmed_valid` when the orphan is unambiguously the canonical with a real inflectional clitic (prefix preposition/conjunction, or real pronoun suffix attached to an already-canonical base form).
+
+Be strict. A false `confirmed_valid` corrupts the canonical-variant graph and silently mangles ULK merges; a false `bogus_mle_error` just means we delete a recently-created unreferenced lemma row and no real data is lost.
+
+For each entry return `verdict` and a short `reason` (1-2 sentences explaining the verdict).
+
+Return JSON matching the provided schema. Every input id must appear in results exactly once."""
+
+
+def load_step3_created() -> list[dict[str, Any]]:
+    """Return the 33 Step 3 'created' entries with orphan + canonical context."""
+    progress = json.loads(STEP3_PROGRESS.read_text())
+    audit = json.loads(AUDIT_JSON.read_text())
+    orphan_by_id = {o["lemma_id"]: o for o in audit["buckets"]["orphan_compound"]}
+
+    out = []
+    for orphan_id_str, entry in progress["entries"].items():
+        if entry["outcome"] != "created":
+            continue
+        orphan_id = int(orphan_id_str)
+        orphan = orphan_by_id.get(orphan_id, {})
+        out.append({
+            "orphan_id": orphan_id,
+            "orphan_ar": orphan.get("lemma_ar", ""),
+            "orphan_gloss": orphan.get("gloss_en", "") or "",
+            "orphan_bare": orphan.get("lemma_ar_bare", ""),
+            "clitic_signals": orphan.get("clitic_signals", {}),
+            "new_canonical_id": entry["new_canonical_id"],
+            "canonical_ar": entry["canonical_ar"],
+            "canonical_gloss": entry["gloss_en"],
+            "canonical_pos": entry["pos"],
+            "canonical_root": entry.get("root_str", ""),
+        })
+    return sorted(out, key=lambda x: x["orphan_id"])
+
+
+def load_progress() -> dict[str, Any]:
+    if not REGATE_PROGRESS.exists():
+        return {"entries": {}, "started_at": None, "completed_at": None}
+    return json.loads(REGATE_PROGRESS.read_text())
+
+
+def save_progress(progress: dict[str, Any]) -> None:
+    REGATE_PROGRESS.parent.mkdir(parents=True, exist_ok=True)
+    tmp = REGATE_PROGRESS.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(progress, indent=2, ensure_ascii=False))
+    tmp.replace(REGATE_PROGRESS)
+
+
+def build_batch_prompt(batch: list[dict[str, Any]]) -> str:
+    payload = []
+    for local_id, entry in enumerate(batch, start=1):
+        payload.append({
+            "id": local_id,
+            "orphan_ar": entry["orphan_ar"],
+            "orphan_gloss": entry["orphan_gloss"],
+            "orphan_bare": entry["orphan_bare"],
+            "proposed_canonical_ar": entry["canonical_ar"],
+            "proposed_canonical_gloss": entry["canonical_gloss"],
+            "proposed_canonical_pos": entry["canonical_pos"],
+            "clitic_signals": entry["clitic_signals"],
+        })
+    return "Re-gate the following entries:\n\n" + json.dumps(payload, ensure_ascii=False, indent=2)
+
+
+def llm_regate_batch(batch: list[dict[str, Any]]) -> dict[int, dict[str, Any]] | None:
+    prompt = build_batch_prompt(batch)
+    try:
+        resp = generate_completion(
+            prompt=prompt,
+            system_prompt=SYSTEM_PROMPT,
+            json_schema=REGATE_SCHEMA,
+            temperature=0.1,
+            timeout=LLM_TIMEOUT_S,
+            model_override="claude_haiku",
+            task_type="decomposition_regate",
+            cli_only=False,
+        )
+    except LLMError as e:
+        print(f"  LLM error: {e}", flush=True)
+        return None
+
+    results = resp.get("results", [])
+    by_id: dict[int, dict[str, Any]] = {}
+    for r in results:
+        lid = r.get("id")
+        if isinstance(lid, int):
+            by_id[lid] = r
+    return by_id
+
+
+def verify_no_refs(db, lemma_id: int) -> dict[str, int]:
+    """Check downstream references for a new canonical. All should be 0."""
+    rows = db.execute(text("""
+        SELECT
+          (SELECT COUNT(*) FROM sentence_words WHERE lemma_id = :id) AS sw,
+          (SELECT COUNT(*) FROM review_log    WHERE lemma_id = :id) AS rl,
+          (SELECT COUNT(*) FROM sentences     WHERE target_lemma_id = :id) AS st,
+          (SELECT COUNT(*) FROM user_lemma_knowledge WHERE lemma_id = :id) AS ulk,
+          (SELECT COUNT(*) FROM lemmas WHERE canonical_lemma_id = :id) AS vars
+    """), {"id": lemma_id}).fetchone()
+    return {"sentence_words": rows[0], "review_log": rows[1], "sent_targets": rows[2], "ulk": rows[3], "variants": rows[4]}
+
+
+def process_batch(db, batch: list[dict[str, Any]], progress: dict[str, Any], *, dry_run: bool) -> None:
+    batch_ids = [e["orphan_id"] for e in batch]
+    print(f"  batch orphans {batch_ids[0]}..{batch_ids[-1]} ({len(batch)})", flush=True)
+    t_start = time.time()
+    results = llm_regate_batch(batch)
+    llm_elapsed = time.time() - t_start
+    print(f"    LLM returned in {llm_elapsed:.1f}s", flush=True)
+
+    if results is None:
+        for entry in batch:
+            progress["entries"][str(entry["orphan_id"])] = {
+                "outcome": "llm_failed",
+                "orphan_ar": entry["orphan_ar"],
+                "new_canonical_id": entry["new_canonical_id"],
+            }
+        save_progress(progress)
+        return
+
+    for local_id, entry in enumerate(batch, start=1):
+        r = results.get(local_id)
+        if r is None:
+            progress["entries"][str(entry["orphan_id"])] = {
+                "outcome": "llm_failed",
+                "reason": "missing from batch response",
+                "orphan_ar": entry["orphan_ar"],
+                "new_canonical_id": entry["new_canonical_id"],
+            }
+            continue
+
+        verdict = r.get("verdict")
+        reason = r.get("reason", "")
+        refs = verify_no_refs(db, entry["new_canonical_id"])
+
+        progress["entries"][str(entry["orphan_id"])] = {
+            "outcome": verdict,
+            "reason": reason,
+            "orphan_ar": entry["orphan_ar"],
+            "orphan_gloss": entry["orphan_gloss"],
+            "proposed_canonical_ar": entry["canonical_ar"],
+            "proposed_canonical_gloss": entry["canonical_gloss"],
+            "new_canonical_id": entry["new_canonical_id"],
+            "clitic_signals": entry["clitic_signals"],
+            "canonical_refs": refs,
+        }
+        mark = "⚠️ BOGUS" if verdict == "bogus_mle_error" else "✓ valid"
+        print(f"    {mark} orphan #{entry['orphan_id']} {entry['orphan_ar']} → canonical #{entry['new_canonical_id']} {entry['canonical_ar']} — {reason[:100]}", flush=True)
+
+    save_progress(progress)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--batch-size", type=int, default=BATCH_SIZE)
+    parser.add_argument("--resume", action="store_true",
+                        help="Skip entries already re-gated. Retry llm_failed.")
+    args = parser.parse_args()
+
+    created = load_step3_created()
+    print(f"Loaded {len(created)} Step 3 created entries", flush=True)
+
+    progress = load_progress()
+    if progress.get("started_at") is None:
+        progress["started_at"] = time.strftime("%Y-%m-%dT%H:%M:%S")
+
+    done_outcomes = {"confirmed_valid", "bogus_mle_error"}
+    to_process = []
+    for e in created:
+        existing = progress["entries"].get(str(e["orphan_id"]))
+        if args.resume and existing and existing["outcome"] in done_outcomes:
+            continue
+        to_process.append(e)
+    print(f"Will re-gate {len(to_process)} (already done: {len(created) - len(to_process)})", flush=True)
+    if not to_process:
+        return 0
+
+    db = SessionLocal()
+    try:
+        for i in range(0, len(to_process), args.batch_size):
+            batch = to_process[i:i + args.batch_size]
+            print(f"\n[{i + 1}..{i + len(batch)} of {len(to_process)}]", flush=True)
+            process_batch(db, batch, progress, dry_run=args.dry_run)
+
+        progress["completed_at"] = time.strftime("%Y-%m-%dT%H:%M:%S")
+        save_progress(progress)
+    finally:
+        db.close()
+
+    counts: dict[str, int] = {}
+    for entry in progress["entries"].values():
+        counts[entry["outcome"]] = counts.get(entry["outcome"], 0) + 1
+    print("\n=== Summary ===", flush=True)
+    for k, v in sorted(counts.items()):
+        print(f"  {k}: {v}", flush=True)
+    print(f"Progress file: {REGATE_PROGRESS}", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/research/decomposition-regate-2026-04-24.json
+++ b/research/decomposition-regate-2026-04-24.json
@@ -1,0 +1,636 @@
+{
+  "entries": {
+    "437": {
+      "outcome": "confirmed_valid",
+      "reason": "Real compound with prefix preposition clitic بِ (bi- 'with') legitimately stripped. The feminine ة is the noun ending, not a clitic. Orphan 'with speed' correctly decomposes to canonical 'speed' + prefix.",
+      "orphan_ar": "بِسُرْعة",
+      "orphan_gloss": "quickly",
+      "proposed_canonical_ar": "سُرْعَة",
+      "proposed_canonical_gloss": "speed; haste",
+      "new_canonical_id": 3139,
+      "clitic_signals": {
+        "prc1": "bi_prep"
+      },
+      "canonical_refs": {
+        "sentence_words": 0,
+        "review_log": 0,
+        "sent_targets": 0,
+        "ulk": 0,
+        "variants": 0
+      }
+    },
+    "546": {
+      "outcome": "bogus_mle_error",
+      "reason": "Feminine nisba adjective misread: نَرْجِسِيَّة ends in -يَّة (feminine nisba marker), not a possessive clitic. Masculine/feminine nisba pairs are separate lemmas in this system.",
+      "orphan_ar": "نَرْجِسِيَّةٌ",
+      "orphan_gloss": "narcissism",
+      "proposed_canonical_ar": "نَرْجِسِيّ",
+      "proposed_canonical_gloss": "narcissistic; narcissism",
+      "new_canonical_id": 3153,
+      "clitic_signals": {
+        "enc0": "3ms_poss"
+      },
+      "canonical_refs": {
+        "sentence_words": 0,
+        "review_log": 0,
+        "sent_targets": 0,
+        "ulk": 0,
+        "variants": 0
+      }
+    },
+    "576": {
+      "outcome": "bogus_mle_error",
+      "reason": "Feminine nisba misread: قَبَائِلِيَّة (-يَّة feminine marker) falsely parsed as possessing the masculine form. Gender pairs (masc/fem nisba) are separate dictionary lemmas.",
+      "orphan_ar": "قَبَائِلِيَّةٌ",
+      "orphan_gloss": "Kabyle language",
+      "proposed_canonical_ar": "قَبائِلِيّ",
+      "proposed_canonical_gloss": "relating to Kabyle; Kabyle",
+      "new_canonical_id": 3154,
+      "clitic_signals": {
+        "enc0": "3ms_poss"
+      },
+      "canonical_refs": {
+        "sentence_words": 0,
+        "review_log": 0,
+        "sent_targets": 0,
+        "ulk": 0,
+        "variants": 0
+      }
+    },
+    "704": {
+      "outcome": "bogus_mle_error",
+      "reason": "Feminine noun form misread: كَعْبَة ends in ـَة (feminine marker), not 3ms possessive clitic. The orphan is the canonical feminine noun; the ة is an inflectional ending, not a stripped clitic.",
+      "orphan_ar": "كَعْبَةٌ",
+      "orphan_gloss": "cube, a cubic structure",
+      "proposed_canonical_ar": "كَعْب",
+      "proposed_canonical_gloss": "cube; ankle bone",
+      "new_canonical_id": 3155,
+      "clitic_signals": {
+        "enc0": "3ms_poss"
+      },
+      "canonical_refs": {
+        "sentence_words": 0,
+        "review_log": 0,
+        "sent_targets": 0,
+        "ulk": 0,
+        "variants": 0
+      }
+    },
+    "753": {
+      "outcome": "bogus_mle_error",
+      "reason": "Feminine/singulative noun form misread: قِسْمَة ends in ـَة (feminine or singulative marker), not a possessive clitic. These are separate dictionary lemmas in gender/number pairs.",
+      "orphan_ar": "قِسْمَةٌ",
+      "orphan_gloss": "division, fate",
+      "proposed_canonical_ar": "قِسْم",
+      "proposed_canonical_gloss": "division; allocation; fate; portion",
+      "new_canonical_id": 3156,
+      "clitic_signals": {
+        "enc0": "3ms_poss"
+      },
+      "canonical_refs": {
+        "sentence_words": 0,
+        "review_log": 0,
+        "sent_targets": 0,
+        "ulk": 0,
+        "variants": 0
+      }
+    },
+    "802": {
+      "outcome": "bogus_mle_error",
+      "reason": "Singulative/collective pair explicitly cited as a known failure in the audit instructions: نَعام (collective) and نَعَامَة (singulative) are separate dictionary lemmas. The ة is the singulative marker, not a clitic.",
+      "orphan_ar": "نَعَامَةٌ",
+      "orphan_gloss": "ostrich",
+      "proposed_canonical_ar": "نَعام",
+      "proposed_canonical_gloss": "ostrich",
+      "new_canonical_id": 3157,
+      "clitic_signals": {
+        "enc0": "3ms_poss"
+      },
+      "canonical_refs": {
+        "sentence_words": 0,
+        "review_log": 0,
+        "sent_targets": 0,
+        "ulk": 0,
+        "variants": 0
+      }
+    },
+    "1055": {
+      "outcome": "bogus_mle_error",
+      "reason": "Feminine noun misread: شَفْرَة ends in ـَة (feminine ending), not 3ms possessive clitic. Gender-paired or feminine-derivative noun forms are separate lemmas; the orphan is canonical.",
+      "orphan_ar": "شَفْرَةٌ",
+      "orphan_gloss": "large knife",
+      "proposed_canonical_ar": "شَفْر",
+      "proposed_canonical_gloss": "knife blade; sharp instrument",
+      "new_canonical_id": 3158,
+      "clitic_signals": {
+        "enc0": "3ms_poss"
+      },
+      "canonical_refs": {
+        "sentence_words": 0,
+        "review_log": 0,
+        "sent_targets": 0,
+        "ulk": 0,
+        "variants": 0
+      }
+    },
+    "1060": {
+      "outcome": "bogus_mle_error",
+      "reason": "Feminine nisba misread: نَامُوسِيَّة (-يَّة feminine nisba suffix) falsely parsed as possessive. The feminine and masculine nisba forms are separate lemmas; the orphan is the canonical feminine form.",
+      "orphan_ar": "نَامُوسِيَّةٌ",
+      "orphan_gloss": "mosquito net",
+      "proposed_canonical_ar": "نامُوس",
+      "proposed_canonical_gloss": "mosquito net; screen",
+      "new_canonical_id": 3159,
+      "clitic_signals": {
+        "enc0": "3ms_poss"
+      },
+      "canonical_refs": {
+        "sentence_words": 0,
+        "review_log": 0,
+        "sent_targets": 0,
+        "ulk": 0,
+        "variants": 0
+      }
+    },
+    "1134": {
+      "outcome": "bogus_mle_error",
+      "reason": "Feminine nisba gender pair misread: شُكْرِيَّة (fem) cannot be decomposed into شُكْرِيّ (masc) + possessive. Masculine/feminine nisba pairs are separate dictionary lemmas in this system.",
+      "orphan_ar": "شُكْرِيَّةٌ",
+      "orphan_gloss": "of thanks",
+      "proposed_canonical_ar": "شُكْرِيّ",
+      "proposed_canonical_gloss": "of thanks; thanksgiving; related to gratitude",
+      "new_canonical_id": 3143,
+      "clitic_signals": {
+        "enc0": "3ms_poss"
+      },
+      "canonical_refs": {
+        "sentence_words": 0,
+        "review_log": 0,
+        "sent_targets": 0,
+        "ulk": 0,
+        "variants": 0
+      }
+    },
+    "1168": {
+      "outcome": "bogus_mle_error",
+      "reason": "Different lemma (noun vs verb): تَقِيَّة (noun: 'fear, caution') proposed as possessive of وَقَى (verb: 'protected'). These are separate lexical entries with different parts of speech and meanings.",
+      "orphan_ar": "تَقِيَّةٌ",
+      "orphan_gloss": "fear, caution, prudence",
+      "proposed_canonical_ar": "وَقَى",
+      "proposed_canonical_gloss": "fearfulness; piety; caution",
+      "new_canonical_id": 3160,
+      "clitic_signals": {
+        "enc0": "3ms_dobj"
+      },
+      "canonical_refs": {
+        "sentence_words": 0,
+        "review_log": 0,
+        "sent_targets": 0,
+        "ulk": 0,
+        "variants": 0
+      }
+    },
+    "1259": {
+      "outcome": "bogus_mle_error",
+      "reason": "Gender pairs of nisba adjectives (إسبانِيّ / إسبانِيّة) are separate dictionary lemmas. The orphan is the feminine form, and the ـة is a gender marker, not a clitic.",
+      "orphan_ar": "إِسْبَانِيَّةٌ",
+      "orphan_gloss": "Spanish",
+      "proposed_canonical_ar": "إِسْبانِيّ",
+      "proposed_canonical_gloss": "Spanish (adj./noun, masc. form)",
+      "new_canonical_id": 3147,
+      "clitic_signals": {
+        "enc0": "3ms_poss"
+      },
+      "canonical_refs": {
+        "sentence_words": 0,
+        "review_log": 0,
+        "sent_targets": 0,
+        "ulk": 0,
+        "variants": 0
+      }
+    },
+    "1391": {
+      "outcome": "bogus_mle_error",
+      "reason": "Singulative and collective forms are separate dictionary lemmas. تِينَة (one fig) and تِين (figs) are distinct entries. The ـة is a singulative marker, not 3ms_poss.",
+      "orphan_ar": "تِينَةٌ",
+      "orphan_gloss": "fig (fruit)",
+      "proposed_canonical_ar": "تِين",
+      "proposed_canonical_gloss": "fig (fruit)",
+      "new_canonical_id": 3161,
+      "clitic_signals": {
+        "enc0": "3ms_poss"
+      },
+      "canonical_refs": {
+        "sentence_words": 0,
+        "review_log": 0,
+        "sent_targets": 0,
+        "ulk": 0,
+        "variants": 0
+      }
+    },
+    "1394": {
+      "outcome": "bogus_mle_error",
+      "reason": "Gender pairs of adjectives are separate lemmas. جَبَّارَة (feminine) and جَبّار (masculine) are distinct dictionary entries. The ـة is a gender marker.",
+      "orphan_ar": "جَبَّارَةٌ",
+      "orphan_gloss": "mighty; giant",
+      "proposed_canonical_ar": "جَبّار",
+      "proposed_canonical_gloss": "mighty; giant; powerful one",
+      "new_canonical_id": 3162,
+      "clitic_signals": {
+        "enc0": "3ms_poss"
+      },
+      "canonical_refs": {
+        "sentence_words": 0,
+        "review_log": 0,
+        "sent_targets": 0,
+        "ulk": 0,
+        "variants": 0
+      }
+    },
+    "1409": {
+      "outcome": "bogus_mle_error",
+      "reason": "The orphan and proposed canonical are different dictionary lemmas with distinct meanings (feminine noun vs. verbal noun form). The ـة is not a clitic.",
+      "orphan_ar": "حِكَّةٌ",
+      "orphan_gloss": "an itch",
+      "proposed_canonical_ar": "حَكّ",
+      "proposed_canonical_gloss": "itch; itching",
+      "new_canonical_id": 3163,
+      "clitic_signals": {
+        "enc0": "3ms_poss"
+      },
+      "canonical_refs": {
+        "sentence_words": 0,
+        "review_log": 0,
+        "sent_targets": 0,
+        "ulk": 0,
+        "variants": 0
+      }
+    },
+    "1410": {
+      "outcome": "bogus_mle_error",
+      "reason": "Orphan ends in ـة with only 3ms_poss signal—the hallmark false-positive. The ـة is a feminine marker, not a clitic suffix.",
+      "orphan_ar": "دَلَّاعَةٌ",
+      "orphan_gloss": "watermelon",
+      "proposed_canonical_ar": "دَلّاع",
+      "proposed_canonical_gloss": "watermelon",
+      "new_canonical_id": 3164,
+      "clitic_signals": {
+        "enc0": "3ms_poss"
+      },
+      "canonical_refs": {
+        "sentence_words": 0,
+        "review_log": 0,
+        "sent_targets": 0,
+        "ulk": 0,
+        "variants": 0
+      }
+    },
+    "1453": {
+      "outcome": "bogus_mle_error",
+      "reason": "Distinct dictionary lemmas: شَارِحَة (punctuation mark: colon) vs. شارِح (explainer). Same root, different lemmas. The ـة is not a clitic.",
+      "orphan_ar": "شَارِحَةٌ",
+      "orphan_gloss": "colon, \" : \"",
+      "proposed_canonical_ar": "شارِح",
+      "proposed_canonical_gloss": "expounding, explaining; expounder",
+      "new_canonical_id": 3165,
+      "clitic_signals": {
+        "enc0": "3ms_poss"
+      },
+      "canonical_refs": {
+        "sentence_words": 0,
+        "review_log": 0,
+        "sent_targets": 0,
+        "ulk": 0,
+        "variants": 0
+      }
+    },
+    "1538": {
+      "outcome": "bogus_mle_error",
+      "reason": "Although prefix clitics (وَ, الـ) are correctly stripped, the resulting feminine nisba (إِعْدَادِيَّة) is a separate lemma from the masculine canonical (إِعْدادِيّ). Gender pairs are separate lemmas in this system.",
+      "orphan_ar": "وَالإِعْدَادِيَّةِ",
+      "orphan_gloss": "and preparatory",
+      "proposed_canonical_ar": "إِعْدادِيّ",
+      "proposed_canonical_gloss": "preparatory; pertaining to preparation",
+      "new_canonical_id": 3166,
+      "clitic_signals": {
+        "prc0": "Al_det",
+        "prc2": "wa_part"
+      },
+      "canonical_refs": {
+        "sentence_words": 0,
+        "review_log": 0,
+        "sent_targets": 0,
+        "ulk": 0,
+        "variants": 0
+      }
+    },
+    "1640": {
+      "outcome": "bogus_mle_error",
+      "reason": "Gender pairs of adjectives are separate lemmas. صَاخِبَة (feminine) and صاخِب (masculine) are distinct dictionary entries. The ـة is a gender marker.",
+      "orphan_ar": "صَاخِبَةٌ",
+      "orphan_gloss": "noisy",
+      "proposed_canonical_ar": "صاخِب",
+      "proposed_canonical_gloss": "loud; noisy",
+      "new_canonical_id": 3140,
+      "clitic_signals": {
+        "enc0": "3ms_poss"
+      },
+      "canonical_refs": {
+        "sentence_words": 0,
+        "review_log": 0,
+        "sent_targets": 0,
+        "ulk": 0,
+        "variants": 0
+      }
+    },
+    "1644": {
+      "outcome": "bogus_mle_error",
+      "reason": "Gender pairs of adjectives are separate lemmas. مَبْسُوطَة (feminine) and مَبْسُوط (masculine) are distinct dictionary entries. The ـة is a gender marker.",
+      "orphan_ar": "مَبْسُوطَةٌ",
+      "orphan_gloss": "happy",
+      "proposed_canonical_ar": "مَبْسُوط",
+      "proposed_canonical_gloss": "spread out; extended; happy; pleased",
+      "new_canonical_id": 3142,
+      "clitic_signals": {
+        "enc0": "3ms_poss"
+      },
+      "canonical_refs": {
+        "sentence_words": 0,
+        "review_log": 0,
+        "sent_targets": 0,
+        "ulk": 0,
+        "variants": 0
+      }
+    },
+    "1739": {
+      "outcome": "bogus_mle_error",
+      "reason": "Canonical feminine noun whose ـة is the feminine ending, not a clitic. The orphan is itself the legitimate canonical form, not a compound of سَتّار.",
+      "orphan_ar": "سِتَارَة",
+      "orphan_gloss": "curtain",
+      "proposed_canonical_ar": "سَتّار",
+      "proposed_canonical_gloss": "curtain; veil; one who hides/conceals",
+      "new_canonical_id": 3144,
+      "clitic_signals": {
+        "enc0": "3ms_poss"
+      },
+      "canonical_refs": {
+        "sentence_words": 0,
+        "review_log": 0,
+        "sent_targets": 0,
+        "ulk": 0,
+        "variants": 0
+      }
+    },
+    "1740": {
+      "outcome": "bogus_mle_error",
+      "reason": "سَجَّادَة is itself a canonical feminine noun (carpet). The ة ending was misread as 3ms_poss suffix; سَجّاد is a different lemma (agent noun: one who prostrates).",
+      "orphan_ar": "سَجَّادَة",
+      "orphan_gloss": "carpet",
+      "proposed_canonical_ar": "سَجّاد",
+      "proposed_canonical_gloss": "carpet; one who prostrates",
+      "new_canonical_id": 3145,
+      "clitic_signals": {
+        "enc0": "3ms_poss"
+      },
+      "canonical_refs": {
+        "sentence_words": 0,
+        "review_log": 0,
+        "sent_targets": 0,
+        "ulk": 0,
+        "variants": 0
+      }
+    },
+    "1792": {
+      "outcome": "confirmed_valid",
+      "reason": "Real prefix conjunction وَ (wa- and) stripped from comparative adjective. Legitimate compound decomposition.",
+      "orphan_ar": "وَأَذْكَى",
+      "orphan_gloss": "and smarter",
+      "proposed_canonical_ar": "أَذْكَى",
+      "proposed_canonical_gloss": "smarter; more intelligent (comparative adj.)",
+      "new_canonical_id": 3150,
+      "clitic_signals": {
+        "prc2": "wa_sub"
+      },
+      "canonical_refs": {
+        "sentence_words": 0,
+        "review_log": 0,
+        "sent_targets": 0,
+        "ulk": 0,
+        "variants": 0
+      }
+    },
+    "1829": {
+      "outcome": "confirmed_valid",
+      "reason": "Real prefix preposition لِ (li- for) stripped from proper name Ahmed. Legitimate compound.",
+      "orphan_ar": "لِأَحْمَد",
+      "orphan_gloss": "(name) for Ahmed",
+      "proposed_canonical_ar": "أَحْمَد",
+      "proposed_canonical_gloss": "Ahmed (proper name)",
+      "new_canonical_id": 3151,
+      "clitic_signals": {
+        "prc1": "la_emph"
+      },
+      "canonical_refs": {
+        "sentence_words": 0,
+        "review_log": 0,
+        "sent_targets": 0,
+        "ulk": 0,
+        "variants": 0
+      }
+    },
+    "1839": {
+      "outcome": "bogus_mle_error",
+      "reason": "بَقَّالَة is itself a canonical feminine noun (grocery store). The ة was misread as 3ms_poss; بَقّال is a different lemma (grocer, agent noun).",
+      "orphan_ar": "بَقَّالَة",
+      "orphan_gloss": "grocery store",
+      "proposed_canonical_ar": "بَقّال",
+      "proposed_canonical_gloss": "grocer; grocery merchant",
+      "new_canonical_id": 3141,
+      "clitic_signals": {
+        "enc0": "3ms_poss"
+      },
+      "canonical_refs": {
+        "sentence_words": 0,
+        "review_log": 0,
+        "sent_targets": 0,
+        "ulk": 0,
+        "variants": 0
+      }
+    },
+    "2612": {
+      "outcome": "bogus_mle_error",
+      "reason": "حصبة (measles, feminine noun) has its ة feminine ending misread as 3ms_poss, creating false decomposition to حصب (a different lemma: gravel/disease).",
+      "orphan_ar": "حصبه",
+      "orphan_gloss": "measles",
+      "proposed_canonical_ar": "حَصَب",
+      "proposed_canonical_gloss": "measles; gravel",
+      "new_canonical_id": 3146,
+      "clitic_signals": {
+        "enc0": "3ms_poss"
+      },
+      "canonical_refs": {
+        "sentence_words": 0,
+        "review_log": 0,
+        "sent_targets": 0,
+        "ulk": 0,
+        "variants": 0
+      }
+    },
+    "2662": {
+      "outcome": "confirmed_valid",
+      "reason": "Plural + real 3ms_poss possessive suffix on canonical feminine noun فَضْلَة (dropping). The ه is genuine possessive, not a misread feminine ending.",
+      "orphan_ar": "فضلاته",
+      "orphan_gloss": "his droppings",
+      "proposed_canonical_ar": "فَضْلَة",
+      "proposed_canonical_gloss": "dropping; droppings",
+      "new_canonical_id": 3152,
+      "clitic_signals": {
+        "enc0": "3ms_poss"
+      },
+      "canonical_refs": {
+        "sentence_words": 0,
+        "review_log": 0,
+        "sent_targets": 0,
+        "ulk": 0,
+        "variants": 0
+      }
+    },
+    "2862": {
+      "outcome": "confirmed_valid",
+      "reason": "Real prefix conjunction وَ (and) + real 3mp direct object pronoun on verb تَرَك (left). Both are genuine clitics.",
+      "orphan_ar": "وَتَرَكَهُم",
+      "orphan_gloss": "and left them",
+      "proposed_canonical_ar": "تَرَك",
+      "proposed_canonical_gloss": "left; abandoned",
+      "new_canonical_id": 3148,
+      "clitic_signals": {
+        "prc2": "wa_sub",
+        "enc0": "3mp_dobj"
+      },
+      "canonical_refs": {
+        "sentence_words": 0,
+        "review_log": 0,
+        "sent_targets": 0,
+        "ulk": 0,
+        "variants": 0
+      }
+    },
+    "2864": {
+      "outcome": "confirmed_valid",
+      "reason": "Real prefix conjunction وَ (wa- and) stripped from noun رَعْد (thunder). Simple legitimate compound.",
+      "orphan_ar": "وَرَعد",
+      "orphan_gloss": "and thunder",
+      "proposed_canonical_ar": "رَعْد",
+      "proposed_canonical_gloss": "thunder",
+      "new_canonical_id": 3167,
+      "clitic_signals": {
+        "prc2": "wa_conj"
+      },
+      "canonical_refs": {
+        "sentence_words": 0,
+        "review_log": 0,
+        "sent_targets": 0,
+        "ulk": 0,
+        "variants": 0
+      }
+    },
+    "2865": {
+      "outcome": "confirmed_valid",
+      "reason": "Plural + real 3mp_poss possessive suffix on canonical noun إِصْبَع (finger). Genuine inflected form of canonical lemma.",
+      "orphan_ar": "أَصَبِعَهُم",
+      "orphan_gloss": "their fingers",
+      "proposed_canonical_ar": "إِصْبَع",
+      "proposed_canonical_gloss": "finger",
+      "new_canonical_id": 3168,
+      "clitic_signals": {
+        "enc0": "3mp_poss"
+      },
+      "canonical_refs": {
+        "sentence_words": 0,
+        "review_log": 0,
+        "sent_targets": 0,
+        "ulk": 0,
+        "variants": 0
+      }
+    },
+    "2875": {
+      "outcome": "confirmed_valid",
+      "reason": "Particle لَعَلَّ (perhaps) with real 2mp pronoun attachment. Both clitics (emphatic prefix + pronoun suffix) are genuine.",
+      "orphan_ar": "لَعَلَّكُم",
+      "orphan_gloss": "perhaps you",
+      "proposed_canonical_ar": "لَعَلَّ",
+      "proposed_canonical_gloss": "perhaps; perchance",
+      "new_canonical_id": 3169,
+      "clitic_signals": {
+        "prc1": "la_emph",
+        "enc0": "2mp_pron"
+      },
+      "canonical_refs": {
+        "sentence_words": 0,
+        "review_log": 0,
+        "sent_targets": 0,
+        "ulk": 0,
+        "variants": 0
+      }
+    },
+    "2901": {
+      "outcome": "confirmed_valid",
+      "reason": "Conjunction prefix وَ (and) is correctly stripped from the particle إِذ. Real clitic, correct canonical form.",
+      "orphan_ar": "وَإِذ",
+      "orphan_gloss": "and when",
+      "proposed_canonical_ar": "إِذ",
+      "proposed_canonical_gloss": "when; at the time when",
+      "new_canonical_id": 3170,
+      "clitic_signals": {
+        "prc2": "wa_conj"
+      },
+      "canonical_refs": {
+        "sentence_words": 0,
+        "review_log": 0,
+        "sent_targets": 0,
+        "ulk": 0,
+        "variants": 0
+      }
+    },
+    "2905": {
+      "outcome": "confirmed_valid",
+      "reason": "Conjunction prefix وَ (and) is correctly stripped from the present-tense verb conjugation. Canonical قَدَّس is the correct dictionary headword form for the verb 'to sanctify'.",
+      "orphan_ar": "وَنُقَدِّسُ",
+      "orphan_gloss": "and we sanctify",
+      "proposed_canonical_ar": "قَدَّس",
+      "proposed_canonical_gloss": "sanctified; hallowed; honored",
+      "new_canonical_id": 3149,
+      "clitic_signals": {
+        "prc2": "wa_sub"
+      },
+      "canonical_refs": {
+        "sentence_words": 0,
+        "review_log": 0,
+        "sent_targets": 0,
+        "ulk": 0,
+        "variants": 0
+      }
+    },
+    "2911": {
+      "outcome": "confirmed_valid",
+      "reason": "Direct object suffix هُم (them, 3mp) is correctly stripped from the verb form. Canonical نَبَّأ is the correct dictionary headword for the verb 'to inform/report'.",
+      "orphan_ar": "أَنبِئهُم",
+      "orphan_gloss": "inform them",
+      "proposed_canonical_ar": "نَبَّأ",
+      "proposed_canonical_gloss": "to inform; to tell; to report",
+      "new_canonical_id": 3171,
+      "clitic_signals": {
+        "enc0": "3mp_dobj"
+      },
+      "canonical_refs": {
+        "sentence_words": 0,
+        "review_log": 0,
+        "sent_targets": 0,
+        "ulk": 0,
+        "variants": 0
+      }
+    }
+  },
+  "started_at": "2026-04-24T13:59:09",
+  "completed_at": "2026-04-24T14:03:32"
+}


### PR DESCRIPTION
## Summary

Step 3 (PR #47) created 33 new canonical lemmas via LLM verdict gate, but post-hoc inspection found a systematic CAMeL MLE failure the gate missed: **feminine ة misread as 3ms possessive pronoun ـه**. 21/33 orphans matched the exact failure pattern; manual spot-check confirmed the majority are bogus.

Stricter re-gate with explicit failure-mode warning + worked examples: **22 bogus, 11 confirmed_valid**. Frozen verdict snapshot at `research/decomposition-regate-2026-04-24.json`.

This PR ships two scripts and deletes the 22 bogus new canonicals. Zero downstream refs on each (verified at regate time, re-verified at apply time). No linking yet — that's Step 4a-link after Step 4b's `decomposition_note` schema lands.

## The failure pattern

CAMeL's MLE decomposes a feminine noun X-ة as masculine stem X + `enc0: 3ms_poss`. The "canonical" it produces is a DIFFERENT dictionary lemma (same root, related meaning). The original LLM gate rationalized these by writing bridging glosses.

Worked examples caught by re-gate:
- orphan سِتَارَة (curtain) → proposed سَتّار (one who conceals). Different lemma.
- orphan نَامُوسِيَّة (mosquito net) → proposed نامُوس (law). Different lemma.
- orphan شَارِحَة (colon ":") → proposed شارِح (explainer). Different word, shared root.
- orphan تِينَة (one fig) → proposed تِين (figs, collective). Singulative/collective are separate dictionary lemmas.

## Survivors

The 11 confirmed_valid are all clean prefix clitics (بِ/لِ/وَ + base) or legitimate verb pronoun-attachment cases. No feminine-ة decompositions in the survivor set.