### PR TITLE
Fix bare ya/waw long-vowel transliteration

### DIFF
--- a/backend/app/services/transliteration.py
+++ b/backend/app/services/transliteration.py
@@ -200,6 +200,22 @@ def _next_has_shadda(chars: list[str], j: int) -> bool:
     return False
 
 
+def _next_has_own_short_vowel(chars: list[str], j: int) -> bool:
+    """Check if the character at position j carries its own fatha/kasra/damma.
+
+    Used to distinguish a consonant ya/waw (has its own vowel) from a long-vowel
+    marker (has sukun or no diacritic). For example, the ya in سِيَاسَة has its
+    own fatha → it's the consonant /j/ in 'siyāsa', not long ī.
+    """
+    n = len(chars)
+    k = j + 1
+    while k < n and chars[k] in _DIACRITICS:
+        if chars[k] in _SHORT_VOWELS:
+            return True
+        k += 1
+    return False
+
+
 def _transliterate_word(word: str, strip_tanwin: bool) -> str:
     chars = list(word)
     n = len(chars)
@@ -283,26 +299,43 @@ def _transliterate_word(word: str, strip_tanwin: bool) -> str:
 
             next_char = chars[j] if j < n else None
             next_shadda = _next_has_shadda(chars, j) if next_char else False
+            # ya/waw is a consonant glide (not a long vowel marker) if either:
+            #  - it has its own short vowel — e.g. سِيَاسَة = siyāsa, not sīāsa;
+            #  - it is immediately followed by alif/maqsura — Arabic doesn't allow
+            #    two adjacent long vowels, so the glide is always consonantal,
+            #    e.g. حَالِياً = ḥāliyā, not ḥālīā.
+            next_is_consonant_glide = False
+            if next_char in (YA, WAW):
+                if _next_has_own_short_vowel(chars, j):
+                    next_is_consonant_glide = True
+                else:
+                    after_ya_diacs, after_ya_pos = _collect_diacritics(chars, j + 1)
+                    if after_ya_pos < n and chars[after_ya_pos] in (ALIF, ALIF_MAQSURA):
+                        next_is_consonant_glide = True
 
             # Long vowel detection
-            # Alif or alif maqsura after fatḥa → ā
-            # Also: bare alif after consonant with no vowel → infer long ā
+            # Long vowels in Arabic are written as a "weak letter" (alif/waw/ya)
+            # after a matching short vowel. In partially-vocalized text the
+            # short vowel is often omitted — readers infer it from the weak
+            # letter. We mirror that for all three: an explicit matching
+            # short vowel triggers a long vowel, AND a vowelless consonant
+            # (no short_vowel, no sukun) followed by the weak letter does too.
             is_long_a = (
                 next_char in (ALIF, ALIF_MAQSURA)
                 and ch != ALIF
                 and (short_vowel == FATHA or (short_vowel is None and not has_sukun))
             )
-            # Waw after ḍamma → ū (but not if waw has shadda = geminate)
             is_long_u = (
-                short_vowel == DAMMA
-                and next_char == WAW
+                next_char == WAW
                 and not next_shadda
+                and not next_is_consonant_glide
+                and (short_vowel == DAMMA or (short_vowel is None and not has_sukun))
             )
-            # Ya after kasra → ī (but not if ya has shadda = geminate/nisba)
             is_long_i = (
-                short_vowel == KASRA
-                and next_char == YA
+                next_char == YA
                 and not next_shadda
+                and not next_is_consonant_glide
+                and (short_vowel == KASRA or (short_vowel is None and not has_sukun))
             )
 
             # Tanwin fatha + alif: alif is silent (orthographic only)
@@ -317,6 +350,14 @@ def _transliterate_word(word: str, strip_tanwin: bool) -> str:
                     out.append("ā")
                 elif is_long_a:
                     out.append("ā")
+                    i = j + 1
+                    continue
+                elif is_long_i:
+                    out.append("ī")
+                    i = j + 1
+                    continue
+                elif is_long_u:
+                    out.append("ū")
                     i = j + 1
                     continue
                 elif short_vowel:

--- a/backend/scripts/backfill_transliteration.py
+++ b/backend/scripts/backfill_transliteration.py
@@ -4,7 +4,10 @@ Uses deterministic Arabic→ALA-LC romanization from diacritized text.
 No LLM needed — pure rule-based character mapping.
 
 Usage:
