### PR TITLE
Backoff-aware multi-target: route hard-failure lemmas through scaffold-rich path

### DIFF
--- a/IDEAS.md
+++ b/IDEAS.md
@@ -12,7 +12,8 @@ Found while drilling into the 21-day learning review. The 211 words in 7-day bac
 2. **Validator demands exact bare-form match on the target** — doesn't accept any inflection. Fix: replace target check in `validate_sentence` with a `lookup_lemma()` resolution to `target_lemma_id`. ~5 LOC.
 3. **Step A2 corpus enrichment kills sentences on first verifier disagreement** — 22.4% kept (1,846/8,250). `same_lemma` is not actionable feedback yet triggers permanent deactivation. Fix: soften `apply_corrections` callsite *in enrichment only*, without weakening the gate for fresh LLM generation (where the same_lemma rejection is intentional hardening — see `feedback_dont_weaken_same_lemma_gate`).
 4. (observability) **New self-correct batch path emits no success events.** Add `batch_self_correct_returned/_validated/_rejected` events. ~10 LOC.
-5. (cleanup) **Drain the 172-entry backoff list** once 1+2 land.
+5. (cleanup) **Drain the 172-entry backoff list** once 1+2 land. — *2026-05-04 update: now expected to drain naturally via backoff-aware multi-target (see entry below); manual drain probably unnecessary.*
+6. (deployed 2026-05-04) **Backoff-aware multi-target** (replaces planned C1 retry): backed-off lemmas can ride along as collateral in multi-target groups (≤1 per group of ≤4 healthy peers). A multi-target success auto-resets `generation_failed_count`. Self-correct paths still exclude backed-off lemmas. Driven by the observation that #2307 (named hard-core failure) succeeded twice as multi-target collateral while consistently empty-failing in single-word fallback. See `research/experiment-log.md` 2026-05-04 entry.
 
 See `research/generation-pipeline-investigation-2026-05-03.md` for full evidence and dependency-ordered fixes.
 

--- a/backend/scripts/pipeline_stats.py
+++ b/backend/scripts/pipeline_stats.py
@@ -53,6 +53,8 @@ def iter_pipeline_entries(log_dir: Path, dates: list[date]):
 def _per_day(entries):
     by_day: dict[date, Counter] = defaultdict(Counter)
     self_correct_returned: dict[date, list[dict]] = defaultdict(list)
+    multi_target_summaries: list[dict] = []
+    multi_target_accepted: list[dict] = []
     issues: Counter[str] = Counter()
     empty_groups: list[dict] = []
 
@@ -64,11 +66,22 @@ def _per_day(entries):
             self_correct_returned[d].append(e)
         elif ev == "batch_self_correct_empty":
             empty_groups.append({"date": d.isoformat(), **e})
+        elif ev == "multi_target_summary":
+            multi_target_summaries.append(e)
+        elif ev == "multi_target_accepted":
+            multi_target_accepted.append(e)
         elif ev == "batch_validation_failed":
             for iss in e.get("issues") or []:
                 issues[iss[:90]] += 1
 
-    return by_day, self_correct_returned, issues, empty_groups
+    return (
+        by_day,
+        self_correct_returned,
+        multi_target_summaries,
+        multi_target_accepted,
+        issues,
+        empty_groups,
+    )
 
 
 def main():
@@ -88,9 +101,14 @@ def main():
         dates = [today - timedelta(days=i) for i in range(args.days)]
         label = f"last {args.days} days ({dates[-1]} .. {dates[0]})"
 
-    by_day, self_correct_returned, issues, empty_groups = _per_day(
-        iter_pipeline_entries(log_dir, dates)
-    )
+    (
+        by_day,
+        self_correct_returned,
+        multi_target_summaries,
+        multi_target_accepted,
+        issues,
+        empty_groups,
+    ) = _per_day(iter_pipeline_entries(log_dir, dates))
 
     print(f"=== Generation Pipeline Stats — {label} ===")
     print(f"Log dir: {log_dir}")
