### PR TITLE
Lookup gap C + frequency-core dry-run prefix alignment

### DIFF
--- a/IDEAS.md
+++ b/IDEAS.md
@@ -28,12 +28,17 @@ suffixes (هما, هم, ها, ه, نا, ني, ك, كم, كن) but the bare 1st-p
 matches because `ي` is also a regular letter; need a careful guard (e.g., only
 strip on a stem that ends in a non-vowel before the `ي`).
 
-### C. Alef-maksura ↔ ya asymmetry in lookup
+### C. [DONE 2026-05-05] Alef-maksura ↔ ya asymmetry in lookup
 
 `إِلَيْهَا` strips `ها` to give `الي` (regular ya, U+064A) but the lemma is
 keyed `الى` (alef-maksura, U+0649) at lemma_id 454. They're different keys.
-**Fix idea**: in `build_comprehensive_lemma_lookup`, for every lemma whose
-bare ends in ى, also index a `ي`-final variant. Same for the inverse.
+**Fix**: `build_lemma_lookup` now has a Pass 1b that, for every lemma whose
+normalized bare ends in ى, indexes a ي-final variant via `set_if_new`. The
+separate pass (rather than inlining in Pass 1) ensures real ي-final lemmas
+(e.g. موسيقي "musical") always claim their own key before a ى-final lemma's
+ya-variant (موسيقى "music") can fill it. 28 ى-final lemmas, 25 add a new
+ي-variant, 3 silently no-op on collision (موسيقى/علي/منى). Inverse direction
+(ي → ى) not done — riskier and no observed gap that needed it.
 
 ### D. Plural / verbal-noun gaps
 
@@ -71,12 +76,13 @@ top 500 78%, top 1,000 68%, top 5,000 29%.
 Follow-ups discovered during deploy:
 - **Kelly source unreachable**: Leeds corpus server (`corpus.leeds.ac.uk`)
   timed out from both local and server. Re-attempt later or mirror the file.
-- **`learned_prefix_count` semantics differ between dry-run and API**: the
-  builder's dry-run printout uses "highest rank ever learned" while the API's
-  `_compute_frequency_core_progress` correctly uses "continuous prefix from
-  rank 1." After deploy the API showed 0 (rank #1 منتدى missing from DB) while
-  the dry-run printed 90. Align the dry-run print to match API semantics so
-  the two numbers don't disagree.
+- **[DONE 2026-05-05] `learned_prefix_count` semantics differ between dry-run
+  and API**: the builder's dry-run printout used "highest rank ever learned"
+  while the API's `_compute_frequency_core_progress` correctly uses "continuous
+  prefix from rank 1." Fixed by adding a `prefix_locked` flag in `print_summary`
+  that freezes `prefix` on the first non-learned row, mirroring the API's
+  `break`-on-gap. Verified against 6 synthetic states (incl. the 90/gap/50
+  scenario from the original report) — both halves now agree.
 - **High-frequency unmapped lemmas**: rank #1 منتدى (forum), #2 قسم (section),
   #13 عملية (operation), #16 المنتدى — these are top-20 forum/web frequencies
   CAMeL captures but Alif's vocabulary never imported. Worth a one-shot script

--- a/backend/app/services/sentence_validator.py
+++ b/backend/app/services/sentence_validator.py
@@ -925,6 +925,19 @@ def build_lemma_lookup(lemmas: list) -> dict[str, int]:
         elif not bare_norm.startswith("ال"):
             lookup.set_if_new("ال" + bare_norm, lem.lemma_id, lem.lemma_ar_bare)
 
+    # Pass 1b: Alef-maksura ↔ ya asymmetry. Clitic stripping turns ـيها into ـي
+    # with regular ya (U+064A), but lemmas like إلى/متى/مقهى are stored with
+    # alef-maksura (U+0649). Index a ي-final variant so post-strip residues remap.
+    # Safe because ى only appears word-final in Arabic orthography. Runs AFTER
+    # the main Pass 1 so a real ي-final lemma (e.g. موسيقي "musical") always
+    # claims its key before the ya_variant of a ى-final lemma (موسيقى "music")
+    # can fill it.
+    for lem in lemmas:
+        bare_norm = normalize_alef(lem.lemma_ar_bare)
+        if len(bare_norm) >= 2 and bare_norm.endswith("ى"):
+            ya_variant = bare_norm[:-1] + "ي"
+            lookup.set_if_new(ya_variant, lem.lemma_id, lem.lemma_ar_bare)
+
     # Pass 2: Register derived forms from forms_json (lower priority)
     # Indexes ALL string-valued keys — no hardcoded whitelist needed
     _FORMS_SKIP_KEYS = {"gender", "verb_form"}  # non-Arabic metadata

