### PR TITLE
Clitic-leftover audit: clean 88 of 95 dirty lemmas

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -129,8 +129,8 @@ Prefer focused sessions. If a task has 4+ distinct parts, suggest breaking into 
 ## gh CLI / Go binaries TLS error in sandbox (2026-04-24)
 - [Details](feedback_gh_sandbox_tls.md) — `OSStatus -26276` from gh/terraform/tofu = Claude Code sandbox blocking `com.apple.trustd` Mach IPC. Retry the same command with `dangerouslyDisableSandbox: true` immediately. Don't waste time on auth, GODEBUG, or `brew upgrade gh`.
 
-## 🟡 1sg possessive clitic leftover audit — 35 dirty lemmas (open, 2026-05-06)
-- [Details](project_clitic_my_leftover_audit.md) — `جدي`, `بيتي`, `أبي` etc. — bare form keeps ـِي. 17 duolingo, 17 textbook_scan, 1 story_import. All predate the 2026-04-24 clitic-aware dedup fix. Cleanup needs canonical-merge + UserLemmaKnowledge follow. Branch: `sh/clitic-my-leftover-audit`.
+## Clitic-leftover audit — 95 lemmas, 88 cleaned (done 2026-05-06)
+- [Details](project_clitic_my_leftover_audit.md) — Broadened from 35 "my X" to all proclitics+enclitics. 75 ALREADY_LINKED stale-wiring cleanups, 7 link-to-existing, 6 create-new-canonical (ميثاق, طغيان, تجارة, اتقى, افسد, مجال). Script: `backend/scripts/cleanup_clitic_leftovers.py`.
 
 ## Architecture Notes (not in CLAUDE.md)
 - FSRS stability floor: "known" with stability < 1.0 -> "lapsed"

--- a/.claude/memory/project_clitic_my_leftover_audit.md
+++ b/.claude/memory/project_clitic_my_leftover_audit.md
@@ -1,21 +1,13 @@
 ---
-name: 1sg possessive clitic leftover audit (35 lemmas)
-description: Pre-2026-04-24 dirty lemmas where bare form keeps the ـِي 1sg possessive clitic — 35 in prod, three import sources, separate from active code path
+name: Clitic-leftover audit (95 lemmas, 88 cleaned)
+description: Pre-2026-04-24 dirty lemmas where bare form kept an unstripped Arabic clitic. Closed via cleanup_clitic_leftovers.py.
 type: project
 originSessionId: e1c13bb6-518c-4982-8330-d1ab3675caab
 ---
-35 prod lemmas where `lemma_ar_bare` ends in ي and `gloss_en` starts with "my " — the 1sg possessive clitic was not stripped at import. By source: 17 from `duolingo`, 17 from `textbook_scan`, 1 from `story_import` ("Prince of Physicians" story_id=20, 2026-03-21).
+Started as the 35-lemma 1sg possessive ("my X") cohort, broadened on 2026-05-06 to all Arabic proclitics + enclitics. Two-signal audit (bare-form clitic shape + matching English gloss prefix) found 95 lemmas total in prod. Cleaned 88 of them via `backend/scripts/cleanup_clitic_leftovers.py` — three idempotent phases (A: stale-wiring repoint, B: link to existing canonicals, C: create new canonicals + link). 7 false positives were ل-initial verbs glossed "to V" (English infinitive, not "for X" proclitic) — left alone.
 
-Examples: `جدي` "my grandfather" → should be `جد`. `بيتي` "my house" → `بيت`. `اسمي` "my name" → `اسم`. `أبي` "my father" → `أب`. `كتبي` "my books" → `كتاب`. Concrete trigger that surfaced this (2026-05-06): lemma 2652 `مَجالِي` "my field" shown as a New Word intro card — the canonical `مجال` doesn't exist yet, so book/corpus sentences containing `مجال` got mapped to this dirty lemma.
+**Why:** All hits predate the 2026-04-24 clitic-aware dedup work. The 2026-04-27 lemma-decomposition audit (Phase 2 step 4c) tagged 91 of these and linked 17 to canonicals, but a residual cohort survived because the prior pass didn't always reassign downstream sentence_words / review_log / target_lemma_id refs at link time, and 13 had no canonical at all. The active import path is now correct.
 
-**Why:** Predates the clitic-aware dedup work. CLAUDE.md memory says "ALL 11 lemma-creation sites now use clitic-aware dedup ... patched in Phase 2 step 1 of the lemma-decomposition audit (2026-04-24)." The active code path is fixed. This is leftover data, not a recurring bug. The `run_quality_gates()` enrichment pass marks `gates_completed_at` but doesn't re-decompose the bare form, and the lemma-decomposition audit's compound focus didn't sweep clitic-attached possessives in the noun vocabulary.
+**How to apply:** When the user reports a "my X" / "and X" / "with X" intro card or a sentence-mapping anomaly that smells like a clitic-attached compound was treated as a real lemma, the audit + cleanup is already done as of 2026-05-06. New leftovers shouldn't appear on this scale because every lemma-creation site uses `resolve_existing_lemma()`. If a new instance does surface, treat it as a one-off data fix using the same `merge_orphan_into_canonical` primitive from `apply_step4c_link_survivors.py:68–121`. **Don't** add ـي to `ENCLITICS` in `sentence_validator.py` — it would over-strip defective verbs (قاضي), relational adjectives (عربي), and dual obliques. The gloss-driven audit's two-signal design is the safer way to surface ـي leftovers.
 
