### PR TITLE
Session quality: skip already-known reps, retry intro-ack, longer LLM sentences

### DIFF
--- a/backend/app/routers/review.py
+++ b/backend/app/routers/review.py
@@ -455,8 +455,16 @@ def acknowledge_experiment_intro(
     body: ExperimentIntroAckIn,
     db: Session = Depends(get_db),
 ):
-    """Acknowledge that an experiment intro card was shown."""
+    """Acknowledge that an experiment intro card was shown.
+
+    The intro_shown_at timestamp gates re-showing; a silent rollback would
+    cause the same intro to fire on the next session build (observed
+    2026-05-04 for lemma #2650 — 3 intros across 3 sessions). Retry on
+    OperationalError instead of swallowing it.
+    """
     from datetime import datetime
+    import time
+    from sqlalchemy.exc import OperationalError
     from app.models import UserLemmaKnowledge
 
     ulk = db.query(UserLemmaKnowledge).filter(
@@ -464,10 +472,25 @@ def acknowledge_experiment_intro(
     ).first()
     if ulk:
         ulk.experiment_intro_shown_at = datetime.utcnow()
-        try:
-            db.commit()
-        except Exception:
-            db.rollback()
+        for attempt in range(3):
+            try:
+                db.commit()
+                break
+            except OperationalError:
+                db.rollback()
+                if attempt == 2:
+                    logging.getLogger(__name__).warning(
+                        f"experiment_intro_shown_at failed to persist for lemma {body.lemma_id} "
+                        f"after 3 retries — intro may re-fire next session"
+                    )
+                    break
+                time.sleep(0.1 * (2 ** attempt))
+                # Re-attach the dirty change after rollback cleared the session
+                ulk = db.query(UserLemmaKnowledge).filter(
+                    UserLemmaKnowledge.lemma_id == body.lemma_id,
+                ).first()
+                if ulk:
+                    ulk.experiment_intro_shown_at = datetime.utcnow()
 
     log_interaction(
         event="experiment_intro_shown",

--- a/backend/app/services/sentence_selector.py
+++ b/backend/app/services/sentence_selector.py
@@ -44,8 +44,14 @@ from app.services.sentence_validator import (
 
 logger = logging.getLogger(__name__)
 
-# Acquisition repetition: each acquiring word should appear this many times in a session
-MIN_ACQUISITION_EXPOSURES = 4
+# Acquisition repetition: how many times an acquiring word should appear in a session.
+# Box 1 = encoding (first exposure), needs 4 reps to lay down memory.
+# Box 2 = consolidation (already encoded), 2 reps is enough — a single correct
+# review here already triggers Tier 1 graduation, so 4 reps wasted 2 cards on
+# words the learner had already mastered (data 2026-05-04).
+MIN_ACQUISITION_EXPOSURES = 4  # legacy alias for box 1 / fallback
+BOX1_MIN_EXPOSURES = 4
+BOX2_MIN_EXPOSURES = 2
 MAX_ACQUISITION_EXTRA_SLOTS = 15  # max extra cards beyond session limit for repetitions
 MAX_AUTO_INTRO_PER_SESSION = 5  # cap new words per single auto-intro call
 AUTO_INTRO_ACCURACY_FLOOR = 0.70  # pause introduction if recent accuracy below this
@@ -1161,28 +1167,39 @@ def build_session(
     # Track pre-repetition count so on-demand generation uses the right budget
     base_item_count = len(selected)
 
-    # 3b. Within-session repetition for acquisition words
-    # Target MIN_ACQUISITION_EXPOSURES (3-4) per acquiring word
+    # 3b. Within-session repetition for acquisition words.
+    # Per-box target: box 1 (encoding) keeps 4 reps; box 2 (consolidation)
+    # gets 2. A single correct rating in box 2 already triggers Tier 1
+    # graduation, so further reps were wasted on already-mastered words.
     acquiring_word_counts: dict[int, int] = {}
+    acquiring_word_targets: dict[int, int] = {}
     for c in selected:
         for w in c.words_meta:
             if w.lemma_id and w.lemma_id in due_lemma_ids:
                 k = knowledge_by_id.get(w.lemma_id)
                 if k and k.knowledge_state == "acquiring":
                     acquiring_word_counts[w.lemma_id] = acquiring_word_counts.get(w.lemma_id, 0) + 1
+                    if w.lemma_id not in acquiring_word_targets:
+                        box = k.acquisition_box or 1
+                        acquiring_word_targets[w.lemma_id] = (
+                            BOX2_MIN_EXPOSURES if box >= 2 else BOX1_MIN_EXPOSURES
+                        )
 
     # Allow session to grow beyond limit to fit acquisition repetitions
     acq_extra_slots = sum(
-        max(0, MIN_ACQUISITION_EXPOSURES - count)
-        for count in acquiring_word_counts.values()
+        max(0, acquiring_word_targets.get(lid, BOX1_MIN_EXPOSURES) - count)
+        for lid, count in acquiring_word_counts.items()
     )
     effective_limit = limit + min(acq_extra_slots, MAX_ACQUISITION_EXTRA_SLOTS)
 
     selected_ids = {c.sentence_id for c in selected}
-    for target_count in range(2, MIN_ACQUISITION_EXPOSURES + 1):
+    max_target = max(acquiring_word_targets.values(), default=BOX1_MIN_EXPOSURES)
+    for target_count in range(2, max_target + 1):
         for acq_lid, count in list(acquiring_word_counts.items()):
             if len(selected) >= effective_limit:
                 break
+            if count >= acquiring_word_targets.get(acq_lid, BOX1_MIN_EXPOSURES):
+                continue
             if count >= target_count:
                 continue
             extra = None

--- a/backend/app/services/sentence_self_correct.py
+++ b/backend/app/services/sentence_self_correct.py
@@ -71,7 +71,7 @@ Tools available in the work_dir:
 JSON with valid, target_found, unknown_words, known_words, function_words, issues.
 
 Per-sentence workflow:
-  1. Draft a 4-10 word Arabic sentence using the target + vocabulary words.
+  1. Draft a 7-14 word Arabic sentence using the target + vocabulary words.
   2. Validate it.
   3. On unknown_words: REPLACE each offending word with a word from \
 vocab_prompt.txt — surgical swaps, not full rewrites — and re-validate.
@@ -88,6 +88,14 @@ Rules:
 - No anaphor referring to unstated context. No continuations starting \
 with و/ف/ثم.
 - Vary sentence structures across the batch (VSO/SVO/idafa/nominal).
+- Aim for ≥8 words by default. Use real Arabic constructions to get there \
+naturally: idafa chains (مدير الشركة الجديد), prepositional phrases \
+(في الصباح الباكر), relative clauses (الذي/التي), modifying adjectives, \
+and specific objects rather than bare ones. Reject your own draft if it \
+reads as a 4-word skeleton; rewrite with more anchoring detail.
+- Vary the agent across sentences in a batch — don't reuse الطبيب, الطفل, \
+الرجل, المعلم more than once per batch. Reach for less generic subjects \
+(scholars, travelers, named professions, time-of-day phrases as topic).
 
 When you have the requested validated count, return the JSON. The `edits` \
 field per sentence = number of validator-driven word swaps before it passed."""
@@ -392,11 +400,13 @@ def generate_sentences_self_correct(
 {target_word} ({target_translation}).
 {example_block}
 1. Read {work_dir}/vocab_prompt.txt once.
-2. For each sentence: draft, validate via \
+2. For each sentence: draft (target ≥8 words, use idafa chains / prep \
+phrases / relative clauses to add detail naturally), validate via \
 `python3 {work_dir}/validator.py "<arabic>" "{target_word}"`, surgically \
 swap each unknown_word with a vocab word and re-validate. Drop after 4 \
 failed edits.
-3. Vary sentence structures across the batch.
+3. Vary sentence structures and agents across the batch — don't reuse the \
+same subject noun (الطبيب, الطفل, etc.) more than once.
 4. Return the JSON when {needed} sentences are validated. Set `edits` per \
 sentence = number of validator-driven word swaps before it passed."""
 
@@ -507,7 +517,7 @@ example_ar, example_en} you must write sentences for).
 JSON with valid, target_found, unknown_words, known_words, function_words, issues.
 
 Per-target workflow:
-  1. Draft a 4-10 word Arabic sentence using the target + vocabulary words.
+  1. Draft a 7-14 word Arabic sentence using the target + vocabulary words.
   2. Validate it.
   3. On unknown_words: REPLACE each offending word with a word from \
 vocab_prompt.txt — surgical swaps, not full rewrites — and re-validate.
@@ -527,6 +537,15 @@ Rules:
 - No anaphor referring to unstated context. No continuations starting \
 with و/ف/ثم.
 - Vary sentence structures across targets (VSO/SVO/idafa/nominal).
+- Aim for ≥8 words by default. Reach length naturally with idafa chains \
+(مدير الشركة الجديد), prepositional phrases (في الصباح الباكر), relative \
+clauses (الذي/التي), modifying adjectives, and concrete objects — not by \
+padding with empty filler. Reject your own draft if it reads as a 4-word \
+skeleton.
+- Across the batch, vary the agent. Do not reuse الطبيب, الطفل, الرجل, \
+المعلم more than once per batch. Reach for less generic subjects (scholars, \
+travelers, named professions, time-of-day phrases as topic, animals, \
+artifacts).
 - The sentence MUST sound like something a literate Arabic speaker would \
 actually say. Reject your own draft if the topic combination is bizarre, \
 forced, or non-sequitur (e.g. "He has an allergy to prayer"). Pick a \
@@ -758,12 +777,16 @@ EACH of {len(targets)} target words listed in {work_dir}/targets.json.
 Workflow:
 1. Read {work_dir}/vocab_prompt.txt and {work_dir}/targets.json once.
 2. For EACH target in targets.json (process them sequentially):
-   a. Draft a sentence featuring target_word.
+   a. Draft a sentence featuring target_word. Aim for ≥8 words; reach length \
+naturally with idafa chains, prepositional phrases, relative clauses, or \
+modifying adjectives — not with empty filler.
    b. Validate via `python3 {work_dir}/validator.py "<arabic>" "<target_bare>"`.
    c. On unknown_words, surgically swap each offending word with a vocab \
 word and re-validate. Drop after 4 failed edits; try a fresh sentence.
    d. Stop once {needed_per_target} validated sentences exist for this target.
-3. Vary sentence structures across the batch (VSO/SVO/idafa/nominal).
+3. Vary sentence structures across the batch (VSO/SVO/idafa/nominal). Vary \
+the agent: don't reuse الطبيب, الطفل, الرجل, المعلم more than once across \
+the whole batch — reach for less generic subjects.
 4. After ALL targets, return JSON: {{"results": [{{"target_lemma_id": N, \
 "sentences": [{{"arabic": "...", "english": "...", "transliteration": "...", \
 "edits": K}}, ...]}}, ...]}}.

--- a/frontend/app/index.tsx
+++ b/frontend/app/index.tsx
@@ -320,6 +320,11 @@ export function ReviewScreen({ fixedMode }: { fixedMode: ReviewMode }) {
   }, []);
 
   // Auto-skip intro cards for words already answered correctly in this session
+  // and auto-skip duplicate sentence cards whose primary lemma the learner
+  // already nailed in this session. One correct exposure is enough; further
+  // reps in the same session are massed practice with diminishing return.
+  // If the first exposure failed, all queued reps remain so the learner gets
+  // the intended re-teaching loop.
   useEffect(() => {
     if (!sentenceSession || sessionSlots.length === 0) return;
     const slot = sessionSlots[cardIndex];
@@ -328,13 +333,22 @@ export function ReviewScreen({ fixedMode }: { fixedMode: ReviewMode }) {
       if (card) {
         const outcome = wordOutcomes.get(card.lemma_id);
         if (outcome && !outcome.failed) {
-          // Word already answered correctly — skip intro, still mark as shown
           acknowledgeExperimentIntro(card.lemma_id, sentenceSession.session_id).catch(() => {});
           if (cardIndex + 1 < sessionSlots.length) {
             setCardIndex(cardIndex + 1);
           }
           return;
         }
+      }
+    }
+    if (slot?.type === "sentence" && sentenceSession.items[slot.itemIndex]) {
+      const item = sentenceSession.items[slot.itemIndex];
+      const outcome = wordOutcomes.get(item.primary_lemma_id);
+      if (outcome && !outcome.failed) {
+        if (cardIndex + 1 < sessionSlots.length) {
+          setCardIndex(cardIndex + 1);
+        }
+        return;
       }
     }
   }, [cardIndex, sessionSlots, experimentIntroCards, wordOutcomes, sentenceSession]);
@@ -2452,7 +2466,9 @@ function SentenceReadingCard({
             : isConfused
               ? styles.confusedWord
               : undefined;
-          const showDiacritics = showAnswer || tashkeelMode === 1 || (tashkeelMode === 0 && word.show_tashkeel !== false);
+          const showDiacritics =
+            tashkeelMode === 1 ||
+            (tashkeelMode === 0 && (showAnswer || word.show_tashkeel !== false));
           return (
             <Text key={`t-${i}`}>
               {i > 0 && " "}
@@ -2579,7 +2595,9 @@ function SentenceListeningCard({
             : isConfused
               ? styles.confusedWord
               : undefined;
-          const showDiacritics = showAnswer || tashkeelMode === 1 || (tashkeelMode === 0 && word.show_tashkeel !== false);
+          const showDiacritics =
+            tashkeelMode === 1 ||
+            (tashkeelMode === 0 && (showAnswer || word.show_tashkeel !== false));
           return (
             <Text key={`t-${i}`}>
               {i > 0 && " "}
@@ -3526,7 +3544,7 @@ const styles = StyleSheet.create({
   },
   cardToggles: {
     flexDirection: "row" as const,
-    justifyContent: "space-between" as const,
+    justifyContent: "flex-end" as const,
     width: "100%",
     marginTop: 10,
     marginBottom: 2,


### PR DESCRIPTION
## Summary

Four session-quality fixes from 2026-05-04 session analysis (835 events, 169 reviews):

- **Box-2 acquisition reps reduced from 4 → 2.** Box-2 (consolidation) needs only 2 exposures because a single correct review already triggers Tier 1 graduation. Today's data showed several box-2 lemmas getting 4 reps and graduating mid-session anyway.
- **Frontend auto-skips duplicate sentence cards** for any lemma already answered correctly in the current session. Failed reviews keep the full re-teaching loop (intro + reps next session). Mirrors the existing intro-card auto-skip.
- **`acknowledge_experiment_intro` retries on lock** with exponential backoff (100ms / 200ms / 400ms) instead of swallowing `OperationalError`. Lemma #2650 got 3 intros across 3 sessions today because the silent rollback masked the contention.
- **LLM sentence prompts target ≥8 words** via idafa chains, prepositional phrases, relative clauses, and concrete objects — not by padding. Also forbids reusing the same agent noun (الطبيب / الطفل / الرجل / المعلم) more than once per batch. Was producing 4-6 word skeletons on repeat.

## Files

- `backend/app/services/sentence_selector.py` — split `MIN_ACQUISITION_EXPOSURES` into `BOX1_MIN_EXPOSURES=4` / `BOX2_MIN_EXPOSURES=2`; per-lemma target lookup in the repetition loop.
- `backend/app/routers/review.py` — retry-on-lock pattern for `acknowledge_experiment_intro`.
- `backend/app/services/sentence_self_correct.py` — system + per-call prompts updated for both single-target and batch flows.
- `frontend/app/index.tsx` — extended the intro auto-skip useEffect to cover sentence cards.