--- a/backend/scripts/build_frequency_core.py
+++ b/backend/scripts/build_frequency_core.py
@@ -583,16 +583,22 @@ def print_summary(db, entries: list[CoreCandidate]) -> None:
     unresolved_top_500 = sum(1 for cand in entries[:500] if cand.lemma_id is None or cand.confidence_tier == "low")
     print(f"  unresolved/low-confidence in top 500: {unresolved_top_500}")
 
+    # `prefix` mirrors the API's `learned_prefix_count` in stats._compute_frequency_core_progress:
+    # the continuous learned prefix from rank 1, NOT the highest rank ever learned. Lock it on
+    # the first gap so a single gap doesn't get masked by later learned entries.
     prefix = 0
+    prefix_locked = False
     gaps: list[tuple[int, CoreCandidate, str]] = []
     for rank, cand in enumerate(entries, 1):
         state = states.get(cand.lemma_id) if cand.lemma_id is not None else "missing_from_db"
         if state in learned_states:
-            prefix = rank
+            if not prefix_locked:
+                prefix = rank
             continue
+        prefix_locked = True
         if len(gaps) < 12:
             gaps.append((rank, cand, state or "new"))
-        if len(gaps) >= 12 and rank > prefix:
+        if len(gaps) >= 12:
             break
 
     print(f"  continuous learned prefix: top {prefix}")


### PR DESCRIPTION
## Summary

Two unrelated fixes from IDEAS.md follow-ups (item 2 + lookup gap C). Both are surgical and low-risk.

### Lookup gap C — alef-maksura ↔ ya asymmetry

`build_lemma_lookup` now has a **Pass 1b** that indexes a ي-final variant for every ى-final lemma.

Resolves the case where clitic-stripped `إِلَيْهَا` → `الي` (regular ya, U+064A) failed to find lemma #454 keyed `الى` (alef-maksura, U+0649). Safe because alef-maksura is always word-final in Arabic orthography.

The variant pass is run **after** Pass 1's bare-form registration so that real ي-final lemmas (e.g. `موسيقي` "musical") always claim their own key before a ى-final lemma's ya-variant (`موسيقى` "music") can fill it. 28 ى-final lemmas total: 25 add a new variant key, 3 collide with a real ي-final lemma and silently no-op via `set_if_new` (`موسيقى/علي/منى` — these are genuinely different words from `موسيقي/علي/مني`).

### Frequency-core dry-run "continuous learned prefix"

The dry-run printout in `build_frequency_core.print_summary` claimed to be the continuous-learned prefix but was actually "highest rank ever learned" — kept incrementing past gaps. Locked the prefix on the first non-learned row to match the API's `_compute_frequency_core_progress` in `stats.py`, which correctly breaks on the first gap.

Verified with synthetic states including the 90/gap/50 scenario from the post-deploy report — the two readouts now agree.

## Verification

- 196 targeted tests pass: `test_sentence_validator`, `test_frequency_core_builder`, `test_frequency_lanes`, `test_sentence_eligibility`, `test_corpus_import`, `test_book_import`
- Lookup verification on the prod DB confirmed all collision cases resolve to the correct lemma (e.g. `علي` → 1968 Ali, `على` → 453 on/upon)
- Prefix logic verified across 6 cases including empty input, all-learned, and the 90/gap/50 scenario

## What's NOT in scope

Other items from the same IDEAS.md follow-ups intentionally deferred:
- Kelly/Leeds source — server still down
- Top-20 unmapped frequency-core lemmas — needs LLM enrichment + quality gates
- Lookup gap A (missing `ل` lemma) — needs a one-shot script that creates function-word Lemma rows; wider blast radius, want to do separately
- Lookup gap B (1st-person ي enclitic) — explicitly flagged risky in IDEAS.md
- Lookup gap D (verbal-noun gaps) — same shape as the top-20 import work