### PR TITLE
Intro cards: filter function words and proper names

### DIFF
--- a/backend/app/services/sentence_selector.py
+++ b/backend/app/services/sentence_selector.py
@@ -1453,6 +1453,7 @@ def build_session(
                 "stability": w.stability,
                 "is_due": w.is_due,
                 "is_function_word": w.is_function_word,
+                "is_proper_name": w.is_proper_name,
                 "knowledge_state": w.knowledge_state,
                 "root": root_obj.root if root_obj else None,
                 "root_meaning": root_obj.core_meaning_en if root_obj else None,
@@ -1719,6 +1720,15 @@ def _build_intro_cards(
     new_card_ids &= eligible_ids
     rescue_card_ids &= eligible_ids
 
+    # Backstop: even if a function word or proper name has knowledge_state="acquiring"
+    # in the DB (e.g. legacy book imports stamped a ULK row before the upstream
+    # filter existed), do not render a card for it.
+    drop_ids = set(new_card_ids) | set(rescue_card_ids)
+    if drop_ids:
+        kept = set(_drop_function_and_proper_name_lemma_ids(db, drop_ids))
+        new_card_ids &= kept
+        rescue_card_ids &= kept
+
     if not new_card_ids and not rescue_card_ids:
         return []
 
@@ -1972,6 +1982,7 @@ def _find_pregenerated_sentences_for_words(
                 "stability": w.stability,
                 "is_due": w.is_due,
                 "is_function_word": w.is_function_word,
+                "is_proper_name": w.is_proper_name,
                 "knowledge_state": w.knowledge_state,
                 "root": root_obj.root if root_obj else None,
                 "root_meaning": root_obj.core_meaning_en if root_obj else None,
@@ -2008,11 +2019,16 @@ def _find_pregenerated_sentences_for_words(
 
 
 def _session_intro_eligible_lemma_ids(db: Session, items: list[dict]) -> set[int]:
-    """Return canonical non-function lemma IDs that appear in session items."""
+    """Return canonical content-word lemma IDs that appear in session items.
+
+    Excludes function words (`is_function_word` flag from WordMeta) and proper
+    names (`is_proper_name` flag) — neither category receives intro cards or
+    cold-promotion to acquiring.
+    """
     raw_ids: set[int] = set()
     for item in items:
         for word in item.get("words", []) or []:
-            if word.get("is_function_word"):
+            if word.get("is_function_word") or word.get("is_proper_name"):
                 continue
             lid = word.get("lemma_id")
             if isinstance(lid, int):
@@ -2055,6 +2071,12 @@ def _ensure_session_words_have_intro_state(
     Sentence review already auto-introduces unknown collateral words after the
     card is answered. Doing it here preserves that learning flow while allowing
     the intro card to appear before the sentence.
+
+    Function words (`ل`, `هم`, `في`, …) and proper names (Heidi, Ali, …) are
+    excluded — they never receive intro cards (CLAUDE.md invariants). Without
+    this guard, an unmapped proper-name surface auto-created by step 0b would
+    flow encountered → acquiring → intro card the moment a sentence containing
+    it became eligible.
     """
     if not lemma_ids:
         return
@@ -2068,17 +2090,21 @@ def _ensure_session_words_have_intro_state(
         ):
             knowledge_by_id[ulk.lemma_id] = ulk
 
-    to_start = [
+    candidate_ids = [
         lid for lid in lemma_ids
         if lid not in knowledge_by_id
         or knowledge_by_id[lid].knowledge_state == "encountered"
     ]
-    if not to_start:
+    if not candidate_ids:
+        return
+
+    candidate_ids = _drop_function_and_proper_name_lemma_ids(db, candidate_ids)
+    if not candidate_ids:
         return
 
     from app.services.acquisition_service import start_acquisition
 
-    for lid in to_start:
+    for lid in candidate_ids:
         ulk = start_acquisition(
             db,
             lemma_id=lid,
@@ -2086,6 +2112,38 @@ def _ensure_session_words_have_intro_state(
             due_immediately=False,
         )
         knowledge_by_id[lid] = ulk
+
+
+def _drop_function_and_proper_name_lemma_ids(
+    db: Session, lemma_ids: list[int] | set[int]
+) -> list[int]:
+    """Filter lemma IDs that should never get intro cards or auto-promotion.
+
+    Per CLAUDE.md: function words and proper names are inert in the SRS
+    pipeline — they earn no FSRS / acquisition credit and never get intro
+    cards. The check is by lemma row (`word_category == "proper_name"`) and
+    by bare-form lookup against `FUNCTION_WORD_GLOSSES`.
+    """
+    if not lemma_ids:
+        return []
+    lemmas = (
+        db.query(Lemma)
+        .filter(Lemma.lemma_id.in_(list(lemma_ids)))
+        .all()
+    )
+    by_id = {l.lemma_id: l for l in lemmas}
+    keep: list[int] = []
+    for lid in lemma_ids:
+        lem = by_id.get(lid)
+        if lem is None:
+            keep.append(lid)
+            continue
+        if lem.word_category == "proper_name":
+            continue
+        if lem.lemma_ar_bare and _is_function_word(lem.lemma_ar_bare):
+            continue
+        keep.append(lid)
+    return keep
 
 
 def _with_fallbacks(

--- a/backend/scripts/demote_inert_acquiring.py
+++ b/backend/scripts/demote_inert_acquiring.py
@@ -1,0 +1,111 @@
+"""Demote function-word and proper-name lemmas out of `acquiring` state.
+
+Per CLAUDE.md, function words and proper names are inert in the SRS
+pipeline — no FSRS card, no acquisition box, no review credit, no intro
+card. But legacy book/textbook imports occasionally stamped a ULK row
+with `knowledge_state="acquiring"` for these lemmas before the upstream
+filter existed. Those rows then surface as intro cards in `_build_intro_cards`.
+
+This script identifies them and resets `knowledge_state` to `encountered`,
+clearing the acquisition box / next-due / generation backoff fields so
+the lemma reverts to a passive scaffold helper. Run with --dry-run first.
+
+Usage:
+    python3 scripts/demote_inert_acquiring.py --dry-run
+    python3 scripts/demote_inert_acquiring.py --apply
+
+Logged via ActivityLog as `manual_action`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from dotenv import load_dotenv
+
+load_dotenv(Path(__file__).resolve().parent.parent / ".env")
+
+from app.database import SessionLocal
+from app.models import Lemma, UserLemmaKnowledge
+from app.services.activity_log import log_activity
+from app.services.sentence_validator import _is_function_word
+
+
+def find_inert_acquiring(db) -> list[tuple[UserLemmaKnowledge, Lemma, str]]:
+    """Return (ulk, lemma, reason) tuples for acquiring rows that should not be acquiring."""
+    rows = (
+        db.query(UserLemmaKnowledge, Lemma)
+        .join(Lemma, Lemma.lemma_id == UserLemmaKnowledge.lemma_id)
+        .filter(UserLemmaKnowledge.knowledge_state == "acquiring")
+        .all()
+    )
+    out = []
+    for ulk, lem in rows:
+        if lem.word_category == "proper_name":
+            out.append((ulk, lem, "proper_name"))
+            continue
+        if lem.lemma_ar_bare and _is_function_word(lem.lemma_ar_bare):
+            out.append((ulk, lem, "function_word"))
+    return out
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Demote inert acquiring lemmas")
+    g = parser.add_mutually_exclusive_group(required=True)
+    g.add_argument("--dry-run", action="store_true")
+    g.add_argument("--apply", action="store_true")
+    args = parser.parse_args()
+
+    db = SessionLocal()
+    try:
+        targets = find_inert_acquiring(db)
+        if not targets:
+            print("No acquiring rows match the function-word / proper-name criteria.")
+            return 0
+
+        print(f"{len(targets)} ULK rows to demote:")
+        for ulk, lem, reason in targets:
+            print(
+                f"  #{lem.lemma_id} ar={lem.lemma_ar!r} bare={lem.lemma_ar_bare!r} "
+                f"gloss={(lem.gloss_en or '')[:30]!r} reason={reason} "
+                f"times_seen={ulk.times_seen} times_correct={ulk.times_correct}"
+            )
+
+        if args.dry_run:
+            print("\n--dry-run; no changes written. Re-run with --apply.")
+            return 0
+
+        for ulk, _lem, _reason in targets:
+            ulk.knowledge_state = "encountered"
+            ulk.acquisition_box = None
+            ulk.acquisition_next_due = None
+            ulk.acquisition_started_at = None
+            # Intentionally NOT clearing experiment_intro_shown_at: keeping the
+            # historical marker prevents an intro card from re-firing if a
+            # future regression ever lets one of these back into acquiring.
+        db.commit()
+
+        log_activity(
+            db,
+            event_type="manual_action",
+            summary=f"Demoted {len(targets)} inert lemmas (function_word/proper_name) from acquiring to encountered",
+            details={
+                "lemma_ids": [t[1].lemma_id for t in targets],
+                "by_reason": {
+                    r: [t[1].lemma_id for t in targets if t[2] == r]
+                    for r in {t[2] for t in targets}
+                },
+            },
+        )
+        print(f"\nDemoted {len(targets)} rows. Logged to ActivityLog.")
+        return 0
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_sentence_selector.py
+++ b/backend/tests/test_sentence_selector.py
@@ -862,6 +862,87 @@ class TestIntroCardsForSessionWords:
         assert ulk.knowledge_state == "acquiring"
         assert [c["lemma_id"] for c in result["experiment_intro_cards"]] == [4]
 
+    def test_proper_name_is_not_promoted_or_carded(self, db_session):
+        """A proper-name lemma in a session sentence must NOT be promoted to
+        acquiring and must NOT receive an intro card. Reproduces the Heidi
+        regression: fix_null_lemma_ids step 0b auto-creates a proper_name
+        lemma; without the guard it flowed encountered → acquiring → intro."""
+        _seed_word(db_session, 1, "كتاب", "book", due_hours=-1)
+        heidi = Lemma(
+            lemma_id=2,
+            lemma_ar="هايدي",
+            lemma_ar_bare="هايدي",
+            pos="noun",
+            gloss_en="(proper name)",
+            word_category="proper_name",
+            gates_completed_at=datetime.now(timezone.utc),
+        )
+        db_session.add(heidi)
+        db_session.add(UserLemmaKnowledge(
+            lemma_id=2,
+            knowledge_state="encountered",
+            fsrs_card_json=None,
+            introduced_at=None,
+            times_seen=0,
+            times_correct=0,
+            total_encounters=0,
+            source="book",
+        ))
+        _seed_sentence(
+            db_session,
+            1,
+            "كتاب هايدي",
+            "Heidi's book",
+            1,
+            [("كتاب", 1), ("هايدي", 2)],
+        )
+        db_session.commit()
+
+        result = build_session(db_session, limit=1)
+        ulk = db_session.query(UserLemmaKnowledge).filter_by(lemma_id=2).one()
+
+        assert ulk.knowledge_state == "encountered"
+        assert 2 not in {c["lemma_id"] for c in result["experiment_intro_cards"]}
+
+    def test_legacy_acquiring_function_word_does_not_render_card(self, db_session):
+        """A pre-existing acquiring ULK row for a function-word lemma (e.g. ال,
+        منذ — created before the upstream guard existed) must not produce an
+        intro card. The bare-form check `_is_function_word` is the backstop."""
+        _seed_word(db_session, 1, "كتاب", "book", due_hours=-1)
+        particle = Lemma(
+            lemma_id=2,
+            lemma_ar="مُنْذُ",
+            lemma_ar_bare="منذ",
+            pos="prep",
+            gloss_en="since",
+            gates_completed_at=datetime.now(timezone.utc),
+        )
+        db_session.add(particle)
+        db_session.add(UserLemmaKnowledge(
+            lemma_id=2,
+            knowledge_state="acquiring",
+            acquisition_box=1,
+            acquisition_next_due=datetime.now(timezone.utc) + timedelta(hours=4),
+            introduced_at=datetime.now(timezone.utc),
+            times_seen=0,
+            times_correct=0,
+            total_encounters=0,
+            source="book",
+        ))
+        _seed_sentence(
+            db_session,
+            1,
+            "كتاب منذ",
+            "book since",
+            1,
+            [("كتاب", 1), ("منذ", 2)],
+        )
+        db_session.commit()
+
+        result = build_session(db_session, limit=1)
+
+        assert 2 not in {c["lemma_id"] for c in result["experiment_intro_cards"]}
+
 
 class TestFillPhasePregenerated:
     """Fill phase should use pre-generated sentences (no LLM calls in session build)."""

--- a/docs/scripts-catalog.md
+++ b/docs/scripts-catalog.md
@@ -100,6 +100,7 @@ These scripts are designed to run periodically against the generation pipeline b
 - `cleanup_lemma_mappings.py` — Batch cleanup of lemma data quality issues: wrong glosses, missing particles, conjugated-form lemmas, possessive-form lemmas, al-prefix lemmas, batch re-map via CAMeL + LLM.
 - `investigate_mapping_flags.py` — Investigate word_mapping flags: shows sentence text, current word→lemma mappings. `--all` shows all statuses, `--fix` re-evaluates and applies corrections via LLM.
 - `cleanup_stale_state.py` — One-time cleanup: clear stale acquisition_box on non-acquiring words, fix circular canonical_lemma_id references, fix conjugated variants with own ULK when canonical already known. `--apply` to commit (default: dry run).
+- `demote_inert_acquiring.py` — One-shot cleanup: demote function-word and proper-name lemmas that ended up in `acquiring` from legacy book/textbook imports back to `encountered`. Per CLAUDE.md these categories are inert (no FSRS, no acquisition box, no intro card) and should never be `acquiring`. Filter is `word_category == "proper_name"` plus a bare-form `_is_function_word` lookup so legacy `word_category=None` rows are caught too. Preserves `experiment_intro_shown_at` so an intro card cannot re-fire. `--dry-run` / `--apply`.
 - `rollback_glitch_session.py` — Roll back the April 1, 2026 sync glitch session (102 bogus "Again" reviews). Restores FSRS state for 11 lapsed words. Also deactivates sentence 20403 (separated ال) and suspends lemma 441. `--execute` to apply (default: dry run).
 
 ## Analysis & Testing


### PR DESCRIPTION
## Symptom

Intro cards being rendered for particles (لم, هم, ال, منذ, إلا, أيّ) and proper names (Heidi). All useless — these categories are explicitly inert per CLAUDE.md.

## Root cause

`_ensure_session_words_have_intro_state` in `sentence_selector.py` calls `start_acquisition` for every cold session word from `_session_intro_eligible_lemma_ids`, but the eligibility set only filtered `is_function_word` and the cold-promote helper had no `word_category` guard. So a proper-name surface auto-created by `fix_null_lemma_ids` step 0b would flow `encountered` → `acquiring` → intro card the moment a sentence containing it became eligible.

For function words: legacy book/textbook imports created `acquiring` ULK rows for these lemmas (#441 ال, #2030 منذ, #691 إلا, #360 أيّ on prod) before the upstream filter existed. `_build_intro_cards` had no defensive filter, so those rows continued to render cards.

Triggered today by PR #64 + tokenizer remap + step 0b proper-name auto-create — many previously-stuck sentences became eligible for review at once, surfacing the latent bug.

## Three lines of defense

1. **`_ensure_session_words_have_intro_state`** filters candidate lemma IDs through `_drop_function_and_proper_name_lemma_ids` before calling `start_acquisition`. Primary fix.
2. **`_build_intro_cards`** applies the same filter at card-render time. Backstop catches legacy acquiring rows.
3. **Word-dict serializers** now emit `is_proper_name`; **`_session_intro_eligible_lemma_ids`** excludes both flags. Cleans up the eligibility set so other downstream consumers are also right.

## Tests

Two new cases in `TestIntroCardsForSessionWords`:
- `test_proper_name_is_not_promoted_or_carded`: encountered Heidi-style proper-name lemma in a session sentence stays `encountered` and no intro card is rendered.
- `test_legacy_acquiring_function_word_does_not_render_card`: pre-existing acquiring ULK row for a function-word lemma (منذ "since") produces no intro card.

257 tests pass across `test_sentence_selector` + `test_reintro` + `test_sentence_validator` + `test_sentence_eligibility` + `test_corpus_import` + `test_book_import`.

## Data cleanup

New script `backend/scripts/demote_inert_acquiring.py` (cataloged in `docs/scripts-catalog.md`). Demotes function-word + proper-name lemmas in `acquiring` back to `encountered`. Local dry-run shows 18 ULK rows; prod has fewer (~5 expected). Will run with `--apply` on prod after this PR merges.