-**How to apply:** When the user reports a "my X" intro card or a sentence-mapping anomaly on a noun, suspect this audit. Don't hot-patch a single lemma — they're systemic. Cleanup needs (a) decide canonical for each, (b) check if the canonical lemma already exists, (c) merge via `canonical_lemma_id` (or create canonical + redirect). `SentenceWord.lemma_id` and `UserLemmaKnowledge` rows must follow the redirect — UserLemmaKnowledge especially is live FSRS data, so any merge script needs a dry-run + activity_log entry + DB backup. Branch name when picked up: `sh/clitic-my-leftover-audit`.
-
-Audit query that surfaces them:
-```python
-db.query(Lemma).filter(
-    Lemma.lemma_ar_bare.like("%ي"),
-    Lemma.gloss_en.like("my %"),
-).all()
-```
+The 6 newly-created canonicals (lemma_id 3349–3354) are ميثاق "covenant", طغيان "transgression", تجارة "trade", اتقى "to fear", افسد "to corrupt", مجال "field". All went through `run_quality_gates(enrich=True)` synchronously so they have proper roots, transliteration, etymology, and forms_json populated by Claude Haiku.

--- a/IDEAS.md
+++ b/IDEAS.md
@@ -23,7 +23,7 @@ shape + matching English gloss prefix). Found 95 hits in prod:
 
 Concrete trigger: lemma #2652 `مَجالِي` "my field" appeared as a New Word
 intro card because the canonical `مجال` didn't exist; book/corpus sentences
-containing بare `مجال` got mapped to the dirty compound.
+containing the bare form `مجال` got mapped to the dirty compound.
 
 Implementation: `backend/scripts/cleanup_clitic_leftovers.py` (idempotent,
 three phases). Reuses the `merge_orphan_into_canonical` primitive from

--- a/IDEAS.md
+++ b/IDEAS.md
@@ -4,45 +4,38 @@
 
 ---
 
-## 🟡 Clitic-leftover audit — 35 "my X" lemmas (2026-05-06)
+## 🟢 [DONE 2026-05-06] Broadened clitic-leftover audit — 95 lemmas, 88 cleaned
 
-While investigating PR #72 (proper-name leak) found a second class of leftover
-dirty data: **35 lemmas where the bare form ends in ـِي and the gloss starts
-with "my "** — the 1sg possessive clitic was never stripped at import. By
-source: 17 duolingo, 17 textbook_scan, 1 story_import (`مَجالِي` "my field"
-from "Prince of Physicians" story_id=20). All predate the 2026-04-24 clitic-
-aware dedup fix. Examples: `جدي` "my grandfather" (should be `جد`), `بيتي`
-"my house" (`بيت`), `أبي` "my father" (`أب`), `كتبي` "my books" (`كتاب`),
-`اسمي` "my name" (`اسم`), `مَجالِي` "my field" (`مجال`).
+Started as the "my X" cohort (35 lemmas) but broadened to all proclitics
+(و, ف, ب, ل, ك, ال, وال, بال, فال, كال, لل) + enclitics (ـي, ـنا, ـك, ـه, ـها,
+ـهم, ـهن, ـكم, ـكن, ـني, ـهما) using a two-signal audit (bare-form clitic
+shape + matching English gloss prefix). Found 95 hits in prod:
 
-Concrete trigger that surfaced this: book/corpus sentences containing the
-bare `مجال` got mapped to lemma 2652 `مَجالِي` because the canonical `مجال`
-doesn't exist yet — they shared a root and `مجالي` was the closest match.
+  * **75 ALREADY_LINKED** — `canonical_lemma_id` set by 2026-04-27 decomposition
+    audit, but 31 had stale sentence_words / review_log / target_lemma_id /
+    UserLemmaKnowledge refs left pointing at the compound. Cleaned via
+    `merge_or_drop_orphan_ulk` (preserves FSRS state).
+  * **13 ORPHAN_NO_CANON** — no canonical link. 7 mapped onto existing
+    canonicals via alef/hamza variant lookup; 6 needed brand-new canonicals
+    created (ميثاق, طغيان, تجارة, اتقى, افسد, مجال) with full LLM enrichment.
+  * **7 FALSE_POS_VERB** — ل-initial verbs whose English "to V" infinitive
+    looks like the "to/for X" proclitic gloss. Skipped.
 
-**Fix idea** (`sh/clitic-my-leftover-audit`):
-1. For each of the 35 dirty lemmas, decide the canonical (e.g. `جد` for `جدي`)
-   and check whether it already exists in the DB.
-2. If it exists: redirect via `canonical_lemma_id`. Update all `SentenceWord.
-   lemma_id` and `UserLemmaKnowledge` rows to point at the canonical. Then
-   suspend or delete the dirty lemma.
-3. If it doesn't exist: create the canonical with proper bare form + gloss
-   stripped of "my", run quality gates, then redirect.
-4. **`UserLemmaKnowledge` is live FSRS data** — must dry-run + DB backup +
-   activity log before any merge. Anything else risks losing review history.
+Concrete trigger: lemma #2652 `مَجالِي` "my field" appeared as a New Word
+intro card because the canonical `مجال` didn't exist; book/corpus sentences
+containing بare `مجال` got mapped to the dirty compound.
 
