### PR TITLE
Persist shown-intro set in AsyncStorage (fix re-fire after iOS suspend)

### DIFF
--- a/frontend/app/index.tsx
+++ b/frontend/app/index.tsx
@@ -53,6 +53,7 @@ import {
 } from "../lib/types";
 import { posLabel, FormsRow, FormsStrip, GrammarRow, PlayButton } from "../lib/WordCardComponents";
 import { syncEvents } from "../lib/sync-events";
+import { getShownIntroLemmaIds, markIntroShown } from "../lib/offline-store";
 import { flushQueue } from "../lib/sync-queue";
 import { useNetStatus } from "../lib/net-status";
 import ActionMenu from "../lib/review/ActionMenu";
@@ -275,11 +276,13 @@ export function ReviewScreen({ fixedMode }: { fixedMode: ReviewMode }) {
   const [reintroCards, setReintroCards] = useState<ReintroCard[]>([]);
   const [reintroIndex, setReintroIndex] = useState(0);
   const [experimentIntroCards, setExperimentIntroCards] = useState<ReintroCard[]>([]);
-  // Track intro lemmas already shown in this UI session, so background
-  // refreshes (applyFreshSession) don't re-emit a card the user just dismissed
-  // — server ack lag through the sync queue can leave `experiment_intro_shown_at`
-  // unset when the next prefetch returns. Bug: lemmas 259/464/596 fired 3-4×
-  // in a single 10-min session on 2026-05-06.
+  // Track intro lemmas already shown to the user (last 24h), so cached
+  // sessions and background refreshes don't replay them. Backed by AsyncStorage
+  // so it survives component remounts (iOS app suspend/restore). useRef-only
+  // dedup was insufficient — bug observed 2026-05-06 sessions 4-5: lemmas
+  // 308/345/3103/255/321 each fired 2-4× across resumed sessions because the
+  // ref reset on remount and the cached AsyncStorage session still listed
+  // them as intros.
   const shownIntroLemmaIdsRef = useRef<Set<number>>(new Set());
   const [verseCards, setVerseCards] = useState<VerseCard[]>([]);
   const [verseFlipped, setVerseFlipped] = useState(false);
@@ -346,7 +349,17 @@ export function ReviewScreen({ fixedMode }: { fixedMode: ReviewMode }) {
       playsInSilentModeIOS: true,
       staysActiveInBackground: false,
     });
-    loadSession();
+    // Hydrate the persisted shown-intro set BEFORE loading the session, so
+    // buildInterleavedSession can filter out already-acked intros even on a
+    // fresh component mount (iOS app suspend / restart).
+    (async () => {
+      try {
+        shownIntroLemmaIdsRef.current = await getShownIntroLemmaIds();
+      } catch {
+        shownIntroLemmaIdsRef.current = new Set();
+      }
+      await loadSession();
+    })();
     return () => {
       cleanupSound();
     };
