### PR TITLE
Log every card the user sees on screen

### DIFF
--- a/backend/app/routers/review.py
+++ b/backend/app/routers/review.py
@@ -446,6 +446,39 @@ def submit_reintro_result(
     return {"status": "ok", "result": body.result, "lemma_id": body.lemma_id}
 
 
+class CardShownIn(PydanticBaseModel):
+    """What the user actually sees on screen.
+
+    Logged from the frontend on every card transition so we can reconstruct
+    the user's session card-by-card — not just the acks. Without this, intro
+    cards re-firing or being skipped were invisible until the user clicked
+    Continue (which writes the ack and the only log entry).
+    """
+    card_type: str  # "intro" | "sentence" | "reintro" | "verse" | "grammar" | "wrapup"
+    session_id: str | None = None
+    lemma_id: int | None = None
+    sentence_id: int | None = None
+    card_index: int | None = None
+    total_cards: int | None = None
+    detail: dict | None = None
+
+
+@router.post("/log-card-shown")
+def log_card_shown(body: CardShownIn):
+    """Fire-and-forget: record that a card transitioned onto the user's screen."""
+    log_interaction(
+        event="card_shown",
+        card_type=body.card_type,
+        session_id=body.session_id,
+        lemma_id=body.lemma_id,
+        sentence_id=body.sentence_id,
+        card_index=body.card_index,
+        total_cards=body.total_cards,
+        detail=body.detail,
+    )
+    return {"status": "ok"}
+
+
 class ExperimentIntroAckIn(PydanticBaseModel):
     lemma_id: int
     session_id: str | None = None

--- a/frontend/app/index.tsx
+++ b/frontend/app/index.tsx
@@ -34,6 +34,7 @@ import {
   getWrapUpCards,
   getConfusionHelp,
   generateUuid,
+  logCardShown,
   BASE_URL,
 } from "../lib/api";
 import {
@@ -435,6 +436,97 @@ export function ReviewScreen({ fixedMode }: { fixedMode: ReviewMode }) {
       showTime.current = Date.now();
     }
   }, [cardIndex, cardState]);
+
+  // Trace what the user actually sees on screen, card by card. Without this
+  // we only had ack-driven events (`experiment_intro_shown`, `sentence_review`)
+  // which fire on USER ACTION — invisible to a card that re-rendered, was
+  // auto-skipped, or got replaced by a background prefetch. This event is
+  // fire-and-forget and tagged so we can reconstruct the exact card sequence
+  // the user experienced.
+  useEffect(() => {
+    if (!sentenceSession || sessionSlots.length === 0) return;
+    const slot = sessionSlots[cardIndex];
+    if (!slot) return;
+    const sid = sentenceSession.session_id;
+    const total = sessionSlots.length;
+    if (slot.type === "experiment_intro") {
+      const card = experimentIntroCards[slot.introIndex];
+      if (card) {
+        logCardShown({
+          card_type: "intro",
+          session_id: sid,
+          lemma_id: card.lemma_id,
+          card_index: cardIndex,
+          total_cards: total,
+          detail: { times_seen: card.times_seen ?? 0, source: card.source ?? null },
+        });
+      }
+    } else if (slot.type === "sentence") {
+      const item = sentenceSession.items[slot.itemIndex];
+      if (item) {
+        logCardShown({
+          card_type: "sentence",
+          session_id: sid,
+          sentence_id: item.sentence_id,
+          lemma_id: item.primary_lemma_id,
+          card_index: cardIndex,
+          total_cards: total,
+        });
+      }
+    } else if (slot.type === "verse") {
+      const verse = verseCards[slot.verseIndex];
+      if (verse) {
+        logCardShown({
+          card_type: "verse",
+          session_id: sid,
+          card_index: cardIndex,
+          total_cards: total,
+          detail: { verse_id: (verse as any).verse_id ?? null },
+        });
+      }
+    }
+  }, [cardIndex, sessionSlots, sentenceSession, experimentIntroCards, verseCards]);
+
+  // Also trace the non-slot card flows (reintro, grammar, wrap-up).
+  useEffect(() => {
+    const card = reintroCards[reintroIndex];
+    if (card) {
+      logCardShown({
+        card_type: "reintro",
+        session_id: sentenceSession?.session_id,
+        lemma_id: card.lemma_id,
+        card_index: reintroIndex,
+        total_cards: reintroCards.length,
+      });
+    }
+  }, [reintroIndex, reintroCards, sentenceSession?.session_id]);
+
+  useEffect(() => {
+    const lesson = grammarLessons[grammarLessonIndex];
+    if (lesson) {
+      logCardShown({
+        card_type: "grammar",
+        session_id: sentenceSession?.session_id,
+        card_index: grammarLessonIndex,
+        total_cards: grammarLessons.length,
+        detail: { feature_key: lesson.feature_key, is_refresher: !!lesson.is_refresher },
+      });
+    }
+  }, [grammarLessonIndex, grammarLessons, sentenceSession?.session_id]);
+
+  useEffect(() => {
+    if (!inWrapUp) return;
+    const card = wrapUpCards[wrapUpIndex];
+    if (card) {
+      logCardShown({
+        card_type: "wrapup",
+        session_id: sentenceSession?.session_id,
+        lemma_id: card.lemma_id,
+        card_index: wrapUpIndex,
+        total_cards: wrapUpCards.length,
+      });
+    }
+  }, [inWrapUp, wrapUpIndex, wrapUpCards, sentenceSession?.session_id]);
 
   // TTS audio playback for listening mode — wait until session data is loaded
   useEffect(() => {

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -928,6 +928,26 @@ export async function submitReintroResult(
   return { status: "queued", result, lemma_id: lemmaId };
 }
 
+export interface CardShownPayload {
+  card_type: "intro" | "sentence" | "reintro" | "verse" | "grammar" | "wrapup";
+  session_id?: string | null;
+  lemma_id?: number | null;
+  sentence_id?: number | null;
+  card_index?: number | null;
+  total_cards?: number | null;
+  detail?: Record<string, unknown> | null;
+}
+
+/** Fire-and-forget: tell the backend the user is now seeing this card. */
+export function logCardShown(payload: CardShownPayload): void {
+  if (!netStatus.isOnline) return;
+  fetch(`${BASE_URL}/api/review/log-card-shown`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  }).catch(() => {});
+}
+
 export async function acknowledgeExperimentIntro(
   lemmaId: number,
   sessionId?: string,


### PR DESCRIPTION
## Summary

Backend `POST /api/review/log-card-shown` + frontend `logCardShown` instrumentation. Five useEffects in index.tsx fire on every card transition (intro, sentence, verse, reintro, grammar, wrap-up). The analyzer can now reconstruct the exact card sequence the user experienced.

Until now, only ack-driven events were logged (`experiment_intro_shown` fires on ack endpoint hit; `sentence_review` fires on submit). Auto-skipped cards, re-rendered cards, cards replaced by a background prefetch — all invisible. Made it impossible to verify whether intro re-fire fixes were working without a user report.

Fire-and-forget POST, online-only. No effect on session-build performance.

## Verifying after deploy

Pull today's interaction log and grep for `card_shown` events. Each event has `card_type`, `session_id`, `lemma_id`/`sentence_id`, `card_index`, `total_cards`. Sequence of events under a single session_id = the user's card-by-card timeline.