-Related to top sections A/B below: section B already proposes adding the bare
-1sg possessive `ي` to `ENCLITICS` so future surface forms strip correctly at
-lookup time. That fix would also help these dirty rows find the right
-canonical (once canonicals exist), so doing B first is a reasonable
-prerequisite.
+Implementation: `backend/scripts/cleanup_clitic_leftovers.py` (idempotent,
+three phases). Reuses the `merge_orphan_into_canonical` primitive from
+`apply_step4c_link_survivors.py`. See `research/experiment-log.md`
+2026-05-06 (latest) for the full writeup.
 
-Audit query:
-```python
-db.query(Lemma).filter(
-    Lemma.lemma_ar_bare.like("%ي"),
-    Lemma.gloss_en.like("my %"),
-).all()
-```
+`ENCLITICS` in `sentence_validator.py` deliberately still excludes ـي —
+adding it would over-strip defective verbs (قاضي) and relational adjectives
+(عربي). The audit's two-signal design (clitic shape AND gloss prefix)
+sidesteps that ambiguity, which is why it can safely surface ـي leftovers
+without false positives. See section B below for the prior idea about
+adding ـي to ENCLITICS — keeping it as a [REJECTED] alternative.
 
 ---
 
@@ -73,13 +66,18 @@ guard is correct (prevents matching very short stems against false roots) — th
 real fix is that `ل` should match directly without clitic stripping when the
 surface form IS just `لي`.
 
-### B. Missing 1st-person possessive `ي` in ENCLITICS
+### B. [REJECTED 2026-05-06] Missing 1st-person possessive `ي` in ENCLITICS
 
 `شُهْرَتِي` (my fame) cannot strip the trailing `ي`. ENCLITICS includes object
 suffixes (هما, هم, ها, ه, نا, ني, ك, كم, كن) but the bare 1st-person possessive
-`ي` is absent. Adding it would also help `كتابي`, `بيتي`, etc. Risk: many false
-matches because `ي` is also a regular letter; need a careful guard (e.g., only
-strip on a stem that ends in a non-vowel before the `ي`).
+`ي` is absent. Adding it would also help `كتابي`, `بيتي`, etc.
+
+**Rejected** in favor of the gloss-driven audit (see top entry, 2026-05-06).
+Adding ـي to ENCLITICS would over-strip defective verbs (قاضي, ماضي), relational
+adjectives (عربي, طبي, رياضي), and dual oblique inflections at every import.
+The pre-2026-04-24 cohort of ـي leftovers was cleaned as a one-time data fix
+via `cleanup_clitic_leftovers.py` (95 lemma audit). The active import path
+relies on CAMeL morphology + `resolve_existing_lemma()` for proper handling.
 
 ### C. [DONE 2026-05-05] Alef-maksura ↔ ya asymmetry in lookup
 