@@ -101,6 +119,26 @@ def main():
         return
 
     # ── Daily breakdown ──
+    # mt_grp = number of multi_target_summary events (one per group call).
+    # mt_ret = sum of sentences_returned across summaries (sentences from LLM).
+    # mt_acc = sum of accepted across summaries (post-quality-review survivors).
+    mt_by_day: dict[date, tuple[int, int, int]] = defaultdict(lambda: (0, 0, 0))
+    for s in multi_target_summaries:
+        # Find the date by parsing ts; fall back to no-op if absent
+        ts = s.get("ts", "")
+        try:
+            d = datetime.fromisoformat(ts).date() if ts else None
+        except ValueError:
+            d = None
+        if d is None:
+            continue
+        g, r, a = mt_by_day[d]
+        mt_by_day[d] = (
+            g + 1,
+            r + (s.get("sentences_returned") or 0),
+            a + (s.get("accepted") or 0),
+        )
+
     print("Self-correct (single + batch fallback) | Multi-target (Phase 1) | shared")
     print(f"{'date':<12} {'sc_ret':>6} {'sc_acc':>6} {'sc_emp':>6} | "
           f"{'mt_grp':>6} {'mt_ret':>6} {'mt_acc':>6} {'mt_fail':>7} | "
@@ -112,11 +150,7 @@ def main():
         sc_ret = c.get("batch_self_correct_returned", 0)
         sc_acc = c.get("batch_self_correct_accepted", 0)
         sc_emp = c.get("batch_self_correct_empty", 0)
-        # Multi-target events. mt_grp counts groups attempted (one summary per call).
-        # mt_ret counts sentences returned by the LLM, mt_acc the post-quality-review survivors.
-        mt_grp = c.get("multi_target_summary", 0)
-        mt_ret = c.get("multi_target_returned", 0)
-        mt_acc = c.get("multi_target_accepted", 0)
+        mt_grp, mt_ret, mt_acc = mt_by_day.get(d, (0, 0, 0))
         mt_fail = c.get("multi_target_failed", 0)
         val_fail = c.get("batch_validation_failed", 0)
         sc_ret_sum += sc_ret
@@ -138,14 +172,6 @@ def main():
              if sc_ret_sum + sc_emp_sum else ""))
     print(f"  sentences accepted (post-Haiku verify): {sc_acc_sum}")
 
-    # ── Multi-target effectiveness ──
-    print()
-    print("Multi-target path (Phase 1 of cron, dominant generation source):")
-    print(f"  groups attempted: {mt_grp_sum}")
-    print(f"  sentences returned by LLM: {mt_ret_sum}")
-    print(f"  sentences accepted (post-quality-review): {mt_acc_sum}"
-          + (f"  ({100*mt_acc_sum/mt_ret_sum:.1f}% of returned)" if mt_ret_sum else ""))
-
     if self_correct_returned:
         all_groups = [e for ents in self_correct_returned.values() for e in ents]
         per_target = []
@@ -162,6 +188,31 @@ def main():
             print(f"  mean sentences/target: {mean(per_target):.2f}"
                   f"  (over {len(per_target)} target slots)")
             print(f"  groups returning zero sentences: {zero_groups}/{len(all_groups)}")
+
+    # ── Multi-target effectiveness ──
+    print()
+    print("Multi-target path (Phase 1 of cron, dominant generation source):")
+    print(f"  groups attempted: {mt_grp_sum}")
+    print(f"  sentences returned by LLM: {mt_ret_sum}")
+    print(f"  sentences accepted (post-quality-review): {mt_acc_sum}"
+          + (f"  ({100*mt_acc_sum/mt_ret_sum:.1f}% of returned)" if mt_ret_sum else ""))
+
+    if multi_target_summaries:
+        target_slots: set[int] = set()
+        for s in multi_target_summaries:
+            target_slots.update(s.get("target_lemma_ids") or [])
+        covered_targets: set[int] = set()
+        for a in multi_target_accepted:
+            covered_targets.update(a.get("target_lemma_ids") or [])
+        zero_groups = sum(
+            1 for s in multi_target_summaries
+            if not (s.get("accepted") or 0)
+        )
+        if target_slots:
+            print(f"  distinct target lemmas: {len(target_slots)}")
+            print(f"  targets covered ≥1 accepted sentence: {len(covered_targets)}"
+                  f"  ({100*len(covered_targets)/len(target_slots):.1f}%)")
+            print(f"  groups with zero accepted sentences: {zero_groups}/{len(multi_target_summaries)}")
 
     # ── Empty-response details ──
     if empty_groups:

--- a/backend/scripts/update_material.py
+++ b/backend/scripts/update_material.py
@@ -69,6 +69,38 @@ CAP_HEADROOM = 50  # retire this many below cap to leave room for multi-target b
 PREGEN_SENTENCES_PER_CANDIDATE = 3  # for step C pre-generation of not-yet-introduced words
 
 
+def _augment_groups_with_recovery(
+    groups: list[list[dict]],
+    recovery_words: list[dict],
+    max_group_size: int = 4,
+) -> list[list[dict]]:
+    """Top up multi-target groups with at most 1 backed-off lemma each.
+
+    Recovery lemmas only fill empty slots — never displace a healthy lemma —
+    so groups remain majority-healthy. Skips a recovery lemma whose root_id
+    collides with one already in the group.
+    """
+    if not recovery_words:
+        return groups
+    pool = list(recovery_words)
+    random.shuffle(pool)
+    out: list[list[dict]] = []
+    for group in groups:
+        if len(group) >= max_group_size or not pool:
+            out.append(group)
+            continue
+        existing_roots = {w.get("root_id") for w in group if w.get("root_id") is not None}
+        for i, rw in enumerate(pool):
+            rid = rw.get("root_id")
+            if rid is not None and rid in existing_roots:
+                continue
+            group = group + [rw]
+            pool.pop(i)
+            break
+        out.append(group)
+    return out
+
+
 def get_existing_counts(db: Session) -> dict[int, int]:
     rows = (
         db.query(Sentence.target_lemma_id, func.count(Sentence.id))
@@ -597,6 +629,34 @@ def step_backfill_sentences(
 
     print(f"  Words needing sentences: {len(words_needing)} (of {len(word_tiers)} total)")
 
+    # Backoff-aware multi-target: backed-off lemmas are excluded from the
+    # self-correct paths (where they keep failing) but get free recovery
+    # attempts as collateral in multi-target groups, capped at 1 per group of
+    # ≤4 healthy lemmas. The original concern from #37 was chronic failures
+    # crowding out viable lemmas; the cap keeps groups majority-healthy while
+    # giving backoff lemmas a path back. A successful generation auto-resets
+    # the counter via record_generation_outcome().
+    backoff_recovery_words: list[dict] = []
+    if backoff_ids and len(words_needing) >= 2:
+        sample_n = min(len(backoff_ids), max(1, len(words_needing) // 3))
+        for lid in random.sample(list(backoff_ids), sample_n):
+            lemma = db.query(Lemma).filter(Lemma.lemma_id == lid).first()
+            if not lemma or not (lemma.gloss_en or "").strip():
+                continue
+            backoff_recovery_words.append({
+                "lemma_id": lid,
+                "lemma_ar": lemma.lemma_ar,
+                "gloss_en": lemma.gloss_en or "",
+                "root_id": lemma.root_id,
+                "due_str": "backoff",
+                "existing": existing_counts.get(lid, 0),
+                "needed": 1,
+                "tier": 4,
+                "backfill_target": 1,
+            })
+        if backoff_recovery_words:
+            print(f"  Including {len(backoff_recovery_words)} backed-off lemmas as multi-target recovery (≤1/group)")
+
     total = 0
     words_processed = 0
     covered_by_multi: set[int] = set()
@@ -613,6 +673,8 @@ def step_backfill_sentences(
             write_multi_target_sentence,
         )
         groups = group_words_for_multi_target(words_needing)
+        if backoff_recovery_words:
+            groups = _augment_groups_with_recovery(groups, backoff_recovery_words)
 
         # Phase 1a: generate all multi-target sentences (LLM only, no DB writes)
         all_multi_results: list[tuple[list, dict[str, int]]] = []
@@ -754,6 +816,15 @@ def step_backfill_sentences(
         for w in words_needing:
             lid = w["lemma_id"]
             record_generation_result(db, lid, 1 if lid in covered else 0)
+        # Backoff-recovery lemmas: only record successes (which clear the counter).
+        # Don't penalise failures — they're already on backoff and not in
+        # words_needing; recording another 0-result here would just push their
+        # backoff_until further out without giving them another chance until
+        # they age out. A success via multi-target collateral resets normally.
+        for w in backoff_recovery_words:
+            lid = w["lemma_id"]
+            if lid in covered:
+                record_generation_result(db, lid, 1)
 
     print(f"  → Generated {total} sentences for {words_processed} words")
     return total

--- a/backend/tests/test_generation_backoff.py
+++ b/backend/tests/test_generation_backoff.py
@@ -106,3 +106,79 @@ def test_lemmas_on_backoff_filters_expired_entries(db_session):
 
 def test_lemmas_on_backoff_empty_input(db_session):
     assert lemmas_on_backoff(db_session, []) == set()
+
+
+# ── Backoff-aware multi-target group augmentation ──
+# Backed-off lemmas piggy-back on healthy cohorts via multi-target collateral,
+# capped at 1 per group of ≤4 healthy lemmas. Original concern from #37 was
+# chronic failures crowding out viable lemmas; the cap keeps groups majority-
+# healthy. A successful generation auto-resets the counter via the existing
+# record_generation_result path.
+
+def _w(lemma_id, root_id=None):
+    return {"lemma_id": lemma_id, "lemma_ar": f"w{lemma_id}", "root_id": root_id}
+
+
+def test_augment_skips_full_groups():
+    import sys
+    from pathlib import Path
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+    from update_material import _augment_groups_with_recovery
+
+    full_group = [_w(1, 100), _w(2, 200), _w(3, 300), _w(4, 400)]
+    recovery = [_w(99, 999)]
+    out = _augment_groups_with_recovery([full_group], recovery)
+    assert out == [full_group]  # unchanged — no slot available
+
+
+def test_augment_adds_one_to_undersized_group():
+    import sys
+    from pathlib import Path
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+    from update_material import _augment_groups_with_recovery
+
+    group = [_w(1, 100), _w(2, 200)]
+    recovery = [_w(99, 999), _w(100, 998)]
+    out = _augment_groups_with_recovery([group], recovery)
+    assert len(out) == 1
+    assert len(out[0]) == 3  # 1 recovery added
+    assert out[0][:2] == group  # recovery appended, healthy intact
+
+
+def test_augment_skips_recovery_with_root_collision():
+    import sys
+    import random as _random
+    from pathlib import Path
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+    from update_material import _augment_groups_with_recovery
+
+    _random.seed(0)
+    group = [_w(1, 100), _w(2, 200)]
+    # Both recovery candidates collide with the group's roots.
+    recovery = [_w(99, 100), _w(100, 200)]
+    out = _augment_groups_with_recovery([group], recovery)
+    # No non-colliding option → group left unchanged.
+    assert out[0] == group
+
+
+def test_augment_distributes_one_per_group():
+    import sys
+    import random as _random
+    from pathlib import Path
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+    from update_material import _augment_groups_with_recovery
+
+    _random.seed(0)
+    groups = [
+        [_w(1, 100), _w(2, 200)],
+        [_w(3, 300), _w(4, 400)],
+    ]
+    recovery = [_w(99, 901), _w(100, 902), _w(101, 903)]
+    out = _augment_groups_with_recovery(groups, recovery)
+    # Both groups had room; each gets exactly 1 recovery word.
+    assert len(out[0]) == 3
+    assert len(out[1]) == 3
+    # Recovery lemmas present in result
+    recovery_ids = {99, 100, 101}
+    found = {w["lemma_id"] for g in out for w in g if w["lemma_id"] in recovery_ids}
+    assert len(found) == 2  # one per group, third recovery word unused

--- a/research/experiment-log.md
+++ b/research/experiment-log.md
@@ -4,6 +4,60 @@ Running lab notebook for Alif's learning algorithm. Each entry documents what ch
 
 ---
 
+## 2026-05-04: Backoff-aware multi-target — recovery via collateral coverage
+
+### What
+
+Replaces the planned C1 (blind retry on `batch_self_correct_empty`). Backed-off lemmas are now eligible for multi-target groups as collateral, capped at 1 per group of ≤4 healthy lemmas. Self-correct paths (batch + single-word fallback) still exclude backed-off lemmas — those are where they consistently fail. A successful multi-target generation auto-resets `generation_failed_count` via the existing `record_generation_result()` path.
+
+Implementation: `_augment_groups_with_recovery()` in `update_material.py` tops up under-sized groups with one backed-off lemma each, skipping any with same-root collisions. Recovery lemmas only get success recorded (no failure increments) so their backoff isn't pushed further out by piggy-back attempts.
+
+Bonus: fixed a `pipeline_stats.py` mislabel where the per-target-counts block read from `self_correct_returned` events but printed under "Multi-target path." Multi-target now has its own coverage stats (distinct targets, % covered) and the daily breakdown sums sentences from `multi_target_summary` rather than counting attempt events.
+
+### Why
+
+The handoff plan called for C1 — retry single-word self-correct on empty response. Investigating one cron cycle of multi-target Phase 1 data (after the manual 09:09 UTC trigger) revealed:
+
+- Multi-target Phase 1 hits **88% target coverage** (22/25 lemmas covered ≥1 sentence) and **45.9% post-quality acceptance** (17/37 sentences).
+- One of the handoff's "hard-core 5" failures (#2307) was covered TWICE as collateral in a `[1835, 2307, 632, 2982]` multi-target group, immediately resetting its `generation_failed_count` to 0.
+- Self-correct empties are deterministic budget-exhaust (30-73s elapsed, all `group_size=1`), not flakiness — a same-prompt retry hits the same wall.
+
+The "hard" lemmas aren't permanently hard. They fail in single-word fallback because the LLM has to weave a rare lemma into a sentence using only known-vocab. Bundled with 2-3 healthy peers in a multi-target group, the LLM picks the easiest combo to write naturally about, the rare lemma rides along as collateral, and quality review accepts the result.
+
+The original concern (commit 26bba5f) was that chronic failures crowded out viable lemmas in multi-target batches. The 1-per-group cap directly addresses that: groups remain ≥75% healthy.
+
+### Expected effect
+
+- Backoff list (currently 207 entries, growing ~3-4/hr) drains naturally as backed-off lemmas piggy-back on healthy cohorts.
+- Self-correct empty rate stays ~50% — this isn't trying to fix self-correct, just to route around it for chronic failures.
+- Multi-target coverage rate stays similar (88% in the one observed run) since the cap keeps groups majority-healthy.
+
+### How to verify
+
+- `pipeline_stats --days 7` over the next week. Watch backoff list size:
+  ```bash
+  ssh alif "cd /opt/alif/backend && PYTHONPATH=/opt/limbic .venv/bin/python3 -c 'import sqlite3, datetime; c=sqlite3.connect(\"data/alif.db\"); now=datetime.datetime.utcnow().isoformat(); n=c.execute(\"SELECT COUNT(*) FROM user_lemma_knowledge WHERE generation_backoff_until > ?\", (now,)).fetchone()[0]; print(n)'"
+  ```
+- Cron output should print `Including N backed-off lemmas as multi-target recovery (≤1/group)` when there are backoff entries.
+- Spot-check named recoveries: handoff's "hard-core 5" (#840, #2650, #2651, #582, #2307) — most should clear backoff over the next few cron cycles.
+
+### Decision rationale
+
+C1 (blind retry) was rejected before implementation. Reasoning: pipeline_stats showed self-correct empty rate at 53% with all empties from `group_size=1`, multi-target showed 88% coverage in one run. Retry on a path that's structurally weak just doubles spend on same-prompt failures.
+
+### Test plan
+
+`backend/tests/test_generation_backoff.py` extended with 4 unit tests for `_augment_groups_with_recovery`: full groups untouched, undersized groups topped up with 1 recovery word, root-collision recovery words skipped, distribution of recovery words across multiple groups (1 per group cap).
+
+### Guardrails preserved (CLAUDE.md Rule #14)
+
+- `same_lemma` rejection in `apply_corrections` untouched.
+- `lookup_lemma` not added to multi-target validator's target check (still exact match).
+- No auto-creation of lemmas anywhere.
+- `record_generation_result` policy: recovery lemmas only get success recorded; failures don't push backoff further.
+
+---
+
 ## 2026-05-04: Phase C1.5 — multi-target Phase 1 observability + Phase A measurements
 
 ### What


### PR DESCRIPTION
## Summary

Replaces the handoff's planned **C1 (blind retry on `batch_self_correct_empty`)**. After deploying PR #57's multi-target observability and triggering one manual cron, the data showed C1 was treating the wrong layer — hard-failure lemmas don't need retries, they need scaffold context.

**Multi-target Phase 1** (one cron, 09:09 UTC trigger): 88% target coverage (22/25 lemmas), 45.9% post-quality acceptance, 0 group failures. **#2307** — one of the handoff's named "hard-core 5" with 3 prior single-word empties — was covered twice as collateral in `[1835, 2307, 632, 2982]`, auto-resetting its `generation_failed_count` to 0.

**Self-correct empties are deterministic budget-exhaust**, not flakiness: 30-73s elapsed times, all `group_size=1`. Same prompt + same budget on retry would hit the same wall.

## Change

`update_material.py:step_backfill_sentences` now samples a few backed-off lemmas (cap = `len(words_needing) // 3`) and tops up under-sized multi-target groups with at most one each via the new `_augment_groups_with_recovery()` helper. Recovery lemmas only get success recorded — failures don't push backoff further out.

The original concern from commit 26bba5f (chronic failures crowding out viable lemmas) is addressed by the 1-per-group cap: groups remain ≥75% healthy.

Self-correct batch and single-word fallback paths are unchanged — they still exclude backed-off lemmas.

## Bonus fix: pipeline_stats.py mislabel

The per-target-counts block read from `self_correct_returned` events but printed under "Multi-target path." The previous "170% of returned" line was a smoking gun. Fixed:
- Multi-target section now has its own coverage stats (distinct targets, % covered) sourced from `multi_target_summary` + `multi_target_accepted` events.
- Daily breakdown sums `sentences_returned` and `accepted` from summaries instead of counting attempt events.
- Self-correct's per-target-counts block moved under the self-correct heading where it always belonged.

## Guardrails preserved (CLAUDE.md Rule #14)

- `same_lemma` rejection in `apply_corrections` untouched.
- `lookup_lemma` not added to multi-target validator's target check (still exact match).
- No auto-creation of lemmas anywhere.
- Per-iteration `db.commit()` discipline preserved (no new write-lock paths).

## Verification next 2-7 days

- `pipeline_stats --days 7` should show multi-target target coverage holding ~85-90% and self-correct empty rate roughly unchanged (~50%, since this isn't trying to fix self-correct).
- Backoff list size (currently ~207, growing ~3-4/hr) should stop growing and start draining as backed-off lemmas piggy-back on healthy cohorts.
- Spot-check named recoveries (#840, #2650, #2651) in the next ~10 cron cycles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)