@@ -394,6 +407,12 @@ export function ReviewScreen({ fixedMode }: { fixedMode: ReviewMode }) {
 
     for (const lemmaId of acknowledgedIntros) {
       shownIntroLemmaIdsRef.current.add(lemmaId);
+      // Fire-and-forget the AsyncStorage write so the next prefetch (or app
+      // remount) sees this intro as already-shown even if the network ack
+      // hasn't reached the server yet. acknowledgeExperimentIntro also calls
+      // markIntroShown internally, but doing it here too closes the gap if
+      // the server POST fails.
+      markIntroShown(lemmaId).catch(() => {});
       acknowledgeExperimentIntro(lemmaId, sentenceSession.session_id).catch(() => {});
     }
 
@@ -552,7 +571,9 @@ export function ReviewScreen({ fixedMode }: { fixedMode: ReviewMode }) {
     setReintroCards([]);
     setReintroIndex(0);
     setExperimentIntroCards([]);
-    shownIntroLemmaIdsRef.current = new Set();
+    // NB: do NOT reset shownIntroLemmaIdsRef here. The persisted AsyncStorage
+    // entries have a 24h TTL — clearing on every loadSession() would re-open
+    // the door to cached sessions replaying intros the user already saw.
     setGrammarLessons([]);
     setGrammarLessonIndex(0);
     setGrammarLessonsLoading(false);
@@ -1899,6 +1920,7 @@ export function ReviewScreen({ fixedMode }: { fixedMode: ReviewMode }) {
             style={styles.reintroRememberBtn}
             onPress={() => {
               shownIntroLemmaIdsRef.current.add(card.lemma_id);
+              markIntroShown(card.lemma_id).catch(() => {});
               acknowledgeExperimentIntro(
                 card.lemma_id,
                 sentenceSession?.session_id,

--- a/frontend/lib/__tests__/offline-store.test.ts
+++ b/frontend/lib/__tests__/offline-store.test.ts
@@ -12,6 +12,8 @@ import {
   clearStoryLookups,
   cacheWordLookup,
   getCachedWordLookup,
+  markIntroShown,
+  getShownIntroLemmaIds,
 } from "../offline-store";
 
 const store = (AsyncStorage as any)._store;
@@ -113,6 +115,48 @@ describe("cacheSessions / getCachedSession", () => {
 
     const result = await getCachedSession("reading");
     expect(result).toBeNull();
+  });
+
+  it("filters out already-shown intros from cached session", async () => {
+    const session = {
+      ...makeSession("s-1", [
+        { sentence_id: 1, primary_lemma_id: 10, words: [] },
+      ]),
+      experiment_intro_cards: [
+        { lemma_id: 308, lemma_ar: "كَامِيرَا", gloss_en: "camera" },
+        { lemma_id: 999, lemma_ar: "x", gloss_en: "y" },
+      ],
+    };
+    await cacheSessions("reading", [session as any]);
+    await markIntroShown(308);
+
+    const result = await getCachedSession("reading");
+    expect(result).not.toBeNull();
+    const introIds = (result!.experiment_intro_cards ?? []).map((c: any) => c.lemma_id);
+    expect(introIds).not.toContain(308);
+    expect(introIds).toContain(999);
+  });
+});
+
+describe("markIntroShown / getShownIntroLemmaIds", () => {
+  it("persists across calls", async () => {
+    await markIntroShown(42);
+    await markIntroShown(7);
+    const set = await getShownIntroLemmaIds();
+    expect(set.has(42)).toBe(true);
+    expect(set.has(7)).toBe(true);
+  });
+
+  it("expires entries older than 24h", async () => {
+    // Hand-craft a stale entry
+    const stale = Date.now() - 25 * 60 * 60 * 1000;
+    (AsyncStorage as any)._store["@alif/shown-intros"] = JSON.stringify([
+      [42, stale],
+      [7, Date.now()],
+    ]);
+    const set = await getShownIntroLemmaIds();
+    expect(set.has(42)).toBe(false);
+    expect(set.has(7)).toBe(true);
   });
 });
 

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -54,6 +54,7 @@ import {
   getCachedWordLookup,
   cacheWordLookupBatch,
   getCachedSentenceIds,
+  markIntroShown,
 } from "./offline-store";
 import { enqueueReview, flushQueue, removeFromQueue } from "./sync-queue";
 
@@ -931,6 +932,10 @@ export async function acknowledgeExperimentIntro(
   lemmaId: number,
   sessionId?: string,
 ): Promise<{ status: string }> {
+  // Persist the lemma_id so cached sessions (loaded after iOS suspend / app
+  // restart) don't replay the intro card. The useRef-only dedup in index.tsx
+  // resets on component remount and was insufficient.
+  await markIntroShown(lemmaId);
   await enqueueReview("experiment_intro_ack", {
     lemma_id: lemmaId,
     session_id: sessionId,

--- a/frontend/lib/offline-store.ts
+++ b/frontend/lib/offline-store.ts
@@ -13,6 +13,7 @@ const WORD_LOOKUP_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
 const KEYS = {
   sessions: (mode: ReviewMode) => `@alif/sessions/${mode}`,
   reviewed: "@alif/reviewed",
+  shownIntros: "@alif/shown-intros",
   words: "@alif/words",
   stats: "@alif/stats",
   analytics: "@alif/analytics",
@@ -23,6 +24,11 @@ const KEYS = {
   wordLookupsLegacy: "@alif/word-lookups",
   lastSessionWords: "@alif/last-session-words",
 };
+
+// 24h: short enough that the server's Category 2 rescue card (7-day cooldown)
+// can re-fire when we want it to; long enough to cover any plausible session
+// resume window after the app is suspended/remounted.
+const SHOWN_INTRO_TTL_MS = 24 * 60 * 60 * 1000;
 
 const MAX_CACHED_SESSIONS = 20;
 const SESSION_STALENESS_MS = 30 * 60 * 1000; // 30 minutes
@@ -79,6 +85,7 @@ export async function getCachedSession(
   const key = KEYS.sessions(mode);
   const raw = (await getJson<CachedSessionEntry[] | SentenceReviewSession[]>(key)) ?? [];
   const reviewed = await getReviewedSet();
+  const shownIntros = await getShownIntroLemmaIds();
   const now = Date.now();
 
   // Normalize: support both old format (plain sessions) and new (with cached_at)
@@ -107,7 +114,16 @@ export async function getCachedSession(
         )
     );
     if (remaining.length > 0) {
-      return { ...session, items: remaining };
+      // Strip intros the user already dismissed (24h window). Otherwise a
+      // session resumed after iOS suspend/restart will replay them.
+      const filteredIntros = (session.experiment_intro_cards ?? []).filter(
+        (c) => !shownIntros.has(c.lemma_id),
+      );
+      return {
+        ...session,
+        items: remaining,
+        experiment_intro_cards: filteredIntros,
+      };
     }
   }
   // All sessions exhausted — prune stale reviewed keys in background
@@ -149,6 +165,41 @@ export async function markReviewed(
 async function getReviewedSet(): Promise<Set<string>> {
   const arr = (await getJson<string[]>(KEYS.reviewed)) ?? [];
   return new Set(arr);
+}
+
+// --- Shown intro tracking -----------------------------------------------
+// Persisted across app restarts so cached sessions don't re-fire intros the
+// user already dismissed. Bug (2026-05-06): a useRef-only dedup reset on
+// component remount; iOS app suspend/restore looked like a fresh mount, and
+// AsyncStorage replayed the cached session which still had intros for already-
+// acked lemmas. Server filters once `experiment_intro_shown_at` is set, but
+// only on FRESH responses — cached responses bypass that filter entirely.
+
+export async function markIntroShown(lemmaId: number): Promise<void> {
+  const map = await getShownIntroMap();
+  map.set(lemmaId, Date.now());
+  await persistShownIntroMap(map);
+}
+
+export async function getShownIntroLemmaIds(): Promise<Set<number>> {
+  const map = await getShownIntroMap();
+  return new Set(map.keys());
+}
+
+async function getShownIntroMap(): Promise<Map<number, number>> {
+  const raw = (await getJson<[number, number][]>(KEYS.shownIntros)) ?? [];
+  const cutoff = Date.now() - SHOWN_INTRO_TTL_MS;
+  const map = new Map<number, number>();
+  for (const [lid, ts] of raw) {
+    if (ts >= cutoff) map.set(lid, ts);
+  }
+  return map;
+}
+
+async function persistShownIntroMap(map: Map<number, number>): Promise<void> {
+  const cutoff = Date.now() - SHOWN_INTRO_TTL_MS;
+  const arr = Array.from(map.entries()).filter(([, ts]) => ts >= cutoff);
+  await setJson(KEYS.shownIntros, arr);
 }
 
 export async function unmarkReviewed(


### PR DESCRIPTION
## Summary

PR #68's useRef-only dedup didn't survive component remounts. iOS suspended the app (memory pressure, backgrounded > N min) and re-mounted the component with an empty ref. AsyncStorage's cached session still listed intros for lemmas the user already dismissed, so they re-fired — observed in 2026-05-06 sessions 4-5 where lemmas 308/345/3103/255/321 each fired 2-4× across resumed sessions.

The server-side `experiment_intro_shown_at` filter correctly suppresses already-shown intros on FRESH responses, but cached AsyncStorage sessions bypass it entirely.

Three changes:

- **`markIntroShown` / `getShownIntroLemmaIds`** in `offline-store.ts`, backed by `@alif/shown-intros` (24h TTL). Long enough to cover any session resume; short enough that server's Category 2 rescue card (7-day cooldown) can still fire later.
- **`acknowledgeExperimentIntro`** + Continue button + auto-skip loop all call `markIntroShown` (fire-and-forget so it doesn't block UI advance).
- **`getCachedSession`** strips already-shown intros from `experiment_intro_cards` on retrieval. Belt-and-braces: cached sessions can't replay stale intros even if the in-memory ref is mid-hydration.

`loadSession` no longer resets the ref — TTL handles staleness.

Tests: 2 new offline-store tests covering persistence + 24h TTL + cached-session intro filter.