--- a/backend/scripts/cleanup_clitic_leftovers.py
+++ b/backend/scripts/cleanup_clitic_leftovers.py
@@ -1,0 +1,412 @@
+#!/usr/bin/env python3
+"""Clean up clitic-leftover lemmas from pre-2026-04-24 imports.
+
+Background
+----------
+Before the 2026-04-24 clitic-aware dedup work, several import paths
+created lemma rows where the bare form still carried an unstripped
+proclitic (و, ب, ل, ال, ...) or enclitic (ـي, ـك, ـه, ـها, ـهم, ...).
+The 2026-04-27 lemma-decomposition audit (Phase 2 step 4c) tagged 91
+of these and linked 17 to canonicals, but a residual cohort survived
+because the clitic-shape audit was scoped to compound forms with
+existing canonicals.
+
+A broader audit on 2026-05-06 surfaced 95 such lemmas:
+  * 75 ALREADY_LINKED — canonical_lemma_id set, but some still carry
+    stale sentence_words / review_log / target_lemma_id / ULK refs.
+  * 13 ORPHAN_NO_CANON — canonical_lemma_id NULL.
+  *  7 FALSE_POS_VERB — ل-initial verbs, false positives, skipped.
+
+This script handles the first two groups in three phases:
+
+  Phase A (75 lemmas)  — repoint stale refs on already-linked compounds.
+  Phase B  (7 lemmas)  — link orphans to existing in-DB canonicals.
+  Phase C  (6 lemmas)  — create new canonicals + link orphans.
+
+Usage
+-----
+    python3 scripts/cleanup_clitic_leftovers.py --dry-run
+    python3 scripts/cleanup_clitic_leftovers.py
+    python3 scripts/cleanup_clitic_leftovers.py --skip-create  # phases A+B only
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+BACKEND_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(BACKEND_ROOT))
+
+from sqlalchemy import text  # noqa: E402
+
+from app.database import SessionLocal  # noqa: E402
+from app.models import Lemma, UserLemmaKnowledge  # noqa: E402
+from app.services.activity_log import log_activity  # noqa: E402
+from app.services.lemma_quality import run_quality_gates  # noqa: E402
+
+
+REPORT_FILE = BACKEND_ROOT / "data" / "clitic_leftovers_cleanup.json"
+
+
+# ---------- Phase B: orphans whose stripped form already exists in DB.
+# Mapping: orphan_id -> canonical_id (verified to exist in prod 2026-05-06).
+PHASE_B_LINKS: list[tuple[int, int, str]] = [
+    # (orphan_id, canonical_id, note)
+    (42,   45,   "جدتي → جدة (grandmother)"),
+    (1732, 1736, "وناكل → ناكل (we eat, inflected canonical row)"),
+    (2902, 2907, "للملئكة → الملئكة (the angels)"),
+    (2850, 1444, "شيطينهم → شيطان (devil/demon)"),
+    (2866, 663,  "ءاذانهم → أذن (ear)"),
+    (2880, 1033, "وادعوا → دعا (to call)"),
+    (2355, 477,  "بالشوكلاته → شوكولاتة (chocolate)"),
+]
+
+
+# ---------- Phase C: orphans whose canonical does not yet exist; create stub
+# + run quality gates (enrichment will fill diacritized full form, root, etc.).
+# 'full' is a best-guess vocalized form; enrichment may overwrite it.
+PHASE_C_CREATE: list[dict[str, Any]] = [
+    {"orphan_id": 2894, "bare": "ميثاق", "full": "مِيثَاق",
+     "gloss_en": "covenant, treaty", "pos": "noun", "source": "audit_2026-05-06"},
+    {"orphan_id": 2854, "bare": "طغيان", "full": "طُغْيَان",
+     "gloss_en": "transgression, excess", "pos": "noun", "source": "audit_2026-05-06"},
+    {"orphan_id": 2858, "bare": "تجارة", "full": "تِجَارَة",
+     "gloss_en": "trade, commerce", "pos": "noun", "source": "audit_2026-05-06"},
+    {"orphan_id": 2882, "bare": "اتقى", "full": "اِتَّقَى",
+     "gloss_en": "to fear, beware",  "pos": "verb", "source": "audit_2026-05-06"},
+    {"orphan_id": 2895, "bare": "افسد", "full": "أَفْسَدَ",
+     "gloss_en": "to corrupt, ruin", "pos": "verb", "source": "audit_2026-05-06"},
+    {"orphan_id": 2652, "bare": "مجال", "full": "مَجَال",
+     "gloss_en": "field, domain, scope", "pos": "noun", "source": "audit_2026-05-06"},
+]
+
+
+# Phase A is computed at runtime — every lemma we surface in the broadened
+# audit that already has canonical_lemma_id, but has at least one stale ref.
+
+# Mirror the audit query so the script is self-contained.
+PROCLITICS = ["وال", "بال", "فال", "كال", "لل", "ال", "و", "ف", "ب", "ل", "ك"]
+ENCLITICS = ["هما", "هم", "هن", "ها", "كم", "كن", "نا", "ني", "ه", "ك", "ي"]
+ENCLITIC_GLOSS = {
+    "ي":   ("my ",), "نا": ("our ", "us "), "ك": ("your ", "you "),
+    "كم":  ("your ",), "كن": ("your ",), "ه": ("his ", "him ", "its "),
+    "ها":  ("her ", "its "), "هم": ("their ", "them "),
+    "هن":  ("their ", "them "), "هما": ("their ", "them "), "ني": ("me ",),
+}
+PROCLITIC_GLOSS = {
+    "و": ("and ",), "ف": ("and ", "so ", "then "),
+    "ب": ("with ", "by ", "in "), "ل": ("to ", "for "),
+    "ك": ("like ", "as "), "ال": ("the ",),
+    "وال": ("and the ",), "بال": ("with the ", "by the ", "in the "),
+    "فال": ("and the ", "so the "), "كال": ("like the ", "as the "),
+    "لل": ("to the ", "for the "),
+}
+
+
+def find_phase_a(db) -> list[dict[str, Any]]:
+    """Return lemmas matching the broadened clitic audit AND already linked."""
+    out: list[dict[str, Any]] = []
+    rows = db.execute(text(
+        "SELECT lemma_id, lemma_ar_bare, gloss_en, pos, canonical_lemma_id "
+        "FROM lemmas WHERE lemma_ar_bare IS NOT NULL "
+        "AND gloss_en IS NOT NULL AND gloss_en != ''"
+    )).fetchall()
+    for r in rows:
+        bare = (r.lemma_ar_bare or "").strip()
+        gloss = (r.gloss_en or "").strip().lower()
+        if not bare or not gloss or r.canonical_lemma_id is None:
+            continue
+        match = None
+        for enc in sorted(ENCLITICS, key=len, reverse=True):
+            if bare.endswith(enc) and len(bare) > len(enc) + 1:
+                if any(gloss.startswith(p) for p in ENCLITIC_GLOSS.get(enc, ())):
+                    match = ("enclitic", enc); break
+        if match is None:
+            for pro in PROCLITICS:
+                if bare.startswith(pro) and len(bare) > len(pro) + 1:
+                    if any(gloss.startswith(p) for p in PROCLITIC_GLOSS.get(pro, ())):
+                        match = ("proclitic", pro); break
+        if match is None:
+            continue
+        # Skip ل-initial verbs (English "to V" infinitive false positives).
+        if match == ("proclitic", "ل") and r.pos == "verb":
+            continue
+        out.append({"orphan_id": r.lemma_id, "canonical_id": r.canonical_lemma_id})
+    return sorted(out, key=lambda h: h["orphan_id"])
+
+
+def reassign_refs(db, orphan_id: int, canonical_id: int) -> dict[str, int]:
+    """Repoint sentence_words, review_log, sentence.target_lemma_id from
+    orphan -> canonical. Idempotent."""
+    sw = db.execute(text("UPDATE sentence_words SET lemma_id=:c WHERE lemma_id=:o"),
+                    {"o": orphan_id, "c": canonical_id}).rowcount or 0
+    rl = db.execute(text("UPDATE review_log SET lemma_id=:c WHERE lemma_id=:o"),
+                    {"o": orphan_id, "c": canonical_id}).rowcount or 0
+    st = db.execute(text("UPDATE sentences SET target_lemma_id=:c WHERE target_lemma_id=:o"),
+                    {"o": orphan_id, "c": canonical_id}).rowcount or 0
+    return {"sentence_words": sw, "review_logs": rl, "sent_targets": st}
+
+
+def merge_or_drop_orphan_ulk(db, orphan_id: int, canonical_id: int) -> dict[str, Any]:
+    """If both ULKs exist, weighted-merge into canonical and delete orphan ULK.
+    If only orphan ULK, reassign to canonical. If only canonical or neither,
+    no-op. Same semantics as merge_orphan_into_canonical()."""
+    orphan_ulk = db.query(UserLemmaKnowledge).filter(
+        UserLemmaKnowledge.lemma_id == orphan_id).first()
+    canon_ulk = db.query(UserLemmaKnowledge).filter(
+        UserLemmaKnowledge.lemma_id == canonical_id).first()
+    if orphan_ulk is None:
+        return {"action": "no_orphan_ulk_noop"}
+    if canon_ulk is None:
+        orphan_ulk.lemma_id = canonical_id
+        return {"action": "reassigned_orphan_ulk_to_canonical",
+                "merged_times_seen": orphan_ulk.times_seen}
+    o_seen = orphan_ulk.times_seen or 0
+    c_seen = canon_ulk.times_seen or 0
+    canon_ulk.times_seen = o_seen + c_seen
+    canon_ulk.times_correct = (canon_ulk.times_correct or 0) + (orphan_ulk.times_correct or 0)
+    if o_seen > c_seen and orphan_ulk.fsrs_card_json:
+        canon_ulk.fsrs_card_json = orphan_ulk.fsrs_card_json
+        canon_ulk.knowledge_state = orphan_ulk.knowledge_state
+        if orphan_ulk.last_reviewed:
+            canon_ulk.last_reviewed = orphan_ulk.last_reviewed
+    db.delete(orphan_ulk)
+    return {"action": "merged_orphan_into_canonical_ulk",
+            "merged_times_seen": canon_ulk.times_seen}
+
+
+def phase_a_cleanup(db, dry_run: bool) -> tuple[list[dict], list[int]]:
+    """Repoint stale refs on already-linked compounds. Skip ones with nothing
+    to do."""
+    items = find_phase_a(db)
+    print(f"\n=== Phase A: scanning {len(items)} ALREADY_LINKED lemmas ===", flush=True)
+    log: list[dict] = []
+    canonicals_touched: set[int] = set()
+    for item in items:
+        oid, cid = item["orphan_id"], item["canonical_id"]
+        sw = db.execute(text("SELECT COUNT(*) FROM sentence_words WHERE lemma_id=:o"),
+                        {"o": oid}).scalar()
+        rl = db.execute(text("SELECT COUNT(*) FROM review_log WHERE lemma_id=:o"),
+                        {"o": oid}).scalar()
+        st = db.execute(text("SELECT COUNT(*) FROM sentences WHERE target_lemma_id=:o"),
+                        {"o": oid}).scalar()
+        ulk = db.execute(text("SELECT COUNT(*) FROM user_lemma_knowledge WHERE lemma_id=:o"),
+                         {"o": oid}).scalar()
+        if sw == 0 and rl == 0 and st == 0 and ulk == 0:
+            continue
+        if dry_run:
+            log.append({"phase": "A", "orphan_id": oid, "canonical_id": cid,
+                        "outcome": "dry_run",
+                        "stale": {"sw": sw, "rl": rl, "st": st, "ulk": ulk}})
+            print(f"  dry-run #{oid} -> #{cid}: sw={sw} rl={rl} st={st} ulk={ulk}",
+                  flush=True)
+            continue
+        refs = reassign_refs(db, oid, cid)
+        ulk_action = merge_or_drop_orphan_ulk(db, oid, cid)
+        canonicals_touched.add(cid)
+        log.append({"phase": "A", "orphan_id": oid, "canonical_id": cid,
+                    "outcome": "cleaned", "refs": refs, "ulk": ulk_action,
+                    "at": time.strftime("%Y-%m-%dT%H:%M:%S")})
+        print(f"  cleaned #{oid} -> #{cid}: refs={refs} ulk={ulk_action}", flush=True)
+    return log, sorted(canonicals_touched)
+
+
+def phase_b_link(db, dry_run: bool) -> tuple[list[dict], list[int]]:
+    """Link orphans to existing in-DB canonicals (full merge_orphan)."""
+    print(f"\n=== Phase B: linking {len(PHASE_B_LINKS)} orphans to existing canonicals ===",
+          flush=True)
+    log: list[dict] = []
+    canonicals_touched: set[int] = set()
+    for oid, cid, note in PHASE_B_LINKS:
+        orphan = db.get(Lemma, oid)
+        canon = db.get(Lemma, cid)
+        if orphan is None or canon is None:
+            log.append({"phase": "B", "orphan_id": oid, "canonical_id": cid,
+                        "outcome": "missing_row",
+                        "exists": {"orphan": orphan is not None,
+                                   "canonical": canon is not None}})
+            print(f"  ⚠️ missing rows for #{oid} or #{cid}", flush=True)
+            continue
+        if orphan.canonical_lemma_id is not None:
+            log.append({"phase": "B", "orphan_id": oid, "canonical_id": cid,
+                        "outcome": "already_linked",
+                        "current_canonical": orphan.canonical_lemma_id})
+            print(f"  skip #{oid} — already linked to #{orphan.canonical_lemma_id}",
+                  flush=True)
+            continue
+        if dry_run:
+            sw = db.execute(text("SELECT COUNT(*) FROM sentence_words WHERE lemma_id=:o"),
+                            {"o": oid}).scalar()
+            ulk = db.execute(text("SELECT COUNT(*) FROM user_lemma_knowledge WHERE lemma_id=:o"),
+                             {"o": oid}).scalar()
+            log.append({"phase": "B", "orphan_id": oid, "canonical_id": cid,
+                        "outcome": "dry_run", "note": note,
+                        "stale": {"sw": sw, "ulk": ulk}})
+            print(f"  dry-run #{oid} -> #{cid} ({note}): sw={sw} ulk={ulk}", flush=True)
+            continue
+        refs = reassign_refs(db, oid, cid)
+        ulk_action = merge_or_drop_orphan_ulk(db, oid, cid)
+        orphan.canonical_lemma_id = cid
+        canonicals_touched.add(cid)
+        log.append({"phase": "B", "orphan_id": oid, "canonical_id": cid,
+                    "outcome": "linked", "note": note, "refs": refs,
+                    "ulk": ulk_action,
+                    "at": time.strftime("%Y-%m-%dT%H:%M:%S")})
+        print(f"  linked #{oid} -> #{cid} ({note}): refs={refs} ulk={ulk_action}",
+              flush=True)
+    return log, sorted(canonicals_touched)
+
+
+def phase_c_create_and_link(db, dry_run: bool, skip_create: bool
+                            ) -> tuple[list[dict], list[int]]:
+    """Create new canonicals + link orphans. Quality gates run with
+    enrich=True synchronously, so each new lemma gets full LLM enrichment."""
+    if skip_create:
+        print(f"\n=== Phase C: skipped (--skip-create) ===", flush=True)
+        return [], []
+    print(f"\n=== Phase C: creating {len(PHASE_C_CREATE)} canonicals + linking ===",
+          flush=True)
+    log: list[dict] = []
+    new_canonical_ids: list[int] = []
+    pairs: list[tuple[int, int]] = []  # (orphan_id, new_canonical_id)
+    for spec in PHASE_C_CREATE:
+        oid = spec["orphan_id"]
+        orphan = db.get(Lemma, oid)
+        if orphan is None:
+            log.append({"phase": "C", "orphan_id": oid, "outcome": "missing_orphan"})
+            continue
+        if orphan.canonical_lemma_id is not None:
+            log.append({"phase": "C", "orphan_id": oid, "outcome": "already_linked",
+                        "current_canonical": orphan.canonical_lemma_id})
+            print(f"  skip #{oid} — already linked", flush=True)
+            continue
+        existing = db.execute(text(
+            "SELECT lemma_id FROM lemmas WHERE lemma_ar_bare=:b"),
+            {"b": spec["bare"]}).fetchone()
+        if existing is not None:
+            log.append({"phase": "C", "orphan_id": oid,
+                        "outcome": "canonical_now_exists_use_phase_b",
+                        "found_canonical": existing[0]})
+            print(f"  ⚠️ #{oid}: canonical {spec['bare']!r} already exists as "
+                  f"#{existing[0]} — re-run after moving to PHASE_B_LINKS", flush=True)
+            continue
+        if dry_run:
+            log.append({"phase": "C", "orphan_id": oid, "outcome": "dry_run_create",
+                        "spec": spec})
+            print(f"  dry-run create #{oid} → new canonical {spec['bare']!r} "
+                  f"({spec['gloss_en']})", flush=True)
+            continue
+        new_lemma = Lemma(
+            lemma_ar=spec["full"], lemma_ar_bare=spec["bare"],
+            gloss_en=spec["gloss_en"], pos=spec["pos"], source=spec["source"],
+        )
+        db.add(new_lemma)
+        db.flush()
+        new_id = new_lemma.lemma_id
+        new_canonical_ids.append(new_id)
+        pairs.append((oid, new_id))
+        log.append({"phase": "C", "orphan_id": oid, "new_canonical_id": new_id,
+                    "outcome": "created",
+                    "spec": spec, "at": time.strftime("%Y-%m-%dT%H:%M:%S")})
+        print(f"  created #{new_id} {spec['bare']} for orphan #{oid}", flush=True)
+
+    if not dry_run and new_canonical_ids:
+        db.commit()
+        print(f"  committed {len(new_canonical_ids)} stub canonicals", flush=True)
+        print(f"  running quality gates (enrich=True) on new canonicals...",
+              flush=True)
+        gates = run_quality_gates(db, new_canonical_ids, enrich=True,
+                                  background_enrich=False)
+        db.commit()
+        print(f"  gates: finalized={gates.get('finalize')} "
+              f"variants={gates.get('variants')} stamped={gates.get('stamped')}",
+              flush=True)
+
+        # Now link orphans to their freshly-created canonicals.
+        print(f"  linking {len(pairs)} orphans to new canonicals...", flush=True)
+        for oid, nid in pairs:
+            orphan = db.get(Lemma, oid)
+            refs = reassign_refs(db, oid, nid)
+            ulk_action = merge_or_drop_orphan_ulk(db, oid, nid)
+            orphan.canonical_lemma_id = nid
+            for entry in log:
+                if entry.get("phase") == "C" and entry.get("orphan_id") == oid \
+                        and entry.get("outcome") == "created":
+                    entry["refs"] = refs
+                    entry["ulk"] = ulk_action
+                    break
+            print(f"    linked #{oid} -> #{nid}: refs={refs} ulk={ulk_action}",
+                  flush=True)
+        db.commit()
+    return log, new_canonical_ids
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--skip-create", action="store_true",
+                        help="Skip Phase C (create new canonicals).")
+    parser.add_argument("--skip-gate-rerun", action="store_true",
+                        help="Skip the post-link run_quality_gates(enrich=False) "
+                             "on canonicals touched in phases A/B.")
+    args = parser.parse_args()
+
+    started = time.strftime("%Y-%m-%dT%H:%M:%S")
+    db = SessionLocal()
+    full_log: dict[str, Any] = {"started_at": started, "applied": not args.dry_run,
+                                "entries": []}
+    try:
+        a_log, a_canon = phase_a_cleanup(db, args.dry_run)
+        b_log, b_canon = phase_b_link(db, args.dry_run)
+        full_log["entries"].extend(a_log)
+        full_log["entries"].extend(b_log)
+        if not args.dry_run:
+            db.commit()
+            touched = sorted(set(a_canon) | set(b_canon))
+            if touched and not args.skip_gate_rerun:
+                print(f"\nRe-running quality gates (enrich=False) on {len(touched)} "
+                      f"canonicals touched in phases A/B...", flush=True)
+                run_quality_gates(db, touched, enrich=False,
+                                  background_enrich=False)
+                db.commit()
+
+        c_log, c_new = phase_c_create_and_link(db, args.dry_run, args.skip_create)
+        full_log["entries"].extend(c_log)
+
+        full_log["completed_at"] = time.strftime("%Y-%m-%dT%H:%M:%S")
+        REPORT_FILE.parent.mkdir(parents=True, exist_ok=True)
+        tmp = REPORT_FILE.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(full_log, indent=2, ensure_ascii=False))
+        tmp.replace(REPORT_FILE)
+
+        if not args.dry_run:
+            counts: dict[str, int] = {}
+            for e in full_log["entries"]:
+                k = f"{e.get('phase')}/{e.get('outcome')}"
+                counts[k] = counts.get(k, 0) + 1
+            log_activity(
+                db, "manual_action",
+                f"Clitic-leftover cleanup: {sum(counts.values())} actions across phases A/B/C",
+                detail={"counts": counts, "report": str(REPORT_FILE.relative_to(BACKEND_ROOT.parent))},
+            )
+            db.commit()
+    finally:
+        db.close()
+
+    print("\n=== Summary ===", flush=True)
+    counts: dict[str, int] = {}
+    for e in full_log["entries"]:
+        k = f"{e.get('phase')}/{e.get('outcome')}"
+        counts[k] = counts.get(k, 0) + 1
+    for k, v in sorted(counts.items()):
+        print(f"  {k}: {v}", flush=True)
+    print(f"Report → {REPORT_FILE}", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/research/experiment-log.md
+++ b/research/experiment-log.md
@@ -4,6 +4,91 @@ Running lab notebook for Alif's learning algorithm. Each entry documents what ch
 
 ---
 
+## 2026-05-06 (latest): Broadened clitic-leftover audit — 95 lemmas, 88 cleaned
+
+### What
+
+Follow-up to the 35-lemma 1sg possessive audit. Broadened the gloss-driven
+audit to cover every Arabic proclitic (و, ف, ب, ل, ك, ال, وال, بال, فال, كال, لل)
+and enclitic (ـي, ـنا, ـك, ـه, ـها, ـهم, ـهن, ـكم, ـكن, ـني, ـهما) by
+matching the bare form's clitic shape against an English gloss prefix
+("my ", "and ", "with the ", …). Found 95 hits in prod:
+
+  * **75 ALREADY_LINKED** — `canonical_lemma_id` set by the 2026-04-27
+    decomposition audit (Phase 2 step 4c), but 31 of them still had stale
+    sentence_words / review_log / target_lemma_id / ULK refs pointing at
+    the compound form rather than the canonical. The prior pass set the
+    canonical link but didn't always reassign downstream refs.
+  * **13 ORPHAN_NO_CANON** — no canonical link. Of those: 7 mapped onto
+    existing-in-DB canonicals (with alef-restoration / hamza variants),
+    6 needed brand-new canonicals to be created (ميثاق, طغيان, تجارة,
+    اتقى, افسد, مجال — all Quran/story-import nouns and verbs whose root
+    forms hadn't been imported yet).
+  * **7 FALSE_POS_VERB** — ل-initial verbs like لعب "to play" where the
+    English "to V" infinitive marker masquerades as the "to/for X"
+    proclitic gloss. Skipped.
+
+### Trigger
+
+User reported lemma #2652 `مَجالِي` "my field" appearing as a New Word
+intro card. The canonical `مجال` didn't exist, so any sentence containing
+the surface form `مجال` was being mapped to this dirty compound lemma.
+
+### Fix
+
+`backend/scripts/cleanup_clitic_leftovers.py` runs three idempotent phases:
+
+  * **Phase A** — repoint stale sentence_words / review_log /
+    target_lemma_id from the 75 already-linked compounds to their
+    canonicals; merge or reassign 9 stale ULK rows preserving FSRS state
+    (largest merges: #1834 صديقي 183 times_seen → #1500, #1691 كتبي 144 →
+    #228, #61 بيتي 144 → #181, #69 ابي 125 → #158, #71 امي 123 → #76).
+  * **Phase B** — link 7 orphans to existing canonicals (full
+    `merge_orphan_into_canonical` from `apply_step4c_link_survivors.py`):
+    جدتي→جدة, للملئكة→الملئكة, شيطينهم→شيطان, ءاذانهم→أذن, وادعوا→دعا,
+    بالشوكلاته→شوكولاتة, وناكل→ناكل.
+  * **Phase C** — create 6 new canonical lemmas as stubs, run
+    `run_quality_gates(enrich=True)` synchronously (Claude Haiku CLI
+    populates diacritized form, root, transliteration, etymology,
+    forms_json), then link the orphans.
+
+The merge primitive comes from `apply_step4c_link_survivors.py:68–121`,
+preserving FSRS card / times_seen / last_reviewed when both sides have a
+ULK (weighted merge favoring the side with more reviews).
+
+### Root cause analysis
+
+The active import path is fixed: ALL 11 lemma-creation sites use
+`resolve_existing_lemma()` since 2026-04-24. But `_strip_clitics()` in
+`sentence_validator.py:354` deliberately omits ـي from the ENCLITICS list
+because it's ambiguous with defective-noun final radical (قاضي "judge"),
+relational adjective suffix (عربي "Arabic"), and dual oblique. So even a
+clitic-aware dedup wouldn't have caught these 35 ـي leftovers if it had
+run on those imports.
+
+The right place to catch them is the gloss check, which is exactly what
+this audit does: it requires *both* a clitic-shape match AND a matching
+English gloss prefix, sidestepping the defective-noun ambiguity.
+
+### Verification
+
+  * Local test on a copy of prod DB: A+B+C all applied cleanly, idempotent
+    on re-run. 6 new canonicals enriched correctly with proper roots
+    (تجارة → root #708 same as تاجر "merchant"; اتقى → root #446 same as
+    متقون; افسد → root #1233 same as يفسد; etc.).
+  * Re-running the audit after cleanup: same 95 lemma rows present
+    (intentional — kept as variants pointing at canonicals), but ALREADY_LINKED
+    stale-ref counts drop to zero and ORPHAN_NO_CANON empties out.
+
+### What's deliberately NOT changed
+
+`ENCLITICS` in `sentence_validator.py` still does not include ـي. Adding
+it would over-strip defective verbs and relational adjectives at every
+import. The pre-2026-04-24 cohort was a one-time data fix; the active
+import path doesn't need an ENCLITICS change.
+
+---
+
 ## 2026-05-06 (later): Proper-name filter leak — `pos='noun_prop'` vs `word_category` drift (PR #72)
 
 ### What


### PR DESCRIPTION
## Summary

- Broadens the 35-lemma 1sg possessive audit to all Arabic proclitics + enclitics. Two-signal audit (bare-form clitic shape + matching English gloss prefix) found 95 hits in prod.
- `backend/scripts/cleanup_clitic_leftovers.py` runs three idempotent phases: A) repoint stale sentence_words / review_log / target_lemma_id refs and merge ULKs for 75 already-linked compounds, B) link 7 orphans to existing canonicals (شيطينهم→شيطان, ءاذانهم→أذن, وادعوا→دعا, …), C) create 6 new canonicals (ميثاق, طغيان, تجارة, اتقى, افسد, مجال), run `run_quality_gates(enrich=True)` synchronously, then link.
- Reuses the `merge_orphan_into_canonical` primitive from `apply_step4c_link_survivors.py` so merge semantics stay consistent (weighted ULK merge favoring the side with more reviews — preserves FSRS state).
- Trigger: lemma #2652 `مَجالِي` "my field" appearing as a New Word intro card because canonical `مجال` didn't exist. Now resolved via Phase C.
- 7 false positives (ل-initial verbs glossed "to V") are deliberately skipped.

Local validation: applied A+B+C end-to-end on a fresh prod-DB copy. Idempotent on re-run. New canonicals have proper roots, transliteration, etymology, and forms_json populated by Claude Haiku.

`ENCLITICS` in `sentence_validator.py` is intentionally NOT changed — adding ـي would over-strip defective verbs (قاضي), relational adjectives (عربي), and dual obliques. The gloss-driven audit's two-signal design sidesteps that ambiguity safely.