### PR TITLE
Session quality fixes from 7-day learner data audit

### DIFF
--- a/IDEAS.md
+++ b/IDEAS.md
@@ -4,6 +4,18 @@
 
 ---
 
+## 🟢 [DONE 2026-04-27] Learner-data-driven session quality fixes (PR sh/learning-data-fixes)
+
+Four issues surfaced from production data audit:
+1. **Tier-0 working-memory false positives** — fast-grad fired within 30 seconds of intro card 4/6 times. Fixed with `FAST_GRAD_INTRO_GAP = 10 min` gate.
+2. **Near-duplicate sentences in same session** — 8 high-Jaccard pairs in 7d (worst was 1.0 on lemma sets). Fixed with `JACCARD_VETO_THRESHOLD = 0.7` hard veto in greedy + acquisition-repeat loops.
+3. **Intro card overload** — sessions had up to 10 intros (40% density). Lowered `INTRO_CARDS_MAX` 10→6, ramp slowed to `+1/15`.
+4. **End-of-session intro flood** — 9/17 sessions placed intros in final 25%. Frontend now reorders sentences (intro-bearing front-middle, no-intro wind-down) and excludes intros from final 20%.
+
+Future: re-evaluate `FAST_GRAD_INTRO_GAP` and `JACCARD_VETO_THRESHOLD` after 1-2 weeks of data.
+
+---
+
 ## 🟡 Lemma Decomposition Pipeline — Phase 1 + Phase 2 Steps 1-4b done 2026-04-24, Steps 4c + 5-8 OPEN
 
 User-found bug: a reading card showed **#2862 وَتَرَكَهُم "and left them"** (root 305, source=`quran`) as a single atomic verb lemma. Correct decomposition is و (proclitic "and") + تَرَكَ (verb "he left") + هُمْ (enclitic "-them"). The compound form was stored in `lemmas` instead of the canonical تَرَكَ. User flagged: *"this whole pipeline needs investigation."*

--- a/backend/app/services/acquisition_service.py
+++ b/backend/app/services/acquisition_service.py
@@ -40,6 +40,10 @@ GRADUATION_MIN_REVIEWS = 5
 GRADUATION_MIN_ACCURACY = 0.60
 GRADUATION_MIN_CALENDAR_DAYS = 2
 ROOT_SIBLING_THRESHOLD = 2  # known root siblings needed for Easy graduation boost
+# Tier-0 (first-correct) instant graduation must NOT fire when the intro card
+# was shown moments ago — that's working memory, not learning. Require this
+# much elapsed time since the intro card before allowing fast-grad.
+FAST_GRAD_INTRO_GAP = timedelta(minutes=10)
 
 
 def _reviews_span_calendar_days(db: Session, lemma_id: int, min_days: int) -> bool:
@@ -213,13 +217,22 @@ def submit_acquisition_review(
             acq_due = acq_due.replace(tzinfo=timezone.utc)
         is_due = acq_due <= now
 
-    # Fast-track: first correct review → graduate immediately to FSRS
-    # Production data shows 0% lapse rate for fast grads (≤6 reviews).
-    # FSRS safety net catches any false positives.
+    # Fast-track: first correct review → graduate immediately to FSRS.
+    # Skip when the intro card was shown within FAST_GRAD_INTRO_GAP — a
+    # correct rating seconds after seeing the card is working memory, not
+    # learning, and bypassing acquisition robs the encoding phase.
     graduated = False
     if old_times_seen == 0 and rating_int >= 3:
-        _graduate(ulk, now, db=db)
-        graduated = True
+        intro_shown = ulk.experiment_intro_shown_at
+        if intro_shown is not None:
+            if intro_shown.tzinfo is None:
+                intro_shown = intro_shown.replace(tzinfo=timezone.utc)
+            recent_intro = (now - intro_shown) < FAST_GRAD_INTRO_GAP
+        else:
+            recent_intro = False
+        if not recent_intro:
+            _graduate(ulk, now, db=db)
+            graduated = True
 
     # Box advancement logic
     # Box 1→2: always allowed (encoding phase, within-session repetition)

--- a/backend/app/services/sentence_selector.py
+++ b/backend/app/services/sentence_selector.py
@@ -52,6 +52,7 @@ PIPELINE_BACKLOG_THRESHOLD = 40  # suppress reserved intros when acquiring pipel
 LOW_TIER_INTRO_SOURCES = {"wiktionary", "story_import", "manual", "flag_autocreate", "other"}
 LOW_TIER_BLOCK_BACKLOG = 60  # block low-tier auto-intros once box-1 acquiring exceeds this
 SESSION_SCAFFOLD_DECAY = 0.5  # per-appearance decay for scaffold words already in session
+JACCARD_VETO_THRESHOLD = 0.7  # max lemma-set Jaccard between two sentences in same session
 NEVER_REVIEWED_BOOST = 5.0  # score multiplier for sentences targeting acquiring words with 0 reviews
 LAPSED_BOOST = 3.0  # score multiplier for sentences targeting lapsed words (re-expose soon)
 OVERDUE_ESCALATION_DAYS = 0.5  # start escalating as soon as a card is past due
@@ -301,6 +302,23 @@ def compute_sentence_diversity_score(
         "scaffold_freshness": round(freshness, 3),
         "unique_scaffold_count": unique_scaffold_count,
     }
+
+
+def _is_near_duplicate_of_selected(candidate, selected_lemma_sets: list[set[int]]) -> bool:
+    """True if candidate's lemma set has Jaccard >= JACCARD_VETO_THRESHOLD with any prior."""
+    cand_lemmas = {w.lemma_id for w in candidate.words_meta if w.lemma_id}
+    if not cand_lemmas:
+        return False
+    for prior in selected_lemma_sets:
+        if not prior:
+            continue
+        union = cand_lemmas | prior
+        if not union:
+            continue
+        jacc = len(cand_lemmas & prior) / len(union)
+        if jacc >= JACCARD_VETO_THRESHOLD:
+            return True
+    return False
 
 
 def _auto_introduce_words(
@@ -1027,6 +1045,17 @@ def build_session(
         if best.score <= 0:
             break
 
+        # Whole-sentence near-duplicate veto: skip when this candidate's lemma
+        # set is >= JACCARD_VETO_THRESHOLD overlapping any already-selected
+        # sentence. Catches the "صَامَ المُسْلِمُونَ رَمَضَانَ كُلَّهُ" /
+        # "يَصُومُ المُسْلِمُونَ شَهْرَ رَمَضَانَ" pattern that scaffold-decay misses.
+        selected_lemma_sets = [
+            {w.lemma_id for w in s.words_meta if w.lemma_id} for s in selected
+        ]
+        if _is_near_duplicate_of_selected(best, selected_lemma_sets):
+            candidates.remove(best)
+            continue
+
         selected.append(best)
         best.selection_reason = "greedy_cover"
         best.selection_order = len(selected)
@@ -1090,11 +1119,19 @@ def build_session(
                 break
             if count >= target_count:
                 continue
+            selected_lemma_sets = [
+                {w.lemma_id for w in s.words_meta if w.lemma_id} for s in selected
+            ]
             extra = None
             for c in candidates:
-                if c.sentence_id not in selected_ids and acq_lid in {w.lemma_id for w in c.words_meta}:
-                    extra = c
-                    break
+                if c.sentence_id in selected_ids:
+                    continue
+                if acq_lid not in {w.lemma_id for w in c.words_meta}:
+                    continue
+                if _is_near_duplicate_of_selected(c, selected_lemma_sets):
+                    continue
+                extra = c
+                break
             if extra:
                 extra.selection_reason = "acquisition_repeat"
                 selected.append(extra)
@@ -1347,15 +1384,18 @@ RESCUE_MAX_ACCURACY = 0.50
 RESCUE_COOLDOWN_DAYS = 7
 
 
-INTRO_CARDS_BASE = 5
-INTRO_CARDS_MAX = 10
+INTRO_CARDS_BASE = 4
+INTRO_CARDS_MAX = 6
 
 
 def _dynamic_intro_cap(db: Session) -> int:
     """Scale intro card cap based on un-introed acquiring word backlog.
 
-    Base 5, +1 per 10 un-introed words, capped at 10.
-    After a large import, temporarily shows more intros to clear the backlog.
+    Base 4, +1 per 15 un-introed words, capped at 6. Tightened 2026-04-27 from
+    base=5/max=10 — production data showed sessions of 25 sentences with 10
+    intros (40% intro density), with 9/17 sessions placing the last intro in
+    the final 25% of the session. Lowering the cap shifts excess intros to
+    later sessions and keeps any single session readable.
     """
     unintro_count = (
         db.query(UserLemmaKnowledge)
@@ -1366,7 +1406,7 @@ def _dynamic_intro_cap(db: Session) -> int:
         )
         .count()
     )
-    return min(INTRO_CARDS_MAX, INTRO_CARDS_BASE + unintro_count // 10)
+    return min(INTRO_CARDS_MAX, INTRO_CARDS_BASE + unintro_count // 15)
 
 
 def _build_intro_cards(

--- a/backend/tests/test_acquisition.py
+++ b/backend/tests/test_acquisition.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta, timezone
 from app.models import Lemma, ReviewLog, Root, UserLemmaKnowledge
 from app.services.acquisition_service import (
     BOX_INTERVALS,
+    FAST_GRAD_INTRO_GAP,
     GRADUATION_MIN_ACCURACY,
     GRADUATION_MIN_CALENDAR_DAYS,
     GRADUATION_MIN_REVIEWS,
@@ -116,6 +117,56 @@ def test_tier0_first_correct_graduates(db_session):
     assert ulk.knowledge_state == "learning"
     assert ulk.acquisition_box is None
     assert ulk.fsrs_card_json is not None
+
+
+def test_tier0_blocked_when_intro_just_shown(db_session):
+    """First correct review within FAST_GRAD_INTRO_GAP of intro card stays in box 1.
+
+    Working memory after seeing the intro card should not bypass the encoding phase.
+    """
+    lemma = _create_lemma(db_session)
+    start_acquisition(db_session, lemma.lemma_id)
+
+    ulk = db_session.query(UserLemmaKnowledge).filter_by(lemma_id=lemma.lemma_id).first()
+    ulk.experiment_intro_shown_at = datetime.now(timezone.utc) - timedelta(seconds=20)
+    db_session.flush()
+
+    result = submit_acquisition_review(db_session, lemma.lemma_id, rating_int=3)
+    assert result.get("graduated") is not True
+    assert result["new_state"] == "acquiring"
+
+    ulk = db_session.query(UserLemmaKnowledge).filter_by(lemma_id=lemma.lemma_id).first()
+    assert ulk.knowledge_state == "acquiring"
+    assert ulk.acquisition_box == 2  # advanced box 1→2 (encoding handoff)
+    assert ulk.fsrs_card_json is None
+
+
+def test_tier0_allowed_when_intro_was_long_ago(db_session):
+    """First correct review well past FAST_GRAD_INTRO_GAP still fast-grads."""
+    lemma = _create_lemma(db_session)
+    start_acquisition(db_session, lemma.lemma_id)
+
+    ulk = db_session.query(UserLemmaKnowledge).filter_by(lemma_id=lemma.lemma_id).first()
+    ulk.experiment_intro_shown_at = (
+        datetime.now(timezone.utc) - FAST_GRAD_INTRO_GAP - timedelta(minutes=5)
+    )
+    db_session.flush()
+
+    result = submit_acquisition_review(db_session, lemma.lemma_id, rating_int=3)
+    assert result.get("graduated") is True
+    assert result["new_state"] == "learning"
+
+
+def test_tier0_allowed_when_no_intro_shown(db_session):
+    """First correct review still fast-grads when no intro was shown (e.g. textbook word)."""
+    lemma = _create_lemma(db_session)
+    start_acquisition(db_session, lemma.lemma_id)
+
+    ulk = db_session.query(UserLemmaKnowledge).filter_by(lemma_id=lemma.lemma_id).first()
+    assert ulk.experiment_intro_shown_at is None  # no intro card was shown
+
+    result = submit_acquisition_review(db_session, lemma.lemma_id, rating_int=3)
+    assert result.get("graduated") is True
 
 
 def test_tier0_first_hard_does_not_graduate(db_session):

--- a/backend/tests/test_sentence_selector.py
+++ b/backend/tests/test_sentence_selector.py
@@ -9,11 +9,13 @@ from app.services.fsrs_service import create_new_card
 from app.services.sentence_selector import (
     FRESHNESS_BASELINE,
     INTRO_RESERVE_FRACTION,
+    JACCARD_VETO_THRESHOLD,
     MAX_AUTO_INTRO_PER_SESSION,
     SESSION_SCAFFOLD_DECAY,
     WordMeta,
     _difficulty_match_quality,
     _intro_slots_for_accuracy,
+    _is_near_duplicate_of_selected,
     _scaffold_freshness,
     build_session,
     compute_sentence_diversity_score,
@@ -551,8 +553,10 @@ class TestWithinSessionRepetition:
         db_session.add(lemma)
         db_session.flush()
 
-        # Known scaffold word
+        # Known scaffold words (distinct, so the two sentences aren't near-duplicates)
         _seed_word(db_session, 2, "ولد", "boy", due_hours=24)
+        _seed_word(db_session, 3, "بيت", "house", due_hours=24)
+        _seed_word(db_session, 4, "مدرسة", "school", due_hours=24)
 
         # Acquiring word due now
         naive_due = datetime(2020, 1, 1, 0, 0, 0)
@@ -568,11 +572,12 @@ class TestWithinSessionRepetition:
         )
         db_session.add(ulk)
 
-        # Two sentences containing the acquiring word
-        _seed_sentence(db_session, 1, "الكتاب ولد", "book boy", 1,
-                       [("الكتاب", 1), ("ولد", 2)])
-        _seed_sentence(db_session, 2, "ولد الكتاب", "boy book", 1,
-                       [("ولد", 2), ("الكتاب", 1)])
+        # Two sentences containing the acquiring word — different scaffold words so
+        # they're not near-duplicates (Jaccard veto would block identical lemma sets).
+        _seed_sentence(db_session, 1, "الكتاب في البيت", "book in house", 1,
+                       [("الكتاب", 1), ("بيت", 3)])
+        _seed_sentence(db_session, 2, "الكتاب مع الولد في المدرسة", "book with boy at school", 1,
+                       [("الكتاب", 1), ("ولد", 2), ("مدرسة", 4)])
         db_session.commit()
 
         result = build_session(db_session, limit=10)
@@ -712,6 +717,57 @@ class TestScaffoldDiversity:
         if items[0]["sentence_id"] == 1:
             assert items[1]["sentence_id"] == 3, \
                 "Unique scaffold sentence should be preferred over reused scaffold"
+
+
+class TestNearDuplicateVeto:
+    """Whole-sentence Jaccard veto must block near-identical sentence pairs."""
+
+    def _candidate(self, lemma_ids):
+        class _Cand:
+            pass
+        c = _Cand()
+        c.words_meta = [WordMeta(lemma_id=lid, surface_form="x", gloss_en="x",
+                                  stability=1.0, is_due=False) for lid in lemma_ids]
+        return c
+
+    def test_unrelated_sentences_pass(self):
+        sel = [self._candidate([1, 2, 3, 4])]
+        cand = self._candidate([5, 6, 7, 8])
+        sel_sets = [{w.lemma_id for w in s.words_meta} for s in sel]
+        assert _is_near_duplicate_of_selected(cand, sel_sets) is False
+
+    def test_identical_lemma_set_vetoed(self):
+        sel = [self._candidate([1, 2, 3, 4])]
+        cand = self._candidate([1, 2, 3, 4])
+        sel_sets = [{w.lemma_id for w in s.words_meta} for s in sel]
+        assert _is_near_duplicate_of_selected(cand, sel_sets) is True
+
+    def test_threshold_boundary(self):
+        # 3 of 4 shared, 1 unique each side → Jaccard = 3/5 = 0.6
+        sel = [self._candidate([1, 2, 3, 4])]
+        cand = self._candidate([1, 2, 3, 5])
+        sel_sets = [{w.lemma_id for w in s.words_meta} for s in sel]
+        # Jaccard 0.6 is below 0.7 threshold → not vetoed
+        assert _is_near_duplicate_of_selected(cand, sel_sets) is False
+
+        # 3 of 3 shared + 1 extra in cand → Jaccard = 3/4 = 0.75 → vetoed
+        sel2 = [self._candidate([1, 2, 3])]
+        cand2 = self._candidate([1, 2, 3, 5])
+        sel2_sets = [{w.lemma_id for w in s.words_meta} for s in sel2]
+        assert _is_near_duplicate_of_selected(cand2, sel2_sets) is True
+
+    def test_empty_candidate_passes(self):
+        sel = [self._candidate([1, 2, 3])]
+        cand = self._candidate([])
+        sel_sets = [{w.lemma_id for w in s.words_meta} for s in sel]
+        assert _is_near_duplicate_of_selected(cand, sel_sets) is False
+
+    def test_empty_selected_passes(self):
+        cand = self._candidate([1, 2, 3])
+        assert _is_near_duplicate_of_selected(cand, []) is False
+
+    def test_threshold_constant_in_range(self):
+        assert 0 < JACCARD_VETO_THRESHOLD < 1.0
 
 
 class TestFillPhasePregenerated:

--- a/docs/scheduling-system.md
+++ b/docs/scheduling-system.md
@@ -378,6 +378,8 @@ Graduation uses a tiered system. Tier 0/1/2 can fire on **any review** (includin
 
 **Tier 0 — First-correct instant graduation**: If a word's very first review is correct (rating ≥ 3, `times_seen` was 0), it graduates immediately. Data shows 0% lapse rate for fast graduates. FSRS safety net catches false positives.
 
+**Tier 0 working-memory gate** (2026-04-27): if the intro card was shown within `FAST_GRAD_INTRO_GAP = 10 minutes` of the first review, Tier 0 is **skipped** and the word advances Box 1→2 normally. Production data showed 6/6 traceable fast-grads happened within 60 seconds of the intro card (4/6 within 30s) — that's working memory of the intro card, not knowledge. Words with no intro card shown (e.g. encountered → auto-introduced via collateral) bypass the gate and still fast-grad.
+
 **Tier 1 — Perfect accuracy**: 100% accuracy + 3+ reviews → graduate from any box. No calendar-day or due-date requirement.
 
 **Tier 2 — High accuracy**: ≥80% accuracy + 4+ reviews + box ≥ 2 → graduate. No calendar-day or due-date requirement.
@@ -890,6 +892,23 @@ where SESSION_SCAFFOLD_DECAY = 0.5
 This prevents the same high-frequency scaffold words (e.g., طالب, أستاذ, جميل) from
 appearing in every sentence of a session. The decay is exponential but never reaches zero,
 so a sentence covering many due words can still win over a more diverse single-word sentence.
+
+#### Whole-Sentence Near-Duplicate Veto (2026-04-27)
+
+Per-word scaffold decay isn't enough when two sentences for the same target word share their
+entire lemma set (e.g. `صَامَ المُسْلِمُونَ رَمَضَانَ كُلَّهُ` vs.
+`يَصُومُ المُسْلِمُونَ شَهْرَ رَمَضَانَ كُلَّ سَنَةٍ`). A second hard veto applies in both the
+greedy cover loop and the acquisition-repetition loop:
+
+```
+JACCARD_VETO_THRESHOLD = 0.7
+veto if |cand_lemmas ∩ prior_lemmas| / |cand_lemmas ∪ prior_lemmas| ≥ 0.7
+```
+
+Vetoed candidates are removed from the pool entirely; the next-best candidate is picked. The
+veto fires after the greedy pick, so it doesn't affect scoring math — it only blocks selection.
+Cost: a target word may end up with fewer total exposures in a session if all its candidate
+sentences are mutually near-duplicate; that's the desired tradeoff (variety > raw count).
 
 #### Never-Reviewed Boost
 
@@ -1497,6 +1516,8 @@ remaining cards on the next card advance. See Section 8 "Sentence Pre-Warming" f
 | `LOW_TIER_BLOCK_BACKLOG` | 60 | Block low-tier sources (wiktionary, story_import, manual, flag_autocreate, unsourced) from auto-intro when box-1 acquiring count exceeds this |
 | Adaptive intro bands | 0→3→5 | Slots at <70%/70-85%/≥85% accuracy |
 | `SESSION_SCAFFOLD_DECAY` | 0.5 | Per-appearance multiplier for scaffold words already in session |
+| `JACCARD_VETO_THRESHOLD` | 0.7 | Hard veto: skip candidate sentence if lemma-set Jaccard ≥ this with any prior selection (2026-04-27) |
+| `FAST_GRAD_INTRO_GAP` | 10 min | Tier-0 instant-grad blocked if intro card was shown within this window (working-memory guard, 2026-04-27) |
 | `NEVER_REVIEWED_BOOST` | 5.0 | Score multiplier for sentences targeting acquiring words with 0 reviews OR 0% accuracy |
 | `LAPSED_BOOST` | 3.0 | Score multiplier for sentences targeting any due word in `lapsed` state — drives aggressive re-exposure after a miss |
 | `OVERDUE_ESCALATION_DAYS` | 0.5 | Start boosting score after this many days overdue |
@@ -1742,9 +1763,15 @@ intro cards. `experiment_intro_cards` in session response — retention-optimize
 (pattern, root family, etymology, mnemonic). Single "Continue" button, no self-assessment.
 Acknowledgement via `POST /api/review/experiment-intro-ack` sets `experiment_intro_shown_at`
 timestamp on ULK, preventing the card from appearing again and enforcing 7-day rescue card cooldown.
-**Dynamic cap** (2026-04-07): `min(10, 5 + unintro_backlog // 10)` via `_dynamic_intro_cap()`.
-Scales up after large imports (e.g. textbook scans with 60+ new words), drops to base 5 when
-backlog clears. Constants: `INTRO_CARDS_BASE = 5`, `INTRO_CARDS_MAX = 10`. Replaces fixed
+**Dynamic cap** (2026-04-07, tightened 2026-04-27): `min(6, 4 + unintro_backlog // 15)` via
+`_dynamic_intro_cap()`. Scales up after large imports, drops to base 4 when backlog clears.
+Constants: `INTRO_CARDS_BASE = 4`, `INTRO_CARDS_MAX = 6`. Tightened from 5/10 after production
+data showed 9/17 sessions placing intros in the final 25% — see `research/experiment-log.md`
+2026-04-27 entry. **End-of-session exclusion** (frontend, 2026-04-27): intros never emitted in
+the final 20% of the projected session — late-overflow intros are silently dropped and surface
+in the next session. **Sentence reorder** (frontend, 2026-04-27): intro-bearing sentences are
+placed in the front-middle, no-intro sentences fill the wind-down — guarantees the user
+finishes a session practicing, not facing a fresh-card flood. Replaces fixed
 `MAX_INTRO_CARDS_PER_SESSION = 5`. Variants whose canonical lemma is already known or learning
 skip intro cards entirely (prevents e.g. بنية intro when بني is known). **Auto-skip at render
 time**: if the user already answered a word correctly earlier in the session, its intro card is

--- a/frontend/app/index.tsx
+++ b/frontend/app/index.tsx
@@ -128,20 +128,24 @@ function buildInterleavedSession(
     return overlap;
   });
 
-  // 3. Order sentences: warm-ups (no intro words) first, then sentences that
-  //    introduce new lemmas. This keeps the first 1-2 cards easy and lets us
-  //    interleave intro cards naturally as their target lemmas first appear.
-  const sentenceOrder = items.map((_, i) => i);
-  sentenceOrder.sort((a, b) => {
-    const sa = sentenceIntroWords[a].size;
-    const sb = sentenceIntroWords[b].size;
-    if (sa === 0 && sb > 0) return -1;
-    if (sb === 0 && sa > 0) return 1;
-    return a - b;
-  });
+  // 3. Order: 1-2 no-intro warm-ups → intro-bearing sentences (front-middle) →
+  //    no-intro wind-down (back). The wind-down guarantees the last ~20% of
+  //    the session is intro-free, so the learner finishes with practice, not
+  //    a fresh-card flood (fixed 2026-04-27).
+  const allOrder = items.map((_, i) => i);
+  const noIntro = allOrder.filter((i) => sentenceIntroWords[i].size === 0);
+  const withIntro = allOrder.filter((i) => sentenceIntroWords[i].size > 0);
+  const warmup = noIntro.slice(0, Math.min(2, noIntro.length));
+  const winddown = noIntro.slice(warmup.length);
+  const sentenceOrder = [...warmup, ...withIntro, ...winddown];
 
   // 4. Walk in chosen order. Before each sentence, emit any unshown intro
-  //    cards whose lemma appears in this sentence.
+  //    cards whose lemma appears in this sentence — but never inside the
+  //    last 20% of the projected session. Late intros are silently dropped
+  //    (they'll be picked up in the next session).
+  const INTRO_END_EXCLUSION = 0.20;
+  const estimatedTotal = items.length + introCards.length;
+  const introCutoff = Math.floor(estimatedTotal * (1 - INTRO_END_EXCLUSION));
   const shown = new Set<number>();
   const result: SessionSlot[] = [];
 
@@ -149,17 +153,19 @@ function buildInterleavedSession(
     for (const lemmaId of sentenceIntroWords[sentIdx]) {
       const introIdx = lemmaToIntroIdx.get(lemmaId);
       if (introIdx !== undefined && !shown.has(lemmaId)) {
-        result.push({ type: "experiment_intro" as const, introIndex: introIdx });
-        shown.add(lemmaId);
+        if (result.length < introCutoff) {
+          result.push({ type: "experiment_intro" as const, introIndex: introIdx });
+          shown.add(lemmaId);
+        }
       }
     }
     result.push({ type: "sentence" as const, itemIndex: sentIdx });
   }
 
-  // 5. Flush any intro cards whose lemma never appeared in a session sentence
-  //    (defensive: backend filters intros to covered_ids, so this is rare).
+  // 5. Flush orphan intros whose lemma never appeared in a session sentence,
+  //    but only if they fit before the cutoff. Late orphans are dropped.
   introCards.forEach((c, i) => {
-    if (!shown.has(c.lemma_id)) {
+    if (!shown.has(c.lemma_id) && result.length < introCutoff) {
       result.push({ type: "experiment_intro" as const, introIndex: i });
       shown.add(c.lemma_id);
     }

--- a/research/experiment-log.md
+++ b/research/experiment-log.md
@@ -4,6 +4,43 @@ Running lab notebook for Alif's learning algorithm. Each entry documents what ch
 
 ---
 
+## 2026-04-27: Four learner-data-driven fixes — Tier-0 time gate, Jaccard veto, intro cap, end-of-session intro exclusion
+
+### What
+
+Addressed four concerns from the user's recent learning data with backend + frontend changes (PR sh/learning-data-fixes).
+
+**Fix 1 — Tier-0 instant graduation: time gate against working-memory false positives.**
+`acquisition_service.py:226`: skip instant graduation when `experiment_intro_shown_at` is within `FAST_GRAD_INTRO_GAP = 10 minutes`. A correct first review seconds after the intro card is working memory, not learning. Word advances Box 1→2 normally instead.
+
+**Fix 2 — Whole-sentence Jaccard veto on near-duplicates.**
+`sentence_selector.py`: new helper `_is_near_duplicate_of_selected()` and `JACCARD_VETO_THRESHOLD = 0.7`. After picking a candidate in the greedy cover loop *and* the acquisition-repetition loop, reject if its lemma set has Jaccard ≥ 0.7 with any already-selected sentence. Complements `SESSION_SCAFFOLD_DECAY` (per-word penalty) with a hard whole-sentence veto.
+
+**Fix 3a — Lower intro card cap.**
+`sentence_selector.py:1387`: `INTRO_CARDS_BASE` 5→4, `INTRO_CARDS_MAX` 10→6. Dynamic ramp slowed from `+1/10` to `+1/15`. Caps a single session at ~24% intro density (vs. 40% before).
+
+**Fix 3b — End-of-session intro exclusion + reorder.**
+`frontend/app/index.tsx:131`: rewrote `buildInterleavedSession` so intro-bearing sentences are placed in the front-middle, no-intro sentences in the back. Added `INTRO_END_EXCLUSION = 0.20` — never emit an intro card in the final 20% of the projected session. Late-overflow intros are silently dropped (next session picks them up).
+
+### Why — what the data showed
+
+7-day learner audit on the production DB (sessions, intro events, fast-grads, sentence pairs):
+
+| Concern | Finding | File:line |
+|---|---|---|
+| Intro flood | 2 sessions with 9–10 intros (40% intro density). 9/17 intro-bearing sessions had their last intro in the final 25%. 3 sessions had intros at literal session-end position. | `index.tsx:131-166` (sort + flush both pushed intros to end) |
+| Tier-0 false positives | 6/6 fast-grads with timestamps graduated within 1 minute of the intro card; 4/6 within 30 seconds (e.g. نَفَخَ "to blow" — 12s). Bimodal distribution: nothing between 1m and 14d. | `acquisition_service.py:220` (only `times_seen==0 and rating>=3`, no time check) |
+| Near-duplicate sentences | 8 pairs with Jaccard ≥ 0.5 in 7d; worst case 100% (`صَانَ الْمُتَخَصِّصُ الْكُنُوزَ الْقَدِيمَةَ` / `صَانَ الْمُتَخَصِّصُ الْكَنْزَ الْقَدِيمَ`). Greedy selector picks both because both cover the same due word. | `sentence_selector.py:998` (per-word decay too weak when sentences are highly aligned) |
+| Textbook scan inerts | Working as designed — 170 textbook_scan words in `encountered`, auto-introduced via collateral when relevant. No fix needed. | `ocr_service.py:566` |
+
+### How to verify
+
+- 7 new tests in `test_acquisition.py` and `test_sentence_selector.py` cover boundary cases (intro-shown-recently blocks, intro-shown-long-ago allows, no-intro allows; near-duplicate vetoed, threshold boundary, empty edge cases).
+- Run a session today and check (a) no session > 6 intros, (b) no intro in final 20% of session, (c) no consecutive sentences sharing >70% lemmas.
+- After 7 days: re-run the analysis script and check the fast-grad-within-1-minute count drops to 0, and high-Jaccard sentence pairs drop to 0.
+
+---
+
 ## 2026-04-27: Lemma decomposition Phase 2 step 4c — re-gate 161 `compound_with_canonical` entries, tag 91, link 17, requeue 3,056 corpus sentences
 
 ### What


### PR DESCRIPTION
## Summary

Four fixes addressing concerns surfaced by a 7-day audit of production learner data.

**1. Tier-0 working-memory gate** (`acquisition_service.py`)
Block first-correct instant graduation when the intro card was shown within `FAST_GRAD_INTRO_GAP = 10 min`. Data showed 6/6 traceable fast-grads happened within 60 seconds of the intro card (4/6 within 30s) — e.g. نَفَخَ "to blow" graduated 12s after intro shown. That's working memory, not learning. Words with no intro card (e.g. encountered → auto-introduced via collateral) still fast-grad.

**2. Whole-sentence Jaccard veto** (`sentence_selector.py`)
Hard-veto candidate sentences with lemma-set Jaccard ≥ `JACCARD_VETO_THRESHOLD = 0.7` against any already-selected sentence in the session. Applied in both greedy cover and acquisition-repetition loops. Complements the existing per-word `SESSION_SCAFFOLD_DECAY` (which was too weak when two sentences are highly aligned). Data: 8 high-Jaccard pairs in 7d (worst was 1.0 — `صَانَ الْمُتَخَصِّصُ الْكُنُوزَ الْقَدِيمَةَ` vs `صَانَ الْمُتَخَصِّصُ الْكَنْزَ الْقَدِيمَ`, only inflection differed).

**3. Lower intro card cap** (`sentence_selector.py`)
`INTRO_CARDS_MAX` 10→6, `INTRO_CARDS_BASE` 5→4, ramp slowed from `+1/10` to `+1/15`. Data: two sessions had 10 intros in 25 sentences (40% intro density).

**4. End-of-session intro exclusion + reorder** (`frontend/app/index.tsx`)
Reordered to: warmup (1-2 no-intro sentences) → intro-bearing sentences (front-middle) → no-intro wind-down. Added `INTRO_END_EXCLUSION = 0.20` — intros never emitted in the final 20% of the projected session (orphan flush also respects the cutoff). Data: 9/17 intro-bearing sessions had their last intro in the final 25%; some had intros at the literal session-end position.

## Tests

- 3 new tests in `test_acquisition.py`: time gate blocks within 10min, allows past 10min, allows when no intro shown.
- 6 new tests in `test_sentence_selector.py`: helper passes/vetoes correctly across boundary, identical, empty, and unrelated cases.
- One pre-existing test (`test_acquisition_word_gets_extra_sentence`) updated — was relying on the buggy behavior of picking two sentences with identical lemma sets for acquisition repetition (exactly the pattern the Jaccard veto blocks). Updated to use distinct scaffold words.
- One unrelated pre-existing failure (`test_introduce_endpoint`, missing `decomposition_note` migration in test fixture) exists on `main` already; not introduced by this PR.

## Docs

- `research/experiment-log.md`: full data-driven entry with measurement → fix → verification.
- `docs/scheduling-system.md`: dynamic-cap section updated, new Tier-0 working-memory paragraph, new whole-sentence near-duplicate veto section, `JACCARD_VETO_THRESHOLD` and `FAST_GRAD_INTRO_GAP` added to constants table.
- `IDEAS.md`: marked as DONE with a pointer to revisit thresholds in 1-2 weeks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)