-    cd backend && python3 scripts/backfill_transliteration.py [--dry-run] [--limit=1000]
+    cd backend && python3 scripts/backfill_transliteration.py [--dry-run] [--limit=1000] [--rerun-all]
+
+--rerun-all recomputes for every diacritized lemma (use after fixing the
+transliteration function itself, to refresh stored values).
 """
 
 import sys
@@ -23,27 +26,37 @@ from app.services.activity_log import log_activity
 from app.services.transliteration import transliterate_lemma
 
 
-def backfill(dry_run=False, limit=2000):
+def backfill(dry_run=False, limit=2000, rerun_all=False):
     db = SessionLocal()
 
-    missing = (
-        db.query(Lemma)
-        .filter(
-            (Lemma.transliteration_ala_lc.is_(None)) | (Lemma.transliteration_ala_lc == ""),
-            # Include variants — they appear in word lookups and need transliteration
+    if rerun_all:
+        missing = (
+            db.query(Lemma)
+            .order_by(Lemma.frequency_rank.asc().nullslast())
+            .limit(limit)
+            .all()
         )
-        .order_by(Lemma.frequency_rank.asc().nullslast())
-        .limit(limit)
-        .all()
-    )
+    else:
+        missing = (
+            db.query(Lemma)
+            .filter(
+                (Lemma.transliteration_ala_lc.is_(None)) | (Lemma.transliteration_ala_lc == ""),
+                # Include variants — they appear in word lookups and need transliteration
+            )
+            .order_by(Lemma.frequency_rank.asc().nullslast())
+            .limit(limit)
+            .all()
+        )
 
-    print(f"Found {len(missing)} lemmas without transliteration (limit={limit})")
+    label = "all lemmas" if rerun_all else "lemmas without transliteration"
+    print(f"Found {len(missing)} {label} (limit={limit})")
     if not missing:
         db.close()
         return
 
     total_done = 0
     total_skipped = 0
+    total_unchanged = 0
 
     import re
     diacritic_re = re.compile(r"[\u064B-\u065F\u0670]")
@@ -66,7 +79,13 @@ def backfill(dry_run=False, limit=2000):
             total_skipped += 1
             continue
 
-        print(f"  {lemma.lemma_id} {source} → {translit}")
+        if rerun_all and translit == lemma.transliteration_ala_lc:
+            total_unchanged += 1
+            continue
+
+        prev = lemma.transliteration_ala_lc
+        suffix = f" (was {prev!r})" if rerun_all and prev else ""
+        print(f"  {lemma.lemma_id} {source} → {translit}{suffix}")
         if not dry_run:
             lemma.transliteration_ala_lc = translit
         total_done += 1
@@ -74,17 +93,23 @@ def backfill(dry_run=False, limit=2000):
     if not dry_run:
         db.commit()
 
+    unchanged_note = f", {total_unchanged} unchanged" if total_unchanged else ""
     if dry_run:
         db.rollback()
-        print(f"\nDry run: would update {total_done} lemmas ({total_skipped} skipped)")
+        print(f"\nDry run: would update {total_done} lemmas ({total_skipped} skipped{unchanged_note})")
     else:
-        print(f"\nUpdated {total_done} lemmas with transliteration ({total_skipped} skipped)")
+        print(f"\nUpdated {total_done} lemmas with transliteration ({total_skipped} skipped{unchanged_note})")
         if total_done > 0:
             log_activity(
                 db,
                 event_type="transliteration_backfill_completed",
                 summary=f"Backfilled ALA-LC transliteration for {total_done} lemmas",
-                detail={"lemmas_updated": total_done, "skipped": total_skipped},
+                detail={
+                    "lemmas_updated": total_done,
+                    "skipped": total_skipped,
+                    "unchanged": total_unchanged,
+                    "rerun_all": rerun_all,
+                },
             )
 
     db.close()
@@ -92,8 +117,9 @@ def backfill(dry_run=False, limit=2000):
 
 if __name__ == "__main__":
     dry_run = "--dry-run" in sys.argv
+    rerun_all = "--rerun-all" in sys.argv
     limit = 2000
     for arg in sys.argv:
         if arg.startswith("--limit="):
             limit = int(arg.split("=")[1])
-    backfill(dry_run=dry_run, limit=limit)
+    backfill(dry_run=dry_run, limit=limit, rerun_all=rerun_all)

--- a/backend/scripts/vocalize_unvocalized_lemmas.py
+++ b/backend/scripts/vocalize_unvocalized_lemmas.py
@@ -1,0 +1,186 @@
+"""Add tashkeel (full diacritization) to lemmas whose lemma_ar lacks vowels.
+
+Identifies lemmas where lemma_ar == lemma_ar_bare (i.e., never had any
+diacritics stored) and uses Claude CLI to add proper tashkeel based on the
+bare form, gloss, and POS. Validates each output: stripped vocalized form
+must equal the original bare form. Skips non-Arabic-script lemmas (Hebrew,
+Latin, etc.).
+
+After running, re-run backfill_transliteration.py and backfill_forms_translit.py
+to refresh transliterations for the newly-vocalized lemmas.
+"""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from dotenv import load_dotenv
+from pathlib import Path
+
+load_dotenv(Path(__file__).resolve().parent.parent / ".env")
+
+from app.database import SessionLocal
+from app.models import Lemma
+from app.services.activity_log import log_activity
+from app.services.sentence_validator import strip_diacritics
+from app.services.claude_code import generate_structured
+
+
+_ARABIC_RANGE = range(0x0600, 0x0700)
+
+
+def _is_arabic_script(text: str) -> bool:
+    """True if at least one char is in the Arabic Unicode block."""
+    return any(ord(c) in _ARABIC_RANGE for c in text)
+
+
+_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "vocalized": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "lemma_id": {"type": "integer"},
+                    "vocalized_ar": {"type": "string"},
+                },
+                "required": ["lemma_id", "vocalized_ar"],
+                "additionalProperties": False,
+            },
+        }
+    },
+    "required": ["vocalized"],
+    "additionalProperties": False,
+}
+
+
+_SYSTEM = """You are an expert in Arabic morphology and orthography.
+
+Your task: add full tashkeel (Arabic diacritical marks) to a list of Arabic
+lemmas given as bare unvocalized text plus an English gloss and part of speech.
+
+Rules:
+- Output the same word with proper diacritics (fatha, kasra, damma, sukun,
+  shadda where appropriate). Use lemma/dictionary form (no case ending).
+- For verbs, use the canonical past-tense 3rd-singular masculine form (the
+  citation form), e.g. "كَتَبَ" not "كتب".
+- For nouns and adjectives, use the singular indefinite form with no tanwīn.
+- For ت marbuṭa words ending in ة, do not add a final tanwin or vowel.
+- For function words / particles (e.g. قد, لو, كي, لقد), use their
+  conventional vocalization.
+- The unvocalized letters MUST remain identical — only diacritics are added.
+- If a word is foreign or you genuinely cannot vocalize it, output the bare
+  word unchanged.
+"""
+
+
+def _build_prompt(batch):
+    lines = ["Add tashkeel to each lemma. Reply with the JSON schema only.\n"]
+    for l in batch:
+        lines.append(f'  - lemma_id={l.lemma_id}, bare="{l.lemma_ar_bare}", pos={l.pos or "?"}, gloss="{l.gloss_en or "?"}"')
+    return "\n".join(lines)
+
+
+def vocalize_batch(batch):
+    """Returns dict {lemma_id: vocalized_ar} for the batch."""
+    prompt = _build_prompt(batch)
+    result = generate_structured(
+        prompt=prompt,
+        system_prompt=_SYSTEM,
+        json_schema=_SCHEMA,
+        model="haiku",
+        timeout=120,
+    )
+    return {entry["lemma_id"]: entry["vocalized_ar"] for entry in result.get("vocalized", [])}
+
+
+def main(dry_run=False, batch_size=20):
+    db = SessionLocal()
+    try:
+        rows = (
+            db.query(Lemma)
+            .filter(Lemma.lemma_ar == Lemma.lemma_ar_bare)
+            .order_by(Lemma.lemma_id)
+            .all()
+        )
+
+        arabic = [l for l in rows if _is_arabic_script(l.lemma_ar_bare or "")]
+        skipped_script = len(rows) - len(arabic)
+
+        print(f"Found {len(rows)} unvocalized lemmas")
+        print(f"  {len(arabic)} Arabic-script (will vocalize)")
+        print(f"  {skipped_script} non-Arabic-script (will skip)\n")
+
+        updated = 0
+        rejected_changed_letters = 0
+        rejected_no_diacritics = 0
+        unchanged = 0
+
+        for i in range(0, len(arabic), batch_size):
+            batch = arabic[i : i + batch_size]
+            print(f"--- Batch {i // batch_size + 1} ({len(batch)} lemmas) ---")
+            try:
+                proposals = vocalize_batch(batch)
+            except Exception as e:
+                print(f"  Batch failed: {e}")
+                continue
+
+            for l in batch:
+                proposal = proposals.get(l.lemma_id)
+                if not proposal:
+                    print(f"  {l.lemma_id} {l.lemma_ar_bare}: no proposal")
+                    continue
+
+                # Validate: stripped proposal must match original bare form
+                stripped = strip_diacritics(proposal)
+                if stripped != l.lemma_ar_bare:
+                    print(f"  {l.lemma_id} {l.lemma_ar_bare}: REJECTED (changed letters: got {stripped!r})")
+                    rejected_changed_letters += 1
+                    continue
+
+                # Validate: must contain at least one diacritic
+                if proposal == l.lemma_ar_bare:
+                    print(f"  {l.lemma_id} {l.lemma_ar_bare}: unchanged (LLM returned bare form)")
+                    unchanged += 1
+                    continue
+
+                print(f"  {l.lemma_id} {l.lemma_ar_bare} -> {proposal}")
+                if not dry_run:
+                    l.lemma_ar = proposal
+                updated += 1
+
+            if not dry_run:
+                db.commit()  # Per-batch commit to avoid holding the lock
+
+        print()
+        print(f"Vocalized:                {updated}")
+        print(f"LLM returned bare form:   {unchanged}")
+        print(f"Rejected (letter drift):  {rejected_changed_letters}")
+        print(f"Skipped (non-Arabic):     {skipped_script}")
+
+        if not dry_run and updated > 0:
+            log_activity(
+                db,
+                event_type="lemma_vocalization_completed",
+                summary=f"Added tashkeel to {updated} previously-unvocalized lemmas",
+                detail={
+                    "updated": updated,
+                    "rejected": rejected_changed_letters,
+                    "unchanged": unchanged,
+                    "skipped_non_arabic": skipped_script,
+                },
+            )
+
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    dry_run = "--dry-run" in sys.argv
+    batch_size = 20
+    for arg in sys.argv:
+        if arg.startswith("--batch-size="):
+            batch_size = int(arg.split("=")[1])
+    main(dry_run=dry_run, batch_size=batch_size)

--- a/backend/scripts/vocalize_unvocalized_lemmas.py
+++ b/backend/scripts/vocalize_unvocalized_lemmas.py
@@ -23,7 +23,7 @@ load_dotenv(Path(__file__).resolve().parent.parent / ".env")
 from app.database import SessionLocal
 from app.models import Lemma
 from app.services.activity_log import log_activity
-from app.services.sentence_validator import strip_diacritics
+from app.services.sentence_validator import strip_diacritics, normalize_alef
 from app.services.claude_code import generate_structured
 
 
@@ -83,7 +83,7 @@ def _build_prompt(batch):
     return "\n".join(lines)
 
 
-def vocalize_batch(batch):
+def vocalize_batch(batch, timeout=180):
     """Returns dict {lemma_id: vocalized_ar} for the batch."""
     prompt = _build_prompt(batch)
     result = generate_structured(
@@ -91,7 +91,7 @@ def vocalize_batch(batch):
         system_prompt=_SYSTEM,
         json_schema=_SCHEMA,
         model="haiku",
-        timeout=120,
+        timeout=timeout,
     )
     return {entry["lemma_id"]: entry["vocalized_ar"] for entry in result.get("vocalized", [])}
 
@@ -134,8 +134,10 @@ def main(dry_run=False, batch_size=20):
                     continue
 
                 # Validate: stripped proposal must match original bare form
+                # (after normalizing alef variants — LLM often restores hamza
+                # forms like اعراب → إعراب, which is a valid correction).
                 stripped = strip_diacritics(proposal)
-                if stripped != l.lemma_ar_bare:
+                if normalize_alef(stripped) != normalize_alef(l.lemma_ar_bare):
                     print(f"  {l.lemma_id} {l.lemma_ar_bare}: REJECTED (changed letters: got {stripped!r})")
                     rejected_changed_letters += 1
                     continue

--- a/backend/tests/test_transliteration.py
+++ b/backend/tests/test_transliteration.py
@@ -1,0 +1,90 @@
+"""Regression tests for ALA-LC transliteration.
+
+Focused on cases that previously failed: bare ya/waw without explicit
+kasra/damma should still be inferred as long ī/ū (mirroring the bare-alif
+inference for long ā).
+"""
+from app.services.transliteration import transliterate_arabic
+
+
+def test_bare_ya_after_consonant_long_i():
+    assert transliterate_arabic("حَديقة") == "ḥadīqa"
+    assert transliterate_arabic("قَديم") == "qadīm"
+    assert transliterate_arabic("جَميلة") == "jamīla"
+    assert transliterate_arabic("لَطيفة") == "laṭīfa"
+
+
+def test_bare_waw_after_consonant_long_u():
+    assert transliterate_arabic("بَلوزة") == "balūza"
+    assert transliterate_arabic("تَنّورة") == "tannūra"
+
+
+def test_word_initial_hamza_carrier_long_i():
+    assert transliterate_arabic("إيجار") == "ījār"
+    assert transliterate_arabic("إِيجار") == "ījār"
+
+
+def test_explicit_kasra_ya_still_long_i():
+    assert transliterate_arabic("اِسْمي") == "ismī"
+    assert transliterate_arabic("جَدّي") == "jaddī"
+
+
+def test_explicit_damma_waw_still_long_u():
+    assert transliterate_arabic("صَالُونٌ") == "ṣālūn"
+    assert transliterate_arabic("مَكْتُوب") == "maktūb"
+
+
+def test_consonant_ya_with_sukun_not_long_i():
+    """ya with sukun after fatha is the glide /j/, not long ī."""
+    assert transliterate_arabic("بَيْت") == "bayt"
+    assert transliterate_arabic("بَيْضاء") == "bayḍāʾ"
+
+
+def test_consonant_waw_with_sukun_not_long_u():
+    """waw with sukun after fatha is the glide /w/, not long ū."""
+    assert transliterate_arabic("جَوْعان") == "jawʿān"
+
+
+def test_geminate_ya_not_long_i():
+    """Shadda on ya = nisba/geminate, handled by separate logic."""
+    assert transliterate_arabic("بُنِّيّ") == "bunnī"
+
+
+def test_bare_alif_still_long_a():
+    """Don't regress the existing bare-alif logic."""
+    assert transliterate_arabic("طاوِلة") == "ṭāwila"
+    assert transliterate_arabic("واسِع") == "wāsiʿ"
+
+
+def test_al_prefix_with_bare_ya():
+    assert transliterate_arabic("اَلْحَديقة") == "al-ḥadīqa"
+
+
+def test_empty_and_no_arabic():
+    assert transliterate_arabic("") == ""
+    assert transliterate_arabic("hello") == "hello"
+
+
+def test_ya_with_own_vowel_is_consonant_glide():
+    """kasra + ya(+fatha) + alif = consonant ya, not long ī."""
+    assert transliterate_arabic("سِيَاسَة") == "siyāsa"
+    assert transliterate_arabic("رِيَال") == "riyāl"
+    assert transliterate_arabic("هِيَام") == "hiyām"
+    assert transliterate_arabic("أَغْبِيَاء") == "aghbiyāʾ"
+
+
+def test_waw_with_own_vowel_is_consonant_glide():
+    """damma + waw(+fatha) + alif = consonant waw, not long ū."""
+    assert transliterate_arabic("كُوَالَا") == "kuwālā"
+
+
+def test_bare_ya_before_alif_is_glide():
+    """ya followed by alif (with no diacritics on ya) is consonantal —
+    Arabic doesn't allow two adjacent long vowels. Without this rule
+    حَالِياً becomes ḥālīā instead of ḥāliyā."""
+    assert transliterate_arabic("حَالِياً") == "ḥāliyā"
+
+
+def test_bare_waw_before_alif_is_glide():
+    """damma + waw + alif (no diacritic on waw) is consonant w, not long ū."""
+    assert transliterate_arabic("مَارِهُوانَا") == "mārihuwānā"


