### PR TITLE
Fix variant-canonical scheduling asymmetry

### DIFF
--- a/backend/app/services/acquisition_service.py
+++ b/backend/app/services/acquisition_service.py
@@ -78,6 +78,17 @@ def start_acquisition(
     If due_immediately=True, word is due right now (for auto-intro in current session).
     Otherwise, first review is due after BOX_INTERVALS[1] (4 hours).
     """
+    from app.services.canonical_resolution import resolve_canonical_lemma_id
+
+    # Variants must never get their own scheduling rows; redirect to canonical.
+    canonical_id = resolve_canonical_lemma_id(db, lemma_id)
+    if canonical_id != lemma_id:
+        logger.info(
+            "start_acquisition redirecting variant %s → canonical %s (source=%r)",
+            lemma_id, canonical_id, source,
+        )
+        lemma_id = canonical_id
+
     now = datetime.now(timezone.utc)
     next_due = now if due_immediately else now + BOX_INTERVALS[1]
 
@@ -86,6 +97,11 @@ def start_acquisition(
         .filter(UserLemmaKnowledge.lemma_id == lemma_id)
         .first()
     )
+
+    # Don't demote a known/learning canonical back to acquiring just because a
+    # variant collateral path landed here. Return the existing row unchanged.
+    if ulk and ulk.knowledge_state in ("known", "learning"):
+        return ulk
 
     if ulk:
         # Transition existing record (e.g. from "encountered")

--- a/backend/app/services/book_import_service.py
+++ b/backend/app/services/book_import_service.py
@@ -515,8 +515,11 @@ def import_book(
     # Import unknown words (creates Lemma entries + runs quality gates internally)
     new_ids = _import_unknown_words(db, story, lemma_lookup)
 
-    # Create encountered ULK records for book words that don't have one yet
-    book_lemma_ids = {sw.lemma_id for sw in story.words if sw.lemma_id and not sw.is_function_word}
+    # Create encountered ULK records for book words that don't have one yet.
+    # Redirect variants to their canonical so we never create a variant-scoped ULK.
+    from app.services.canonical_resolution import resolve_canonical_lemma_id
+    raw_book_lemma_ids = {sw.lemma_id for sw in story.words if sw.lemma_id and not sw.is_function_word}
+    book_lemma_ids = {resolve_canonical_lemma_id(db, lid) for lid in raw_book_lemma_ids}
     existing_ulk_ids = set()
     if book_lemma_ids:
         existing_ulk_ids = {

--- a/backend/app/services/canonical_resolution.py
+++ b/backend/app/services/canonical_resolution.py
@@ -1,0 +1,59 @@
+"""Canonical lemma resolution.
+
+Per CLAUDE.md hard invariant: variant lemmas (`canonical_lemma_id` NOT NULL)
+must never get independent FSRS cards or acquisition rows. The canonical is
+the unit of scheduling; variants are tracked via `variant_stats_json` on the
+canonical's ULK row.
+
+Every code path that creates a `UserLemmaKnowledge` row must redirect a
+variant's `lemma_id` to the canonical first. When the redirect lands inside
+`start_acquisition()` and `introduce_word()`, indirect callers
+(`sentence_selector._ensure_session_words_have_intro_state`,
+`quran_service`, `ocr_service.import_words`, `leech_service`,
+`routers/learn.py`) are covered transitively. Direct `db.add(UserLemmaKnowledge(...))`
+sites (`book_import_service`, `ocr_service` cold-encounter path) must call
+`resolve_canonical_lemma_id` explicitly before constructing the row.
+"""
+
+from sqlalchemy.orm import Session
+
+from app.models import Lemma
+
+
+def resolve_canonical_lemma_id(db: Session, lemma_id: int) -> int:
+    """Follow the canonical chain (multi-hop) to the root canonical.
+
+    Returns `lemma_id` itself if it is already canonical, the lemma is
+    missing, or a cycle is detected.
+    """
+    seen: set[int] = set()
+    current_id = lemma_id
+    while current_id not in seen:
+        seen.add(current_id)
+        row = (
+            db.query(Lemma.canonical_lemma_id)
+            .filter(Lemma.lemma_id == current_id)
+            .first()
+        )
+        if not row or row[0] is None:
+            return current_id
+        current_id = row[0]
+    return current_id
+
+
+def resolve_canonical_via_map(
+    lemma_id: int, canonical_by_id: dict[int, int | None]
+) -> int:
+    """Multi-hop resolution using a pre-loaded `lemma_id → canonical_lemma_id` map.
+
+    For hot paths (e.g. `build_session`) where we don't want a query per lemma.
+    """
+    seen: set[int] = set()
+    current_id = lemma_id
+    while current_id not in seen:
+        seen.add(current_id)
+        next_id = canonical_by_id.get(current_id)
+        if next_id is None:
+            return current_id
+        current_id = next_id
+    return current_id

--- a/backend/app/services/ocr_service.py
+++ b/backend/app/services/ocr_service.py
@@ -532,6 +532,11 @@ def process_textbook_page(
                 lemma_id = lookup_lemma(bare, lemma_lookup)
 
             if lemma_id:
+                # If lookup landed on a variant, redirect to its canonical so
+                # we never create or update a variant-scoped ULK row.
+                from app.services.canonical_resolution import resolve_canonical_lemma_id
+                lemma_id = resolve_canonical_lemma_id(db, lemma_id)
+
                 # Existing word — increment encounter count
                 lemma = db.query(Lemma).filter(Lemma.lemma_id == lemma_id).first()
                 ulk = knowledge_map.get(lemma_id)

--- a/backend/app/services/sentence_selector.py
+++ b/backend/app/services/sentence_selector.py
@@ -15,6 +15,7 @@ from typing import Optional
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import Session, joinedload
 
+from app.services.canonical_resolution import resolve_canonical_via_map
 from app.services.fsrs_service import parse_json_column
 from app.services.transliteration import transliterate_arabic, transliterate_forms
 
@@ -646,23 +647,40 @@ def build_session(
 
     due_lemma_ids: set[int] = set()
     stability_map: dict[int, float] = {}
-    knowledge_by_id: dict[int, UserLemmaKnowledge] = {}
+    knowledge_by_id: dict[int, UserLemmaKnowledge] = {k.lemma_id: k for k in all_knowledge}
 
-    # Build function word lemma ID set to exclude from scheduling
+    # Build function word lemma ID set + canonical chain map in one full Lemma scan.
     function_word_lemma_ids: set[int] = set()
-    lemma_bare_map = {
-        row.lemma_id: row.lemma_ar_bare
-        for row in db.query(Lemma.lemma_id, Lemma.lemma_ar_bare).all()
-    }
-    for lid, bare in lemma_bare_map.items():
-        if bare and _is_function_word(bare):
-            function_word_lemma_ids.add(lid)
+    lemma_bare_map: dict[int, str | None] = {}
+    canonical_chain: dict[int, int | None] = {}
+    for row in db.query(Lemma.lemma_id, Lemma.lemma_ar_bare, Lemma.canonical_lemma_id).all():
+        lemma_bare_map[row.lemma_id] = row.lemma_ar_bare
+        canonical_chain[row.lemma_id] = row.canonical_lemma_id
+        if row.lemma_ar_bare and _is_function_word(row.lemma_ar_bare):
+            function_word_lemma_ids.add(row.lemma_id)
+
+    # Variants whose canonical is already known/learning must not enter the
+    # schedule. The review pipeline credits the canonical (sentence_review_service.py
+    # line ~182), so the variant's own box never advances — sentences keep
+    # reappearing under "rescue" forever. Mirror of the guard already in
+    # _build_intro_cards (line ~1683-1688). Drop them from `all_knowledge` so
+    # every downstream consumer (almost_due_fill, fallback paths, etc.) sees
+    # the same filtered view.
+    overshadowed_variants: set[int] = set()
+    for k in all_knowledge:
+        canon_id = resolve_canonical_via_map(k.lemma_id, canonical_chain)
+        if canon_id != k.lemma_id:
+            canon_ulk = knowledge_by_id.get(canon_id)
+            if canon_ulk and canon_ulk.knowledge_state in ("known", "learning"):
+                overshadowed_variants.add(k.lemma_id)
+    if overshadowed_variants:
+        all_knowledge = [k for k in all_knowledge if k.lemma_id not in overshadowed_variants]
+        for vid in overshadowed_variants:
+            knowledge_by_id.pop(vid, None)
 
     overdue_days_map: dict[int, float] = {}  # lemma_id → days past due
 
     for k in all_knowledge:
-        knowledge_by_id[k.lemma_id] = k
-
         if k.knowledge_state == "encountered":
             continue  # passive vocab — not due, not scheduled
         if k.lemma_id in function_word_lemma_ids:

--- a/backend/app/services/word_selector.py
+++ b/backend/app/services/word_selector.py
@@ -734,6 +734,12 @@ def introduce_word(
     Returns the created knowledge record as dict.
     """
     from app.services.acquisition_service import start_acquisition
+    from app.services.canonical_resolution import resolve_canonical_lemma_id
+
+    # Variants must never get their own scheduling rows; redirect to canonical.
+    canonical_id = resolve_canonical_lemma_id(db, lemma_id)
+    if canonical_id != lemma_id:
+        lemma_id = canonical_id
 
     lemma = db.query(Lemma).filter(Lemma.lemma_id == lemma_id).first()
     if not lemma:

--- a/backend/scripts/suspend_variant_ulks.py
+++ b/backend/scripts/suspend_variant_ulks.py
@@ -1,0 +1,193 @@
+"""Cleanup script: suspend variant `UserLemmaKnowledge` rows whose canonical is known/learning,
+and remap `SentenceWord.lemma_id` + `Sentence.target_lemma_id` from variant to canonical.
+
+Background (2026-05-06): A user-visible bug — sentence `أُمِّي تُحِبُّ الشِّوَاءَ عادَةً.`
+kept appearing in review (8× shown, all "understood") because variant lemma #71
+(`أُمّي`) had its own ULK in acquiring box-1 while canonical #76 (`أُمّ`) was
+already known. Review credit was correctly going to canonical, but variant's
+own box never advanced — the screenshot showed "Rescue (recently shown)" forever.
+
+Found 36 such variants in production. This script:
+1. Finds all variants where canonical's ULK state is `known`/`learning` (multi-hop).
+2. Suspends those variant ULKs (keeps the row for audit; clears acquisition fields).
+3. Remaps `SentenceWord.lemma_id` and `Sentence.target_lemma_id` from variant → canonical.
+4. Logs the action via ActivityLog.
+
+Run with `--dry-run` first to inspect counts. The companion code change in
+`canonical_resolution.py` + `sentence_selector.build_session()` prevents
+new variant ULKs from being created post-deploy.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from collections import defaultdict
+
+from sqlalchemy import update
+
+from app.database import SessionLocal
+from app.models import Lemma, Sentence, SentenceWord, UserLemmaKnowledge
+from app.services.canonical_resolution import resolve_canonical_via_map
+from app.services.activity_log import log_activity
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger("suspend_variant_ulks")
+
+
+def find_overshadowed_variants(db) -> dict[int, int]:
+    """Return {variant_lemma_id: canonical_lemma_id} for ULKs that should be suspended.
+
+    Multi-hop: follows the chain to the root canonical. A variant is
+    overshadowed when the root canonical's ULK is `known` or `learning`.
+    """
+    canonical_chain: dict[int, int | None] = {
+        row.lemma_id: row.canonical_lemma_id
+        for row in db.query(Lemma.lemma_id, Lemma.canonical_lemma_id).all()
+    }
+    knowledge_state_by_id: dict[int, str] = {
+        row.lemma_id: row.knowledge_state
+        for row in db.query(UserLemmaKnowledge.lemma_id, UserLemmaKnowledge.knowledge_state).all()
+    }
+
+    overshadowed: dict[int, int] = {}
+    for lemma_id, state in knowledge_state_by_id.items():
+        if state == "suspended":
+            continue
+        canon_id = resolve_canonical_via_map(lemma_id, canonical_chain)
+        if canon_id == lemma_id:
+            continue  # canonical itself
+        if knowledge_state_by_id.get(canon_id) in ("known", "learning"):
+            overshadowed[lemma_id] = canon_id
+    return overshadowed
+
+
+def remap_sentence_words(db, variant_to_canonical: dict[int, int], dry_run: bool) -> int:
+    """Redirect SentenceWord.lemma_id from variant → canonical. Returns affected row count."""
+    if not variant_to_canonical:
+        return 0
+    total = 0
+    for variant_id, canonical_id in variant_to_canonical.items():
+        q = db.query(SentenceWord).filter(SentenceWord.lemma_id == variant_id)
+        affected = q.count()
+        if affected == 0:
+            continue
+        total += affected
+        if not dry_run:
+            db.execute(
+                update(SentenceWord)
+                .where(SentenceWord.lemma_id == variant_id)
+                .values(lemma_id=canonical_id)
+            )
+    return total
+
+
+def remap_sentence_targets(db, variant_to_canonical: dict[int, int], dry_run: bool) -> int:
+    """Redirect Sentence.target_lemma_id from variant → canonical. Returns affected row count."""
+    if not variant_to_canonical:
+        return 0
+    total = 0
+    for variant_id, canonical_id in variant_to_canonical.items():
+        q = db.query(Sentence).filter(Sentence.target_lemma_id == variant_id)
+        affected = q.count()
+        if affected == 0:
+            continue
+        total += affected
+        if not dry_run:
+            db.execute(
+                update(Sentence)
+                .where(Sentence.target_lemma_id == variant_id)
+                .values(target_lemma_id=canonical_id)
+            )
+    return total
+
+
+def suspend_variants(db, variant_to_canonical: dict[int, int], dry_run: bool) -> int:
+    """Suspend the variant ULKs. Preserves the row + audit fields."""
+    if not variant_to_canonical:
+        return 0
+    count = 0
+    for variant_id in variant_to_canonical:
+        ulk = (
+            db.query(UserLemmaKnowledge)
+            .filter(UserLemmaKnowledge.lemma_id == variant_id)
+            .first()
+        )
+        if not ulk:
+            continue
+        count += 1
+        if not dry_run:
+            ulk.knowledge_state = "suspended"
+            ulk.acquisition_box = None
+            ulk.acquisition_next_due = None
+            ulk.acquisition_started_at = None
+            ulk.entered_acquiring_at = None
+            ulk.fsrs_card_json = None
+    return count
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--dry-run", action="store_true", help="Print counts without writing.")
+    args = ap.parse_args()
+
+    db = SessionLocal()
+    try:
+        overshadowed = find_overshadowed_variants(db)
+        if not overshadowed:
+            logger.info("No overshadowed variants found. Nothing to do.")
+            return
+
+        # Pretty preview
+        canon_count = defaultdict(int)
+        for v, c in overshadowed.items():
+            canon_count[c] += 1
+        logger.info(
+            "Found %d overshadowed variants across %d canonicals.",
+            len(overshadowed), len(canon_count),
+        )
+        for v, c in list(overshadowed.items())[:20]:
+            v_lemma = db.query(Lemma).filter(Lemma.lemma_id == v).first()
+            c_lemma = db.query(Lemma).filter(Lemma.lemma_id == c).first()
+            logger.info(
+                "  variant #%d (%s) → canonical #%d (%s)",
+                v, v_lemma.lemma_ar if v_lemma else "?",
+                c, c_lemma.lemma_ar if c_lemma else "?",
+            )
+        if len(overshadowed) > 20:
+            logger.info("  …and %d more", len(overshadowed) - 20)
+
+        suspended = suspend_variants(db, overshadowed, args.dry_run)
+        sw_remapped = remap_sentence_words(db, overshadowed, args.dry_run)
+        st_remapped = remap_sentence_targets(db, overshadowed, args.dry_run)
+
+        logger.info(
+            "%s: %d ULKs to suspend, %d sentence_word rows to remap, %d sentence target_lemma_id to remap.",
+            "DRY-RUN" if args.dry_run else "APPLIED",
+            suspended, sw_remapped, st_remapped,
+        )
+
+        if not args.dry_run:
+            db.commit()
+            log_activity(
+                db,
+                event_type="manual_action",
+                summary=(
+                    f"Suspended {suspended} variant ULKs whose canonical is known/learning, "
+                    f"remapped {sw_remapped} sentence_word rows + {st_remapped} sentence targets."
+                ),
+                detail={
+                    "variant_count": suspended,
+                    "sentence_word_remapped": sw_remapped,
+                    "sentence_target_remapped": st_remapped,
+                    "script": "suspend_variant_ulks.py",
+                },
+            )
+            db.commit()
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main() or 0)

--- a/backend/tests/test_sentence_selector.py
+++ b/backend/tests/test_sentence_selector.py
@@ -284,6 +284,50 @@ class TestGreedySetCover:
         word_only = [i for i in result["items"] if i.get("sentence_id") is None]
         assert len(word_only) == 0
 
+    def test_variant_with_known_canonical_is_not_scheduled(self, db_session):
+        """Regression for the أُمِّي / أُمّ bug (2026-05-06).
+
+        When a variant lemma has its own ULK in acquiring/FSRS state but the
+        canonical is already known/learning, the variant must be excluded from
+        `due_lemma_ids`. Otherwise the user keeps seeing the same sentence
+        forever: review credit goes to the canonical (sentence_review_service),
+        but the variant's box never advances.
+        """
+        # Canonical: أُمّ ("mother") — known, not yet due
+        _seed_word(db_session, 1, "ام", "mother", state="known", stability=100.0, due_hours=24 * 30)
+        # Variant: أُمّي ("my mother") with canonical_lemma_id=1
+        variant_lemma = Lemma(
+            lemma_id=2, lemma_ar="أمي", lemma_ar_bare="امي",
+            pos="noun", gloss_en="my mother", canonical_lemma_id=1,
+        )
+        db_session.add(variant_lemma)
+        db_session.flush()
+        # Give the variant its own acquiring ULK (the bug condition).
+        variant_ulk = UserLemmaKnowledge(
+            lemma_id=2,
+            knowledge_state="acquiring",
+            acquisition_box=1,
+            acquisition_next_due=datetime.now(timezone.utc) - timedelta(days=18),
+            entered_acquiring_at=datetime.now(timezone.utc) - timedelta(days=18),
+            source="textbook_scan",
+        )
+        db_session.add(variant_ulk)
+        # Sentence targeting the variant (mirrors production sentence #41263).
+        _seed_sentence(db_session, 99, "أمي تحب", "my mother loves",
+                       target_lemma_id=2,
+                       word_surfaces_and_ids=[("أمي", 2), ("تحب", 1)])
+        db_session.commit()
+
+        result = build_session(db_session, limit=10)
+        # The variant must NOT contribute to due_lemma_ids; the canonical is
+        # known and not due. Hence no items.
+        target_lemma_ids = {i.get("primary_lemma_id") for i in result["items"]}
+        assert 2 not in target_lemma_ids, (
+            f"Variant lemma 2 should be skipped (canonical is known), "
+            f"but session selected it. items={result['items']}"
+        )
+        assert result["total_due_words"] == 0
+
 
 class TestSessionOrdering:
     def test_easy_sentences_at_bookends(self, db_session):


### PR DESCRIPTION
## Summary

- Variants that have their own `UserLemmaKnowledge` row but whose canonical is `known`/`learning` are now skipped from `due_lemma_ids` in `build_session()`. The screenshot bug — `أُمِّي` (#71) showing as Acquiring (box 1) for an 8th time despite canonical `أُمّ` (#76) being known with stability 107d — was caused by review credit going to canonical (correct) while scheduling kept happening on the variant (bug).
- All `start_acquisition()` and `introduce_word()` callers (including `_ensure_session_words_have_intro_state`, `quran_service`, `ocr_service`, `leech_service`, `/api/learn/introduce`) now redirect a variant `lemma_id` to its multi-hop root canonical at the function entry. Direct `db.add(UserLemmaKnowledge(...))` sites in `book_import_service` and the OCR cold-encounter path call `resolve_canonical_lemma_id` explicitly.
- New `app/services/canonical_resolution.py` provides the redirect helper (`resolve_canonical_lemma_id` + `resolve_canonical_via_map`).
- Cleanup script `backend/scripts/suspend_variant_ulks.py`: suspends overshadowed variant ULKs and remaps their `SentenceWord.lemma_id` + `Sentence.target_lemma_id` to canonical. Verified on a prod DB copy: 39 variants suspended, 3017 sentence_word rows + 547 sentence targets remapped, 0 overshadowed remain.
- Regression test `test_variant_with_known_canonical_is_not_scheduled` covers the screenshot scenario.

## Deployment

After merge:
1. `ssh alif "cp /opt/alif/backend/data/alif.db /opt/alif-backups/alif_pre_variant_fix_\$(date +%Y%m%d_%H%M%S).db"`
2. Pull + restart backend.
3. `ssh alif "cd /opt/alif/backend && PYTHONPATH=/opt/limbic .venv/bin/python3 scripts/suspend_variant_ulks.py --dry-run"` then real run.
4. Verify: query for overshadowed variants returns 0; sentence #41263 `target_lemma_id` is 76.