### PR TITLE
Show daily per-slot throughput in acquisition pipeline

### DIFF
--- a/backend/app/routers/stats.py
+++ b/backend/app/routers/stats.py
@@ -8,7 +8,7 @@ from collections import Counter
 from app.database import get_db
 from app.models import (
     Lemma, UserLemmaKnowledge, ReviewLog, Root,
-    SentenceReviewLog, SentenceWord, PipelineSnapshot,
+    SentenceReviewLog, SentenceWord,
 )
 from app.schemas import (
     StatsOut, DailyStatsPoint, LearningPaceOut,
@@ -1107,7 +1107,10 @@ def _get_acquisition_pipeline(db: Session) -> AcquisitionPipeline:
             if acq_due <= now:
                 due_per_box[box] += 1
 
+    today_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
+    seven_day_start = today_start - timedelta(days=6)  # inclusive of today
     cutoff_7d = now - timedelta(days=7)
+
     grad_rows = (
         db.query(
             UserLemmaKnowledge.lemma_id,
@@ -1125,83 +1128,95 @@ def _get_acquisition_pipeline(db: Session) -> AcquisitionPipeline:
         .all()
     )
 
-    # Build flow history: entries and graduations per day for last 7 days
-    flow_days = []
+    # Per-day per-slot throughput: derived from ReviewLog box transitions +
+    # ULK entered_acquiring_at (new arrivals) + ULK graduated_at (exits).
+    # Replaces the old PipelineSnapshot-based delta, which froze at first
+    # endpoint hit each day and made the page feel static.
+    flow: dict[str, dict] = {}
     for i in range(6, -1, -1):
-        day_start = (now - timedelta(days=i)).replace(
-            hour=0, minute=0, second=0, microsecond=0
-        )
-        day_str = day_start.strftime("%m-%d")
-        flow_days.append({"date": day_str, "entered": 0, "graduated": 0})
+        day = today_start - timedelta(days=i)
+        flow[day.strftime("%Y-%m-%d")] = {
+            "date": day.strftime("%m-%d"),
+            "entered": 0,        # new acquiring entries (via entered_acquiring_at)
+            "box_1_in": 0,       # arrivals at box 1: new entries + lapses back
+            "box_2_in": 0,       # promotions box 1 -> 2
+            "box_3_in": 0,       # promotions box 2 -> 3
+            "graduated": 0,      # exits from box 3 -> known
+        }
 
-    # Count entries per day (using entered_acquiring_at)
-    try:
-        entry_rows = (
-            db.query(
-                func.date(UserLemmaKnowledge.entered_acquiring_at).label("day"),
-                func.count(UserLemmaKnowledge.id).label("cnt"),
-            )
-            .filter(
-                UserLemmaKnowledge.entered_acquiring_at >= cutoff_7d,
-                UserLemmaKnowledge.entered_acquiring_at.isnot(None),
-            )
-            .group_by(func.date(UserLemmaKnowledge.entered_acquiring_at))
-            .all()
+    entry_rows = (
+        db.query(
+            func.date(UserLemmaKnowledge.entered_acquiring_at).label("day"),
+            func.count(UserLemmaKnowledge.id).label("cnt"),
         )
-        entries_by_day = {str(r.day): r.cnt for r in entry_rows}
-    except Exception:
-        entries_by_day = {}
-
-    # Count graduations per day
-    try:
-        grad_day_rows = (
-            db.query(
-                func.date(UserLemmaKnowledge.graduated_at).label("day"),
-                func.count(UserLemmaKnowledge.id).label("cnt"),
-            )
-            .filter(
-                UserLemmaKnowledge.graduated_at >= cutoff_7d,
-                UserLemmaKnowledge.graduated_at.isnot(None),
-            )
-            .group_by(func.date(UserLemmaKnowledge.graduated_at))
-            .all()
+        .filter(
+            UserLemmaKnowledge.entered_acquiring_at >= seven_day_start,
+            UserLemmaKnowledge.entered_acquiring_at.isnot(None),
         )
-        grads_by_day = {str(r.day): r.cnt for r in grad_day_rows}
-    except Exception:
-        grads_by_day = {}
+        .group_by(func.date(UserLemmaKnowledge.entered_acquiring_at))
+        .all()
+    )
+    for r in entry_rows:
+        key = str(r.day)
+        if key in flow:
+            flow[key]["entered"] += r.cnt
+            flow[key]["box_1_in"] += r.cnt
 
-    # Fill flow_days with actual counts
-    for i in range(6, -1, -1):
-        day_dt = (now - timedelta(days=i)).replace(
-            hour=0, minute=0, second=0, microsecond=0
+    grad_day_rows = (
+        db.query(
+            func.date(UserLemmaKnowledge.graduated_at).label("day"),
+            func.count(UserLemmaKnowledge.id).label("cnt"),
         )
-        day_key = day_dt.strftime("%Y-%m-%d")
-        idx = 6 - i
-        flow_days[idx]["entered"] = entries_by_day.get(day_key, 0)
-        flow_days[idx]["graduated"] = grads_by_day.get(day_key, 0)
+        .filter(
+            UserLemmaKnowledge.graduated_at >= seven_day_start,
+            UserLemmaKnowledge.graduated_at.isnot(None),
+        )
+        .group_by(func.date(UserLemmaKnowledge.graduated_at))
+        .all()
+    )
+    for r in grad_day_rows:
+        key = str(r.day)
+        if key in flow:
+            flow[key]["graduated"] += r.cnt
 
-    # Compute daily deltas from snapshot
-    today_str = now.strftime("%Y-%m-%d")
-    counts = {"box_1": len(boxes[1]), "box_2": len(boxes[2]), "box_3": len(boxes[3])}
-    snapshot = db.query(PipelineSnapshot).filter(PipelineSnapshot.date == today_str).first()
-    if snapshot is None:
-        try:
-            snapshot = PipelineSnapshot(
-                date=today_str,
-                box_1_count=counts["box_1"],
-                box_2_count=counts["box_2"],
-                box_3_count=counts["box_3"],
-            )
-            db.add(snapshot)
-            db.commit()
-        except Exception:
-            db.rollback()
-            snapshot = None
-    deltas = {
-        "box_1": counts["box_1"] - (snapshot.box_1_count if snapshot else counts["box_1"]),
-        "box_2": counts["box_2"] - (snapshot.box_2_count if snapshot else counts["box_2"]),
-        "box_3": counts["box_3"] - (snapshot.box_3_count if snapshot else counts["box_3"]),
-    }
+    # Box transitions from acquisition ReviewLog rows
+    log_rows = (
+        db.query(ReviewLog.reviewed_at, ReviewLog.fsrs_log_json)
+        .filter(
+            ReviewLog.is_acquisition.is_(True),
+            ReviewLog.reviewed_at >= seven_day_start.replace(tzinfo=None),
+        )
+        .all()
+    )
+    for r in log_rows:
+        rev_at = r.reviewed_at
+        if rev_at is None:
+            continue
+        if rev_at.tzinfo is None:
+            rev_at = rev_at.replace(tzinfo=timezone.utc)
+        key = rev_at.strftime("%Y-%m-%d")
+        if key not in flow:
+            continue
+        log = r.fsrs_log_json
+        if isinstance(log, str):
+            try:
+                log = json.loads(log)
+            except (json.JSONDecodeError, TypeError):
+                continue
+        if not isinstance(log, dict):
+            continue
+        before = log.get("acquisition_box_before")
+        after = log.get("acquisition_box_after")
+        if before == 1 and after == 2:
+            flow[key]["box_2_in"] += 1
+        elif before == 2 and after == 3:
+            flow[key]["box_3_in"] += 1
+        elif after == 1 and before in (2, 3):
+            flow[key]["box_1_in"] += 1  # lapse back to box 1
+
+    today_key = today_start.strftime("%Y-%m-%d")
+    today_flow = flow[today_key]
+    flow_days = [flow[k] for k in sorted(flow.keys())]
 
     return AcquisitionPipeline(
         box_1=boxes[1],
@@ -1213,9 +1228,10 @@ def _get_acquisition_pipeline(db: Session) -> AcquisitionPipeline:
         box_1_due=due_per_box[1],
         box_2_due=due_per_box[2],
         box_3_due=due_per_box[3],
-        box_1_delta=deltas["box_1"],
-        box_2_delta=deltas["box_2"],
-        box_3_delta=deltas["box_3"],
+        box_1_in_today=today_flow["box_1_in"],
+        box_2_in_today=today_flow["box_2_in"],
+        box_3_in_today=today_flow["box_3_in"],
+        graduated_today=today_flow["graduated"],
         recent_graduations=[
             RecentGraduation(
                 lemma_id=r.lemma_id,

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -257,11 +257,13 @@ class AcquisitionPipeline(BaseModel):
     box_1_due: int = 0
     box_2_due: int = 0
     box_3_due: int = 0
-    box_1_delta: int = 0
-    box_2_delta: int = 0
-    box_3_delta: int = 0
+    box_1_in_today: int = 0  # arrivals at box 1 today (new + lapses back)
+    box_2_in_today: int = 0  # promotions 1->2 today
+    box_3_in_today: int = 0  # promotions 2->3 today
+    graduated_today: int = 0
     recent_graduations: list[RecentGraduation]
-    flow_history: list[dict] = []  # [{date, entered, graduated}] last 7 days
+    # [{date, entered, box_1_in, box_2_in, box_3_in, graduated}] last 7 days
+    flow_history: list[dict] = []
 
 
 class InsightsOut(BaseModel):

--- a/frontend/app/stats.tsx
+++ b/frontend/app/stats.tsx
@@ -309,7 +309,7 @@ function WordLifecycleFunnel({
   encountered: number; acquiring: number; learning: number; known: number; lapsed: number;
   weeklyKnown: number; weeklyLearning: number; netPerDay: number;
   retentionPct: number | null;
-  flowHistory?: Array<{ date: string; entered: number; graduated: number }>;
+  flowHistory?: Array<{ date: string; entered: number; box_1_in: number; box_2_in: number; box_3_in: number; graduated: number }>;
   benchmarks?: ProgressBenchmarks | null;
 }) {
   const stages = [
@@ -903,18 +903,17 @@ function AcquisitionPipelineCard({ pipeline, insights }: { pipeline: Acquisition
     enteringPerDay = pipeline.flow_history.reduce((s, d) => s + d.entered, 0) / days;
     graduatingPerDay = pipeline.flow_history.reduce((s, d) => s + d.graduated, 0) / days;
   }
-  const maxFlow = hasFlow ? Math.max(...pipeline.flow_history.map(d => Math.max(d.entered, d.graduated)), 1) : 1;
-
   const gradRate = insights?.graduation_rate_pct;
   const avgReviews = insights?.avg_encounters_to_graduation;
   const ratio = graduatingPerDay > 0 ? enteringPerDay / graduatingPerDay : 0;
   const isHealthy = ratio > 0 && ratio <= 3;
 
   const boxes = [
-    { label: "Box 1", count: pipeline.box_1_count, due: pipeline.box_1_due ?? 0, interval: "4h" },
-    { label: "Box 2", count: pipeline.box_2_count, due: pipeline.box_2_due ?? 0, interval: "1d" },
-    { label: "Box 3", count: pipeline.box_3_count, due: pipeline.box_3_due ?? 0, interval: "3d" },
+    { label: "Box 1", count: pipeline.box_1_count, due: pipeline.box_1_due ?? 0, interval: "4h", inToday: pipeline.box_1_in_today ?? 0 },
+    { label: "Box 2", count: pipeline.box_2_count, due: pipeline.box_2_due ?? 0, interval: "1d", inToday: pipeline.box_2_in_today ?? 0 },
+    { label: "Box 3", count: pipeline.box_3_count, due: pipeline.box_3_due ?? 0, interval: "3d", inToday: pipeline.box_3_in_today ?? 0 },
   ];
+  const graduatedToday = pipeline.graduated_today ?? 0;
 
   return (
     <View style={styles.deepCard}>
@@ -935,10 +934,24 @@ function AcquisitionPipelineCard({ pipeline, insights }: { pipeline: Acquisition
               </View>
               <Text style={pipeStyles.barInterval}>{box.interval}</Text>
             </View>
+            {box.inToday > 0 && (
+              <Text style={[pipeStyles.boxDue, { color: colors.stateAcquiring }]}>+{box.inToday} today</Text>
+            )}
             {box.due > 0 && <Text style={pipeStyles.boxDue}>{box.due} due</Text>}
           </View>
         );
       })}
+      {graduatedToday > 0 && (
+        <View style={pipeStyles.boxRow}>
+          <Text style={pipeStyles.boxLabel}>Grad</Text>
+          <View style={pipeStyles.barBg}>
+            <View style={[pipeStyles.barFill, { width: "8%", backgroundColor: colors.good }]}>
+              <Text style={pipeStyles.barNum}>{graduatedToday}</Text>
+            </View>
+            <Text style={pipeStyles.barInterval}>today</Text>
+          </View>
+        </View>
+      )}
 
       {/* Throughput metrics */}
       <View style={pipeStyles.throughput}>
@@ -1000,30 +1013,46 @@ function AcquisitionPipelineCard({ pipeline, insights }: { pipeline: Acquisition
         </View>
       )}
 
-      {/* 7-day flow chart */}
-      {hasFlow && pipeline.flow_history.some(d => d.entered > 0 || d.graduated > 0) && (
-        <View style={pipeStyles.flowSection}>
-          <Text style={pipeStyles.flowTitle}>7-day flow</Text>
-          <View style={pipeStyles.flowBars}>
-            {pipeline.flow_history.map((d, i) => (
-              <View key={i} style={pipeStyles.flowCol}>
-                <View style={pipeStyles.flowBarGroup}>
-                  {d.entered > 0 && <View style={[pipeStyles.flowBar, { height: Math.max((d.entered / maxFlow) * 32, 2), backgroundColor: colors.stateAcquiring }]} />}
-                  {d.graduated > 0 && <View style={[pipeStyles.flowBar, { height: Math.max((d.graduated / maxFlow) * 32, 2), backgroundColor: colors.good }]} />}
-                  {d.entered === 0 && d.graduated === 0 && <View style={[pipeStyles.flowBar, { height: 2, backgroundColor: colors.border }]} />}
+      {/* 7-day flow chart: per-slot throughput per day */}
+      {hasFlow && pipeline.flow_history.some(d => d.box_1_in > 0 || d.box_2_in > 0 || d.box_3_in > 0 || d.graduated > 0) && (() => {
+        const slotMax = Math.max(
+          ...pipeline.flow_history.map(d => Math.max(d.box_1_in, d.box_2_in, d.box_3_in, d.graduated)),
+          1,
+        );
+        const slots: Array<{ key: "box_1_in" | "box_2_in" | "box_3_in" | "graduated"; label: string; color: string }> = [
+          { key: "box_1_in", label: "→ Box 1", color: colors.stateEncountered },
+          { key: "box_2_in", label: "→ Box 2", color: colors.stateAcquiring },
+          { key: "box_3_in", label: "→ Box 3", color: colors.stateLearning },
+          { key: "graduated", label: "Graduated", color: colors.good },
+        ];
+        return (
+          <View style={pipeStyles.flowSection}>
+            <Text style={pipeStyles.flowTitle}>7-day throughput per slot</Text>
+            {slots.map(slot => (
+              <View key={slot.key} style={{ marginBottom: 6 }}>
+                <View style={{ flexDirection: "row", alignItems: "center", marginBottom: 2 }}>
+                  <View style={[pipeStyles.flowLegendDot, { backgroundColor: slot.color }]} />
+                  <Text style={pipeStyles.flowLegendText}>{slot.label}</Text>
                 </View>
-                <Text style={pipeStyles.flowDayLabel}>{d.date}</Text>
+                <View style={pipeStyles.flowBars}>
+                  {pipeline.flow_history.map((d, i) => {
+                    const v = d[slot.key];
+                    return (
+                      <View key={i} style={pipeStyles.flowCol}>
+                        <View style={[pipeStyles.flowBarGroup, { justifyContent: "flex-end" }]}>
+                          <View style={[pipeStyles.flowBar, { height: v > 0 ? Math.max((v / slotMax) * 24, 3) : 2, backgroundColor: v > 0 ? slot.color : colors.border, width: 14 }]} />
+                          {v > 0 && <Text style={{ fontSize: 9, color: colors.textSecondary, marginTop: 1 }}>{v}</Text>}
+                        </View>
+                        {slot.key === "graduated" && <Text style={pipeStyles.flowDayLabel}>{d.date}</Text>}
+                      </View>
+                    );
+                  })}
+                </View>
               </View>
             ))}
           </View>
-          <View style={pipeStyles.flowLegend}>
-            <View style={[pipeStyles.flowLegendDot, { backgroundColor: colors.stateAcquiring }]} />
-            <Text style={pipeStyles.flowLegendText}>entered</Text>
-            <View style={[pipeStyles.flowLegendDot, { backgroundColor: colors.good }]} />
-            <Text style={pipeStyles.flowLegendText}>graduated</Text>
-          </View>
-        </View>
-      )}
+        );
+      })()}
 
       {/* Recent graduations */}
       {pipeline.recent_graduations.length > 0 && (

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -650,11 +650,19 @@ export interface AcquisitionPipeline {
   box_1_due: number;
   box_2_due: number;
   box_3_due: number;
-  box_1_delta?: number;
-  box_2_delta?: number;
-  box_3_delta?: number;
+  box_1_in_today?: number;
+  box_2_in_today?: number;
+  box_3_in_today?: number;
+  graduated_today?: number;
   recent_graduations: RecentGraduation[];
-  flow_history: Array<{ date: string; entered: number; graduated: number }>;
+  flow_history: Array<{
+    date: string;
+    entered: number;
+    box_1_in: number;
+    box_2_in: number;
+    box_3_in: number;
+    graduated: number;
+  }>;
 }
 
 export interface InsightsData {


### PR DESCRIPTION
## Summary

The Acquisition Pipeline card felt static even on heavy review days because the per-box "delta" was computed against a `PipelineSnapshot` row that gets frozen the first time stats is loaded each day. So if you opened Stats once in the morning, the rest of the day's progress would never show up.

Replace it with real throughput, computed from `ReviewLog.fsrs_log_json` box transitions (`acquisition_box_before` / `_after`) + `entered_acquiring_at` + `graduated_at`:

- Each box row now shows `+N today` arrivals (Box 1 = new entries + lapses back; Box 2/3 = promotions in)
- New `Grad` row when there are graduations today
- 7-day chart now breaks down per-slot (4 mini-bar rows) so you can see how many cards reached each stage each day, instead of just net `entered`/`graduated`

`flow_history` payload extended with `box_1_in` / `box_2_in` / `box_3_in` per day; existing `entered`/`graduated` kept for the WordLifecycleFunnel consumer.

`PipelineSnapshot` model is left in place (table, harmless rows) but no longer read or written.