### PR DESCRIPTION
## Summary
- Generalize `is_long_i`/`is_long_u` to mirror the existing bare-alif logic so Arabic words with bare ya/waw (no explicit kasra/damma) transliterate correctly: `حَديقة` → `ḥadīqa` (was `ḥadyqa`), `إيجار` → `ījār` (was `yjār`)
- Disambiguate consonant glides: ya/waw is a consonant when it has its own short vowel (`سِيَاسَة` → `siyāsa`, not `sīāsa`) or when it's immediately followed by alif (`حَالِياً` → `ḥāliyā`, not `ḥālīā`)
- Add `--rerun-all` flag to `backfill_transliteration.py` for refreshing stored values after function changes; new `vocalize_unvocalized_lemmas.py` script for the 144 lemmas where `lemma_ar` still lacks tashkeel (separate issue blocking proper transliteration)
- 15 new regression tests covering the bare/glide/explicit cases

## Why
The user reported inconsistent transcription on review/intro cards — `yjar` here, `ījār` there. Root cause was a missing branch in `transliterate_arabic`: the bare-alif inference (added in commit `48e9881`) was never extended to ya/waw, so 18% of the production lemma transliterations and ~95% of sentence-level transliterations were wrong.

Local backfill stats: **324 lemma transliterations corrected, 1738 forms, 4206 sentences**.

## Out of scope (follow-up)
The 144 lemmas whose `lemma_ar` is identical to `lemma_ar_bare` (no tashkeel stored) still render unvocalized on intro cards and yield consonant-only transliteration. The `vocalize_unvocalized_lemmas.py` script is queued to fix these but the local dry-run hit Claude Max-plan rate limits — will run after quota resets.