### PR TITLE
Guard word_category when pos='noun_prop' to stop proper-name intro cards

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -2,6 +2,7 @@ from datetime import datetime, timezone
 from sqlalchemy import (
     Column, Integer, String, Text, Float, DateTime, ForeignKey, JSON, Boolean,
     UniqueConstraint,
+    event,
 )
 from sqlalchemy.orm import relationship, validates
 
@@ -64,6 +65,17 @@ class Lemma(Base):
     knowledge = relationship("UserLemmaKnowledge", back_populates="lemma", uselist=False)
     reviews = relationship("ReviewLog", back_populates="lemma")
     story_words = relationship("StoryWord", back_populates="lemma")
+
+
+@event.listens_for(Lemma, "before_insert")
+def _ensure_proper_name_category(mapper, connection, target):
+    # `pos` and `word_category` independently encode "is this a proper noun" and
+    # used to drift apart silently — `pos='noun_prop'` lemmas with NULL
+    # word_category leaked past the proper-name filters in word_selector,
+    # sentence_selector, and sentence_review_service, producing intro cards for
+    # country/city/personal names. Guarantee they agree at insert time.
+    if target.pos == "noun_prop" and target.word_category is None:
+        target.word_category = "proper_name"
 
 
 class UserLemmaKnowledge(Base):

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -97,3 +97,43 @@ def test_sentence_with_words(db_session):
     fetched = db_session.query(Sentence).first()
     assert len(fetched.words) == 1
     assert fetched.words[0].is_target_word is True
+
+
+def test_noun_prop_auto_sets_word_category(db_session):
+    lemma = Lemma(
+        lemma_ar="ثَمِينَه",
+        lemma_ar_bare="ثمينه",
+        pos="noun_prop",
+        gloss_en="Thameena",
+        source="book",
+    )
+    db_session.add(lemma)
+    db_session.flush()
+    assert lemma.word_category == "proper_name"
+
+
+def test_explicit_word_category_not_overwritten(db_session):
+    lemma = Lemma(
+        lemma_ar="بُوم",
+        lemma_ar_bare="بوم",
+        pos="noun_prop",
+        word_category="onomatopoeia",
+        gloss_en="boom",
+        source="manual",
+    )
+    db_session.add(lemma)
+    db_session.flush()
+    assert lemma.word_category == "onomatopoeia"
+
+
+def test_non_noun_prop_word_category_untouched(db_session):
+    lemma = Lemma(
+        lemma_ar="كِتَاب",
+        lemma_ar_bare="كتاب",
+        pos="noun",
+        gloss_en="book",
+        source="manual",
+    )
+    db_session.add(lemma)
+    db_session.flush()
+    assert lemma.word_category is None


### PR DESCRIPTION
## Summary
- Add `before_insert` listener on `Lemma`: when `pos='noun_prop'` and `word_category IS NULL`, force `word_category='proper_name'`.
- Closes a long-running leak where personal/place-name lemmas (Thameena, Al-Razi, Bakr, Zakariya, Oslo, Sanaa) appeared as full New Word intro cards because the inert-proper-name filters all key on `word_category`, not `pos`.
- 3 model tests cover the guard, explicit-category preservation, and non-noun_prop bypass.

## Background
21+ `Lemma(...)` creation sites; CAMeL-driven imports (textbook_scan, book, story_import) populated `pos` from morphology but left `word_category` for a downstream pass that didn't always run. An event listener catches every existing and future creation site with one piece of code.

## Data backfill (separate, already applied to prod)
Re-ran `import_quality.classify_lemmas` over the 101 dirty rows: 12 → `proper_name`, 82 had `pos` corrected to `noun` (CAMeL misclassifications like "modern", "painter", "Syria"), 7 loanword "junk" entries left for review. DB backed up at `/opt/alif-backups/alif_pre_proper_name_backfill_20260506_212717.db`. Activity logged.