### PR TITLE
Fix test fixture: share schema across all DB code paths

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,14 +1,46 @@
 import os
+import tempfile
 import pytest
 from contextlib import contextmanager
-from sqlalchemy import create_engine, event, StaticPool
+from sqlalchemy import event
 from sqlalchemy.orm import sessionmaker
 
 os.environ["ALIF_SKIP_MIGRATIONS"] = "1"
 os.environ["TESTING"] = "1"
 
-from app.database import Base, get_db
+# Point the app's engine at a tmp file BEFORE importing app.database, so all
+# code paths — request-scoped sessions via Depends(get_db) and ad-hoc calls to
+# SessionLocal() from services / BackgroundTasks — share one schema with the
+# current model definitions. Using a real file (instead of :memory:) keeps the
+# schema visible to fresh connections opened by SessionLocal().
+_test_db_fd, _test_db_path = tempfile.mkstemp(suffix=".alif-test.db")
+os.close(_test_db_fd)
+os.environ["DATABASE_URL"] = f"sqlite:///{_test_db_path}"
+
+from app.database import Base, engine, get_db
 from app.main import app
+
+# FastAPI BackgroundTasks runs queued tasks synchronously after the response in
+# TestClient. Tasks like evaluate_flag, generate_material_for_word, etc. now
+# share the test DB (via the env var above), so they actually execute and
+# mutate state — breaking tests that asserted on intermediate state. Make
+# add_task a no-op for the whole test run; tests that need background-task
+# behavior should test those services directly.
+from starlette.background import BackgroundTasks as _BG
+
+_BG.add_task = lambda self, func, *args, **kwargs: None
+
+
+# Several flag_evaluator tests deliberately seed ContentFlag rows with
+# non-existent lemma_id / sentence_id to exercise "row was deleted" handling.
+# Production has foreign_keys=ON (set by app.database), but enforcing that in
+# tests would require complex fixturing for these legitimate cases. Disable FK
+# enforcement on every test connection — runs after app.database's pragmas.
+@event.listens_for(engine, "connect")
+def _disable_fks_for_tests(dbapi_conn, connection_record):
+    cursor = dbapi_conn.cursor()
+    cursor.execute("PRAGMA foreign_keys=OFF")
+    cursor.close()
 
 
 @contextmanager
@@ -43,11 +75,6 @@ def count_commits(db_session):
 
 @pytest.fixture
 def db_session():
-    engine = create_engine(
-        "sqlite:///:memory:",
-        connect_args={"check_same_thread": False},
-        poolclass=StaticPool,
-    )
     Base.metadata.create_all(bind=engine)
     Session = sessionmaker(bind=engine)
     session = Session()
@@ -56,6 +83,11 @@ def db_session():
     finally:
         session.close()
         Base.metadata.drop_all(bind=engine)
+        # Sharing the production engine means SessionLocal() calls from
+        # service code can leave pooled connections behind. Dispose the pool
+        # at fixture teardown so the next test starts with a clean slate
+        # (otherwise QueuePool overflows after ~15 tests).
+        engine.dispose()
 
 
 @pytest.fixture
@@ -72,3 +104,12 @@ def client(db_session):
     with TestClient(app) as c:
         yield c
     app.dependency_overrides.clear()
+
+
+def pytest_sessionfinish(session, exitstatus):
+    """Remove the tmp test DB file (and any -wal/-shm sidecars) at end of run."""
+    for suffix in ("", "-wal", "-shm", "-journal"):
+        try:
+            os.remove(_test_db_path + suffix)
+        except FileNotFoundError:
+            pass


### PR DESCRIPTION
## Summary

Fixes a long-standing test fixture issue where service code paths (`SessionLocal()` calls, BackgroundTasks) were silently failing because they bound to the production `app.database.engine` pointed at the schema-drifted on-disk dev DB. `test_introduce_endpoint` was failing on `main` with `no such column: lemmas.decomposition_note`; other tests were accidentally hermetic because the bad connection couldn't see any tables.

## Changes

- Set `DATABASE_URL` to a tmp file **before** importing `app.database`, so the production engine targets a fresh schema-current SQLite file.
- Use that same engine in the `db_session` fixture (`drop_all` / `create_all` per test) so all code paths share one schema.
- Patch `BackgroundTasks.add_task` to no-op for the test session — previously tasks failed silently due to schema mismatch; making them actually run broke tests that asserted on intermediate state.
- Disable `foreign_keys` for test connections — `flag_evaluator` tests deliberately create flags with non-existent `lemma_id` to exercise "row was deleted" handling.
- `engine.dispose()` at fixture teardown — service code opens its own `SessionLocal()` instances, leaving pooled connections behind that exhaust QueuePool after ~15 tests.
- `pytest_sessionfinish` removes the tmp DB plus its `-wal` / `-shm` sidecars.

## Result

- Before: 932 passed, 1 failed (`test_introduce_endpoint` — pre-existing).
- After: 939 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)