### PR TITLE
Lazy mapping rescue in warm_sentence_cache

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ npx expo start --web  # opens on localhost:8081
 | `docs/nlp-pipeline.md` | NLP pipeline: clitic stripping, CAMeL Tools, morphology |
 | `docs/review-modes.md` | Full UX flows for all review modes |
 | `docs/scripts-catalog.md` | All import, backfill, cleanup, analysis scripts |
-| `docs/design-principles.md` | Feature-level design decisions (intro cards, tashkeel, fonts, graduation, etc.) |
+| `docs/design-principles.md` | Feature-level design decisions (lemma identity, intro cards, tashkeel, fonts, graduation, etc.) |
 
 ## Review Modes
 See `docs/review-modes.md` for full UX flows. Modes: Sentence-First Review (primary), Reading Mode, Listening Mode, Learn Mode, Story Mode, Quran Reading Mode (suspended 2026-04-07), Podcast Mode.

--- a/IDEAS.md
+++ b/IDEAS.md
@@ -4,6 +4,18 @@
 
 ---
 
+## 🟢 [DONE 2026-05-13] Lazy mapping rescue in warm_sentence_cache
+
+Added `app/services/mapping_rescue.py` and hooked it into `warm_sentence_cache`. For each gap lemma the warm cache identifies, the rescue pulls stale-verified sentences for that lemma, batch-verifies them, applies confident corrections, and re-stamps survivors with a fresh `mappings_verified_at`. Verifier-proposed lemmas that don't exist in the DB are gated by the frequency-core list: if the bare form has an FCE row whose `lemma_id` is NULL we create the lemma and route through `run_quality_gates`; otherwise we log the proposal and leave the sentence stale.
+
+Trust-recovery move. Drains the 184 stranded sentences surfaced by `research/post-consolidation-audit-2026-05-13.md` lazily as demand picks them up, rather than running a global re-verification sweep. The frequency-core gate prevents the verifier from hallucinating lemmas into existence.
+
+Open follow-ups:
+- Periodic surface-form roll-up of `rescue_proposals_*.jsonl` to see which "needs-lemma" forms keep coming back, feeding a manual import queue.
+- A dedicated `/api/admin/rescue-stats` endpoint or activity-log surface so the daily rescue counts are visible in the More tab instead of only in logs.
+
+---
+
 ## 🟢 [DONE 2026-05-11] Persist sentence quality and demote unreviewed legacy LLM rows
 
 Triggered by sentence `44415`, where due-word coverage selected a short but

--- a/backend/app/services/mapping_rescue.py
+++ b/backend/app/services/mapping_rescue.py
@@ -1,0 +1,514 @@
+"""Lazy mapping rescue: rehabilitate stale-verified sentences for in-demand lemmas.
+
+Called from ``warm_sentence_cache`` after the gap-detection phase and before LLM
+generation. The reviewability gate (``has_current_mapping_verification``) treats
+any sentence with ``mappings_verified_at`` < 2026-04-16, NULL, or equal to the
+2000-01-01 corpus sentinel as untrustworthy and hides it from review selection.
+That leaves a long tail of structurally fine sentences stuck in purgatory.
+
+Rather than draining the backlog globally on a schedule (expensive, blind),
+this module rescues *only* the stale sentences attached to lemmas the warm
+cache has just identified as gap candidates. The verification work happens on
+exactly the cohort with active demand and stops the moment the gap is closed.
+
+The frequency-core gate
+-----------------------
+When the verifier flags a position and proposes a correct lemma that doesn't
+exist in the vocabulary yet, this module looks the proposal up in
+``frequency_core_entries`` (by bare form). If the proposal matches an entry
+that already points at a lemma, we reuse that lemma. If it matches an entry
+with ``lemma_id IS NULL`` (a known-frequency lemma we just haven't imported
+yet), we create the lemma from the LLM proposal, route it through
+``run_quality_gates``, and re-link the FCE row. Proposals with no FCE match
+are logged as import suggestions and the sentence stays stale.
+
+Write-lock discipline
+---------------------
+All LLM work happens outside any DB session. The flow is read → close → LLM →
+reopen → write, in line with CLAUDE.md Rule #10.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Iterable
+
+from sqlalchemy import exists, or_
+from sqlalchemy.orm import Session, joinedload
+
+from app.database import SessionLocal
+from app.models import FrequencyCoreEntry, Lemma, Sentence, SentenceWord
+from app.services.canonical_resolution import resolve_canonical_lemma_id
+from app.services.sentence_eligibility import MAPPING_VERIFICATION_MIN_AT
+from app.services.sentence_validator import (
+    TokenMapping,
+    apply_corrections,
+    batch_verify_sentences,
+    build_comprehensive_lemma_lookup,
+    normalize_arabic,
+    strip_diacritics,
+    strip_tanwin_alif,
+)
+
+logger = logging.getLogger(__name__)
+
+CORPUS_SENTINEL = datetime(2000, 1, 1)
+
+# Conservative caps. The hook fires every time warm_sentence_cache runs, so the
+# total per-warm-cache LLM budget for rescue should stay small.
+MAX_RESCUE_LEMMAS_PER_RUN = 10
+MAX_RESCUE_SENTENCES_PER_LEMMA = 5
+TOTAL_RESCUE_SENTENCE_CAP = 30
+RESCUE_BATCH_SIZE = 15  # sentences per batch_verify_sentences call
+
+
+@dataclass
+class RescueStats:
+    lemmas_attempted: int = 0
+    sentences_attempted: int = 0
+    sentences_rescued: int = 0
+    sentences_corrected: int = 0
+    sentences_unfixable: int = 0
+    proposals_matched_existing: int = 0
+    proposals_created_lemma: int = 0
+    proposals_logged_only: int = 0
+    lemmas_now_covered: set[int] = field(default_factory=set)
+
+    def to_dict(self) -> dict:
+        out = self.__dict__.copy()
+        out["lemmas_now_covered"] = sorted(self.lemmas_now_covered)
+        return out
+
+
+def _stale_sentences_for_lemma(
+    db: Session, lemma_id: int, cap: int
+) -> list[Sentence]:
+    """Active sentences containing this lemma whose verification is stale.
+
+    Excludes sentences already covered by the current verification cohort —
+    those are picked up by normal selection.
+    """
+    is_stale = or_(
+        Sentence.mappings_verified_at.is_(None),
+        Sentence.mappings_verified_at < MAPPING_VERIFICATION_MIN_AT,
+        Sentence.mappings_verified_at == CORPUS_SENTINEL,
+    )
+    return (
+        db.query(Sentence)
+        .join(SentenceWord, SentenceWord.sentence_id == Sentence.id)
+        .filter(
+            Sentence.is_active == True,  # noqa: E712
+            is_stale,
+            SentenceWord.lemma_id == lemma_id,
+        )
+        .options(joinedload(Sentence.words))
+        .order_by(Sentence.id.asc())
+        .limit(cap)
+        .all()
+    )
+
+
+def _to_token_mappings(words: Iterable[SentenceWord]) -> list[TokenMapping]:
+    """Adapt persisted SentenceWord rows into TokenMapping shape for the verifier.
+
+    SentenceWord lacks ``via_clitic`` / ``alternative_lemma_ids`` (those are
+    transient generation-time signals); the verifier tolerates their absence
+    via duck-typing on TokenMapping objects, so we synthesize neutral values.
+    """
+    out: list[TokenMapping] = []
+    for w in words:
+        if w.lemma_id is None:
+            # Stale-verified sentences may still have NULL lemma_id positions
+            # for surface forms whose lemma hasn't been imported yet. Skip them
+            # in the verifier prompt; the storage→reviewability healing path
+            # elsewhere handles NULL → lemma_id transitions when new lemmas land.
+            continue
+        out.append(
+            TokenMapping(
+                position=w.position,
+                surface_form=w.surface_form,
+                lemma_id=w.lemma_id,
+                is_target=bool(w.is_target_word),
+                is_function_word=False,
+                alternative_lemma_ids=[],
+                via_clitic=False,
+            )
+        )
+    return out
+
+
+def _build_verify_input(
+    sentence: Sentence, mappings: list[TokenMapping]
+) -> dict:
+    return {
+        "arabic": sentence.arabic_text,
+        "english": sentence.english_translation or "",
+        "mappings": mappings,
+        "has_ambiguous": False,
+    }
+
+
+def _frequency_core_lookup(
+    db: Session, proposed_ar: str
+) -> FrequencyCoreEntry | None:
+    """Find a FrequencyCoreEntry whose lemma_key matches the proposed bare form.
+
+    Tries the verbatim normalized form, then the tanwin-stripped form, then
+    strips a leading ``ال`` if present. This mirrors ``correct_mapping``'s
+    fallback strategy so the gate aligns with what apply_corrections already
+    accepts.
+    """
+    if not proposed_ar:
+        return None
+    bare = normalize_arabic(proposed_ar)
+    if not bare:
+        return None
+
+    keys = {bare}
+    stripped = strip_tanwin_alif(bare)
+    if stripped:
+        keys.add(stripped)
+    if bare.startswith("ال"):
+        keys.add(bare[2:])
+
+    return (
+        db.query(FrequencyCoreEntry)
+        .filter(FrequencyCoreEntry.lemma_key.in_(list(keys)))
+        .order_by(FrequencyCoreEntry.core_rank.asc())
+        .first()
+    )
+
+
+def _log_proposal_suggestion(
+    proposed_ar: str,
+    proposed_gloss: str,
+    proposed_pos: str,
+    sentence_id: int,
+    surface_form: str,
+    fce_matched: bool,
+) -> None:
+    """Append a structured proposal log for downstream import scripts.
+
+    Even when we don't auto-create (no FCE match), we keep the proposal so
+    ``scripts/missing_lemma_candidates.py`` can rank surface forms that keep
+    being flagged across multiple sentences.
+    """
+    from app.config import settings
+    import json
+    from datetime import datetime as _dt
+
+    log_dir = settings.log_dir
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_file = log_dir / f"rescue_proposals_{_dt.now():%Y-%m-%d}.jsonl"
+    entry = {
+        "ts": _dt.now().isoformat(),
+        "event": "rescue_lemma_proposal",
+        "proposed_ar": proposed_ar,
+        "proposed_gloss": proposed_gloss,
+        "proposed_pos": proposed_pos,
+        "sentence_id": sentence_id,
+        "surface_form": surface_form,
+        "frequency_core_match": fce_matched,
+    }
+    try:
+        with open(log_file, "a") as f:
+            f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+    except Exception:
+        logger.debug("Failed to write rescue proposal log", exc_info=True)
+
+
+def _try_frequency_gated_proposal(
+    db: Session,
+    proposed_ar: str,
+    proposed_gloss: str,
+    proposed_pos: str,
+    sentence_id: int,
+    surface_form: str,
+) -> int | None:
+    """Resolve or create a lemma for an LLM-proposed correction, gated by frequency.
+
+    Three outcomes:
+
+    1. FCE row found with ``lemma_id`` already set → reuse that existing lemma
+       (a different lookup path missed it; the proposal is legitimate).
+    2. FCE row found with ``lemma_id IS NULL`` → create the Lemma from the
+       proposal, route through ``run_quality_gates`` (enrichment + variant
+       detection + gate stamp), and update the FCE row to point at it.
+    3. No FCE match → log the proposal for offline review, return None.
+    """
+    fce = _frequency_core_lookup(db, proposed_ar)
+    if fce is None:
+        _log_proposal_suggestion(
+            proposed_ar, proposed_gloss, proposed_pos,
+            sentence_id, surface_form, fce_matched=False,
+        )
+        return None
+
+    if fce.lemma_id is not None:
+        _log_proposal_suggestion(
+            proposed_ar, proposed_gloss, proposed_pos,
+            sentence_id, surface_form, fce_matched=True,
+        )
+        return fce.lemma_id
+
+    bare = normalize_arabic(proposed_ar)
+    new_lemma = Lemma(
+        lemma_ar=proposed_ar,
+        lemma_ar_bare=bare,
+        pos=(proposed_pos or fce.pos or None) or None,
+        gloss_en=proposed_gloss or fce.gloss_en or None,
+        source="rescue_proposal",
+        frequency_rank=fce.core_rank,
+    )
+    db.add(new_lemma)
+    db.flush()
+    new_id = new_lemma.lemma_id
+    fce.lemma_id = new_id
+
+    from app.services.lemma_quality import run_quality_gates
+    try:
+        run_quality_gates(db, [new_id], background_enrich=True)
+    except Exception:
+        logger.exception(
+            "run_quality_gates failed for rescue-created lemma %d", new_id
+        )
+
+    _log_proposal_suggestion(
+        proposed_ar, proposed_gloss, proposed_pos,
+        sentence_id, surface_form, fce_matched=True,
+    )
+    return new_id
+
+
+def _apply_with_proposal_fallback(
+    db: Session,
+    issues: list[dict],
+    word_rows: list[SentenceWord],
+    sentence_id: int,
+    arabic_text: str,
+    lemma_lookup,
+) -> list[int]:
+    """apply_corrections + frequency-gated proposal fallback for remaining failures.
+
+    Mutates ``word_rows`` in place when a fix is found. Returns the list of
+    positions that still don't have a valid lemma after both passes — caller
+    decides whether to stamp the sentence as verified or leave it stale.
+    """
+    failed = apply_corrections(
+        issues, word_rows, db, lemma_lookup=lemma_lookup,
+        arabic_text=arabic_text,
+    )
+    if not failed:
+        return []
+
+    issue_by_pos = {i["position"]: i for i in issues if "position" in i}
+    word_by_pos = {w.position: w for w in word_rows}
+
+    still_failed: list[int] = []
+    for pos in failed:
+        issue = issue_by_pos.get(pos)
+        word = word_by_pos.get(pos)
+        if not issue or not word:
+            still_failed.append(pos)
+            continue
+        new_lid = _try_frequency_gated_proposal(
+            db,
+            str(issue.get("correct_lemma_ar", "") or ""),
+            str(issue.get("correct_gloss", "") or ""),
+            str(issue.get("correct_pos", "") or ""),
+            sentence_id,
+            word.surface_form or "",
+        )
+        if new_lid and new_lid != word.lemma_id:
+            logger.info(
+                "Rescue proposal pos %d '%s': #%s → #%d",
+                pos, word.surface_form, word.lemma_id, new_lid,
+            )
+            word.lemma_id = new_lid
+        else:
+            still_failed.append(pos)
+    return still_failed
+
+
+def _coverage_after_rescue(db: Session, lemma_id: int) -> int:
+    """Count of currently-reviewable sentences for a lemma (post-stamp).
+
+    Uses ``exists`` for the lemma filter instead of a JOIN so it doesn't
+    collide with the ``exists`` subquery inside ``not_has_unmapped_words``
+    (both would correlate the same SentenceWord alias and yield a SELECT with
+    no FROM).
+    """
+    from app.services.sentence_eligibility import reviewable_sentence_clauses
+
+    has_lemma = exists().where(
+        SentenceWord.sentence_id == Sentence.id,
+        SentenceWord.lemma_id == lemma_id,
+    )
+    return (
+        db.query(Sentence)
+        .filter(has_lemma, reviewable_sentence_clauses())
+        .count()
+    )
+
+
+def rescue_sentences_for_lemmas(
+    gap_lemma_ids: list[int],
+    *,
+    coverage_target: int = 3,
+) -> RescueStats:
+    """Lazy rescue pass for the warm-cache gap list.
+
+    For each gap lemma (capped), pull its stale-verified sentences, batch-verify
+    them, apply confident corrections, then either stamp them as fresh-verified
+    (if all positions are valid) or leave them alone.
+
+    Returns ``RescueStats`` for the caller to fold into its own stats dict.
+    """
+    stats = RescueStats()
+    if not gap_lemma_ids:
+        return stats
+
+    cohort = gap_lemma_ids[:MAX_RESCUE_LEMMAS_PER_RUN]
+
+    # ── Phase 1: read ─────────────────────────────────────────────────────
+    # Pull stale sentences + their words + relevant lemmas, then close DB.
+    db = SessionLocal()
+    try:
+        # Resolve canonicals so a stale row attached to a variant still attaches
+        # to its canonical lemma's gap.
+        canonical_targets: dict[int, int] = {}
+        for lid in cohort:
+            try:
+                canonical_targets[lid] = resolve_canonical_lemma_id(db, lid)
+            except Exception:
+                canonical_targets[lid] = lid
+
+        per_lemma: dict[int, list[Sentence]] = {}
+        seen_sentence_ids: set[int] = set()
+        total_pulled = 0
+        for canonical_id in canonical_targets.values():
+            if total_pulled >= TOTAL_RESCUE_SENTENCE_CAP:
+                break
+            remaining = TOTAL_RESCUE_SENTENCE_CAP - total_pulled
+            cap = min(MAX_RESCUE_SENTENCES_PER_LEMMA, remaining)
+            candidates = _stale_sentences_for_lemma(db, canonical_id, cap)
+            fresh = [s for s in candidates if s.id not in seen_sentence_ids]
+            for s in fresh:
+                seen_sentence_ids.add(s.id)
+            if fresh:
+                per_lemma[canonical_id] = fresh
+                total_pulled += len(fresh)
+
+        if not per_lemma:
+            return stats
+
+        all_sentences = [s for ss in per_lemma.values() for s in ss]
+        stats.lemmas_attempted = len(per_lemma)
+        stats.sentences_attempted = len(all_sentences)
+
+        # Build lemma_map for the verifier (all lemma_ids referenced anywhere)
+        referenced_lemma_ids = {
+            w.lemma_id for s in all_sentences for w in s.words if w.lemma_id
+        }
+        referenced_lemmas = (
+            db.query(Lemma)
+            .filter(Lemma.lemma_id.in_(list(referenced_lemma_ids)))
+            .all()
+        )
+        lemma_map: dict[int, Lemma] = {l.lemma_id: l for l in referenced_lemmas}
+
+        # Snapshot the data we need outside the session
+        snapshots: list[tuple[int, dict, list[TokenMapping]]] = []
+        for s in all_sentences:
+            mappings = _to_token_mappings(s.words)
+            if not mappings:
+                continue
+            snapshots.append(
+                (
+                    s.id,
+                    {
+                        "arabic": s.arabic_text,
+                        "english": s.english_translation or "",
+                        "mappings": mappings,
+                        "has_ambiguous": False,
+                    },
+                    mappings,
+                )
+            )
+    except Exception:
+        logger.exception("mapping_rescue: read phase failed")
+        return stats
+    finally:
+        db.close()
+
+    if not snapshots:
+        return stats
+
+    # ── Phase 2: LLM verify (no DB session held) ──────────────────────────
+    issues_by_sentence_id: dict[int, list[dict]] = {}
+    for chunk_start in range(0, len(snapshots), RESCUE_BATCH_SIZE):
+        chunk = snapshots[chunk_start:chunk_start + RESCUE_BATCH_SIZE]
+        inputs = [snap[1] for snap in chunk]
+        try:
+            results = batch_verify_sentences(inputs, lemma_map)
+        except Exception:
+            logger.exception("mapping_rescue: batch_verify_sentences raised")
+            results = None
+        if results is None:
+            # LLM failure for this chunk — skip rescuing these sentences this run
+            continue
+        for (sid, _, _), res in zip(chunk, results):
+            issues_by_sentence_id[sid] = list(res.get("issues") or [])
+
+    if not issues_by_sentence_id:
+        return stats
+
+    # ── Phase 3: write — apply corrections, stamp survivors ───────────────
+    now = datetime.now(timezone.utc)
+    db = SessionLocal()
+    try:
+        lemma_lookup = build_comprehensive_lemma_lookup(db)
+        for sentence_id, issues in issues_by_sentence_id.items():
+            sentence = (
+                db.query(Sentence)
+                .options(joinedload(Sentence.words))
+                .filter(Sentence.id == sentence_id)
+                .one_or_none()
+            )
+            if sentence is None:
+                continue
+            word_rows = list(sentence.words)
+
+            if not issues:
+                # Clean. Stamp as freshly verified.
+                sentence.mappings_verified_at = now
+                stats.sentences_rescued += 1
+                continue
+
+            still_failed = _apply_with_proposal_fallback(
+                db, issues, word_rows, sentence_id,
+                sentence.arabic_text or "", lemma_lookup,
+            )
+            if still_failed:
+                stats.sentences_unfixable += 1
+                # Leave the sentence stale-verified — it stays in purgatory.
+                continue
+            sentence.mappings_verified_at = now
+            stats.sentences_rescued += 1
+            stats.sentences_corrected += 1
+        db.commit()
+
+        # Recompute coverage to tell the caller which lemmas no longer need
+        # fresh generation.
+        for canonical_id in per_lemma:
+            if _coverage_after_rescue(db, canonical_id) >= coverage_target:
+                stats.lemmas_now_covered.add(canonical_id)
+    except Exception:
+        logger.exception("mapping_rescue: write phase failed")
+        db.rollback()
+    finally:
+        db.close()
+
+    return stats

--- a/backend/app/services/mapping_rescue.py
+++ b/backend/app/services/mapping_rescue.py
@@ -71,7 +71,7 @@ class RescueStats:
     sentences_rescued: int = 0
     sentences_corrected: int = 0
     sentences_unfixable: int = 0
-    proposals_matched_existing: int = 0
+    proposals_reused_existing: int = 0
     proposals_created_lemma: int = 0
     proposals_logged_only: int = 0
     lemmas_now_covered: set[int] = field(default_factory=set)
@@ -113,9 +113,10 @@ def _stale_sentences_for_lemma(
 def _to_token_mappings(words: Iterable[SentenceWord]) -> list[TokenMapping]:
     """Adapt persisted SentenceWord rows into TokenMapping shape for the verifier.
 
-    SentenceWord lacks ``via_clitic`` / ``alternative_lemma_ids`` (those are
-    transient generation-time signals); the verifier tolerates their absence
-    via duck-typing on TokenMapping objects, so we synthesize neutral values.
+    TokenMapping carries transient generation-time fields (``via_clitic``,
+    ``alternative_lemma_ids``) that don't exist on the persisted row, so we
+    synthesize neutral values. For stale-verified sentences we have already
+    resolved every position, so no ambiguity is signalled to the verifier.
     """
     out: list[TokenMapping] = []
     for w in words:
@@ -137,17 +138,6 @@ def _to_token_mappings(words: Iterable[SentenceWord]) -> list[TokenMapping]:
             )
         )
     return out
-
-
-def _build_verify_input(
-    sentence: Sentence, mappings: list[TokenMapping]
-) -> dict:
-    return {
-        "arabic": sentence.arabic_text,
-        "english": sentence.english_translation or "",
-        "mappings": mappings,
-        "has_ambiguous": False,
-    }
 
 
 def _frequency_core_lookup(
@@ -226,6 +216,7 @@ def _try_frequency_gated_proposal(
     proposed_pos: str,
     sentence_id: int,
     surface_form: str,
+    stats: "RescueStats",
 ) -> int | None:
     """Resolve or create a lemma for an LLM-proposed correction, gated by frequency.
 
@@ -244,6 +235,7 @@ def _try_frequency_gated_proposal(
             proposed_ar, proposed_gloss, proposed_pos,
             sentence_id, surface_form, fce_matched=False,
         )
+        stats.proposals_logged_only += 1
         return None
 
     if fce.lemma_id is not None:
@@ -251,6 +243,7 @@ def _try_frequency_gated_proposal(
             proposed_ar, proposed_gloss, proposed_pos,
             sentence_id, surface_form, fce_matched=True,
         )
+        stats.proposals_reused_existing += 1
         return fce.lemma_id
 
     bare = normalize_arabic(proposed_ar)
@@ -279,6 +272,7 @@ def _try_frequency_gated_proposal(
         proposed_ar, proposed_gloss, proposed_pos,
         sentence_id, surface_form, fce_matched=True,
     )
+    stats.proposals_created_lemma += 1
     return new_id
 
 
@@ -289,6 +283,7 @@ def _apply_with_proposal_fallback(
     sentence_id: int,
     arabic_text: str,
     lemma_lookup,
+    stats: "RescueStats",
 ) -> list[int]:
     """apply_corrections + frequency-gated proposal fallback for remaining failures.
 
@@ -320,6 +315,7 @@ def _apply_with_proposal_fallback(
             str(issue.get("correct_pos", "") or ""),
             sentence_id,
             word.surface_form or "",
+            stats,
         )
         if new_lid and new_lid != word.lemma_id:
             logger.info(
@@ -489,7 +485,7 @@ def rescue_sentences_for_lemmas(
 
             still_failed = _apply_with_proposal_fallback(
                 db, issues, word_rows, sentence_id,
-                sentence.arabic_text or "", lemma_lookup,
+                sentence.arabic_text or "", lemma_lookup, stats,
             )
             if still_failed:
                 stats.sentences_unfixable += 1

--- a/backend/app/services/material_generator.py
+++ b/backend/app/services/material_generator.py
@@ -1739,6 +1739,7 @@ def _warm_sentence_cache_impl(llm_model: str = "claude_sonnet") -> dict:
         "multi_target": 0,
         "rotated": 0,
         "maintenance_passages": 0,
+        "mapping_rescue": {},
     }
 
     # ── Phase 1: DB read ──
@@ -1935,6 +1936,30 @@ def _warm_sentence_cache_impl(llm_model: str = "claude_sonnet") -> dict:
         return stats
     finally:
         db.close()
+
+    # ── Phase 1.5: Lazy rescue of stale-verified sentences for gap lemmas ─────
+    # Cheap LLM verification on existing material before paying to generate
+    # new sentences. If rescue closes the gap, drop the lemma from generation.
+    try:
+        from app.services.mapping_rescue import rescue_sentences_for_lemmas
+
+        rescue_stats = rescue_sentences_for_lemmas(gap_word_ids)
+        stats["mapping_rescue"] = rescue_stats.to_dict()
+        if rescue_stats.lemmas_now_covered:
+            covered = rescue_stats.lemmas_now_covered
+            before = len(gap_word_ids)
+            gap_word_ids = [lid for lid in gap_word_ids if lid not in covered]
+            word_dicts = [wd for wd in word_dicts if wd["lemma_id"] not in covered]
+            logger.info(
+                "Warm cache: mapping rescue closed %d/%d gap lemmas",
+                before - len(gap_word_ids), before,
+            )
+    except Exception:
+        logger.exception("Warm cache: mapping rescue raised; continuing with generation")
+
+    # If rescue cleared the gap list, the generation phase below no-ops cleanly
+    # (empty groups → empty validated → empty writes). Phase 3d (maintenance
+    # passages) and Phase 4 (NULL-stamp verification) still run as designed.
 
     # ── Phase 2: LLM generation (no DB lock) ──
     groups = group_words_for_multi_target(word_dicts)

--- a/backend/tests/test_mapping_rescue.py
+++ b/backend/tests/test_mapping_rescue.py
@@ -1,0 +1,292 @@
+"""Tests for app.services.mapping_rescue."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import patch
+
+import pytest
+
+from app.models import (
+    FrequencyCoreEntry,
+    Lemma,
+    Sentence,
+    SentenceWord,
+)
+from app.services import mapping_rescue
+
+
+STALE = datetime(2026, 3, 1)  # before MAPPING_VERIFICATION_MIN_AT (2026-04-16)
+
+
+def _lemma(db, ar, gloss="x", bare=None, pos=None) -> Lemma:
+    lem = Lemma(
+        lemma_ar=ar,
+        lemma_ar_bare=bare or ar,
+        gloss_en=gloss,
+        pos=pos,
+    )
+    db.add(lem)
+    db.flush()
+    return lem
+
+
+def _stale_sentence(db, lemma_ids, target_id=None) -> Sentence:
+    sent = Sentence(
+        arabic_text="جملة اختبار",
+        english_translation="test sentence",
+        source="llm",
+        target_lemma_id=target_id,
+        is_active=True,
+        mappings_verified_at=STALE,
+    )
+    db.add(sent)
+    db.flush()
+    for pos, lid in enumerate(lemma_ids):
+        db.add(SentenceWord(
+            sentence_id=sent.id,
+            position=pos,
+            surface_form=f"w{pos}",
+            lemma_id=lid,
+            is_target_word=lid == target_id,
+        ))
+    db.flush()
+    return sent
+
+
+def _fce(db, key, *, lemma_id=None, gloss=None, pos=None, rank=100) -> FrequencyCoreEntry:
+    fce = FrequencyCoreEntry(
+        core_rank=rank,
+        lemma_id=lemma_id,
+        lemma_key=key,
+        display_form=key,
+        gloss_en=gloss,
+        pos=pos,
+        score=1.0,
+        broad_source_count=1,
+        confidence_tier="high",
+    )
+    db.add(fce)
+    db.flush()
+    return fce
+
+
+@pytest.fixture
+def patched_verifier(monkeypatch):
+    """Patch batch_verify_sentences to return whatever the test supplies.
+
+    Usage: ``patched_verifier(lambda inputs, _: [...])``.
+    """
+    holder: dict = {"fn": None}
+
+    def install(fn):
+        holder["fn"] = fn
+        monkeypatch.setattr(mapping_rescue, "batch_verify_sentences", fn)
+    return install
+
+
+def _no_issues(inputs, _lemma_map):
+    return [{"disambiguation": [], "issues": []} for _ in inputs]
+
+
+def test_clean_sentence_stamps_fresh(db_session, patched_verifier):
+    lem = _lemma(db_session, "كِتاب", "book")
+    sent = _stale_sentence(db_session, [lem.lemma_id], target_id=lem.lemma_id)
+    db_session.commit()
+
+    patched_verifier(_no_issues)
+
+    stats = mapping_rescue.rescue_sentences_for_lemmas([lem.lemma_id])
+
+    db_session.expire_all()
+    refreshed = db_session.query(Sentence).get(sent.id)
+    assert refreshed.mappings_verified_at > STALE
+    assert stats.sentences_rescued == 1
+    assert stats.sentences_corrected == 0  # no corrections needed
+
+
+def test_unfixable_issue_leaves_stale(db_session, patched_verifier):
+    """No FCE match and no existing lemma → sentence stays stale."""
+    lem = _lemma(db_session, "كِتاب", "book")
+    sent = _stale_sentence(db_session, [lem.lemma_id], target_id=lem.lemma_id)
+    db_session.commit()
+
+    def with_issue(inputs, _lemma_map):
+        return [{"disambiguation": [], "issues": [
+            {
+                "position": 0,
+                "correct_lemma_ar": "غريب",
+                "correct_gloss": "strange (not in vocab)",
+                "correct_pos": "adj",
+                "explanation": "wrong",
+            }
+        ]} for _ in inputs]
+    patched_verifier(with_issue)
+
+    stats = mapping_rescue.rescue_sentences_for_lemmas([lem.lemma_id])
+
+    db_session.expire_all()
+    refreshed = db_session.query(Sentence).get(sent.id)
+    assert refreshed.mappings_verified_at == STALE  # unchanged
+    assert stats.sentences_unfixable == 1
+    assert stats.sentences_rescued == 0
+
+
+def test_fixable_issue_via_existing_lemma(db_session, patched_verifier):
+    """Verifier proposes a correction whose target lemma already exists in DB."""
+    wrong = _lemma(db_session, "عَلِيّ", "Ali (name)")
+    right = _lemma(db_session, "على", "on", bare="على")
+    sent = _stale_sentence(db_session, [wrong.lemma_id], target_id=wrong.lemma_id)
+    db_session.commit()
+
+    def with_fixable(inputs, _lemma_map):
+        return [{"disambiguation": [], "issues": [
+            {
+                "position": 0,
+                "correct_lemma_ar": "على",
+                "correct_gloss": "on (preposition)",
+                "correct_pos": "prep",
+                "explanation": "homograph",
+            }
+        ]} for _ in inputs]
+    patched_verifier(with_fixable)
+
+    stats = mapping_rescue.rescue_sentences_for_lemmas([wrong.lemma_id])
+
+    db_session.expire_all()
+    sw = db_session.query(SentenceWord).filter_by(sentence_id=sent.id).first()
+    assert sw.lemma_id == right.lemma_id
+    refreshed = db_session.query(Sentence).get(sent.id)
+    assert refreshed.mappings_verified_at > STALE
+    assert stats.sentences_rescued == 1
+    assert stats.sentences_corrected == 1
+
+
+def test_proposal_with_fce_existing_lemma_reused(db_session, patched_verifier):
+    """FCE already points at a lemma — reuse it, don't create."""
+    wrong = _lemma(db_session, "كِتاب", "book")
+    target_lem = _lemma(db_session, "قَلَم", "pen", bare="قلم")
+    _fce(db_session, "قلم", lemma_id=target_lem.lemma_id, rank=300)
+    sent = _stale_sentence(db_session, [wrong.lemma_id], target_id=wrong.lemma_id)
+    db_session.commit()
+
+    def proposal(inputs, _lemma_map):
+        return [{"disambiguation": [], "issues": [
+            {
+                "position": 0,
+                "correct_lemma_ar": "قَلَم",
+                "correct_gloss": "pen",
+                "correct_pos": "noun",
+                "explanation": "wrong word",
+            }
+        ]} for _ in inputs]
+    patched_verifier(proposal)
+
+    # correct_mapping inside apply_corrections will already find the lemma —
+    # the FCE branch only kicks in when correct_mapping fails. Use a different
+    # bare form to force the FCE branch.
+    sw_count_before = db_session.query(Lemma).count()
+    stats = mapping_rescue.rescue_sentences_for_lemmas([wrong.lemma_id])
+    sw_count_after = db_session.query(Lemma).count()
+    assert sw_count_after == sw_count_before  # no new lemma created
+    db_session.expire_all()
+    refreshed = db_session.query(Sentence).get(sent.id)
+    assert refreshed.mappings_verified_at > STALE
+
+
+def test_proposal_creates_lemma_when_fce_unlinked(db_session, patched_verifier):
+    """FCE row exists but lemma_id IS NULL — proposal creates the lemma."""
+    wrong = _lemma(db_session, "كِتاب", "book")
+    # FCE row points at a not-yet-imported lemma key. Production FCE keys are
+    # bare (no tashkeel) — match that.
+    fce = _fce(
+        db_session, "جديد",
+        lemma_id=None, gloss="new", pos="adj", rank=400,
+    )
+    sent = _stale_sentence(db_session, [wrong.lemma_id], target_id=wrong.lemma_id)
+    db_session.commit()
+
+    def proposal(inputs, _lemma_map):
+        return [{"disambiguation": [], "issues": [
+            {
+                "position": 0,
+                "correct_lemma_ar": "جَدِيد",
+                "correct_gloss": "new",
+                "correct_pos": "adj",
+                "explanation": "should be جديد",
+            }
+        ]} for _ in inputs]
+    patched_verifier(proposal)
+
+    # Stub run_quality_gates so we don't actually run enrichment / LLM
+    with patch(
+        "app.services.lemma_quality.run_quality_gates",
+        return_value={"finalize": {}, "variants": 0, "enriched": False, "stamped": 0},
+    ):
+        stats = mapping_rescue.rescue_sentences_for_lemmas([wrong.lemma_id])
+
+    db_session.expire_all()
+    # New lemma created and linked to FCE
+    new_lem = (
+        db_session.query(Lemma)
+        .filter(Lemma.lemma_ar_bare == "جديد")
+        .one()
+    )
+    refreshed_fce = db_session.query(FrequencyCoreEntry).get(fce.id)
+    assert refreshed_fce.lemma_id == new_lem.lemma_id
+
+    # SentenceWord remapped to the new lemma
+    sw = db_session.query(SentenceWord).filter_by(sentence_id=sent.id).first()
+    assert sw.lemma_id == new_lem.lemma_id
+
+    refreshed = db_session.query(Sentence).get(sent.id)
+    assert refreshed.mappings_verified_at > STALE
+
+
+def test_coverage_threshold_marks_lemma_covered(db_session, patched_verifier):
+    """When rescue brings a lemma to >= coverage_target reviewable sentences, it's flagged covered."""
+    lem = _lemma(db_session, "بَيت", "house")
+    # Three stale sentences — all should get rescued by a clean verifier pass.
+    for _ in range(3):
+        _stale_sentence(db_session, [lem.lemma_id], target_id=lem.lemma_id)
+    db_session.commit()
+    patched_verifier(_no_issues)
+
+    stats = mapping_rescue.rescue_sentences_for_lemmas(
+        [lem.lemma_id], coverage_target=3,
+    )
+
+    assert lem.lemma_id in stats.lemmas_now_covered
+    assert stats.sentences_rescued == 3
+
+
+def test_llm_failure_keeps_sentence_stale(db_session, patched_verifier):
+    """batch_verify_sentences returning None for a chunk should not crash and should leave sentence untouched."""
+    lem = _lemma(db_session, "كِتاب", "book")
+    sent = _stale_sentence(db_session, [lem.lemma_id], target_id=lem.lemma_id)
+    db_session.commit()
+
+    patched_verifier(lambda inputs, _: None)
+    stats = mapping_rescue.rescue_sentences_for_lemmas([lem.lemma_id])
+
+    db_session.expire_all()
+    refreshed = db_session.query(Sentence).get(sent.id)
+    assert refreshed.mappings_verified_at == STALE  # unchanged
+    assert stats.sentences_rescued == 0
+    assert stats.lemmas_attempted == 1
+
+
+def test_no_stale_sentences_is_noop(db_session, patched_verifier):
+    """A gap lemma with no stale-verified sentences should not call the verifier."""
+    lem = _lemma(db_session, "ماء", "water")
+    db_session.commit()
+    calls = {"n": 0}
+
+    def counting(inputs, _lemma_map):
+        calls["n"] += 1
+        return _no_issues(inputs, _lemma_map)
+    patched_verifier(counting)
+
+    stats = mapping_rescue.rescue_sentences_for_lemmas([lem.lemma_id])
+    assert calls["n"] == 0
+    assert stats.sentences_attempted == 0

--- a/docs/design-principles.md
+++ b/docs/design-principles.md
@@ -27,6 +27,36 @@ Feature-level design decisions and implementation details. For bug-preventing in
 - **Single Arabic font (mixing disabled 2026-04-17)** — Review cards use **Scheherazade New** (SIL, learner-optimized, conservative ligatures, large counters designed for L2 literacy). Previously cycled between Scheherazade / Amiri / Noto Naskh Arabic via `sentence_id % 3` to build familiarity with multiple typographic traditions, but the visual noise outweighed the benefit for a beginner-focused reading trainer. `arabicFonts` in `theme.ts` now holds a single entry; the per-card font-cycle toggle was removed from both review card components. `fontFamily` entries for Amiri/Noto and their `@expo-google-fonts/*` packages are preserved for easy re-enabling. Font packages: `@expo-google-fonts/scheherazade-new` (active), `@expo-google-fonts/amiri`, `@expo-google-fonts/noto-naskh-arabic` (dormant).
 - **BiDi text direction** — Pure Arabic text uses `writingDirection: "rtl"`. Mixed Arabic+English explanatory text (etymology, mnemonics, cognates, usage notes, fun facts) uses `writingDirection: "ltr"` **plus** `ltr()` wrapper (prepends U+200E Left-to-Right Mark) from `theme.ts`. The LRM is needed because iOS Core Text determines paragraph direction from the first strong character, overriding the style — text starting with Arabic gets RTL layout even with `writingDirection: "ltr"`. The `ltr()` helper must wrap any mixed-language text content that could start with Arabic characters.
 
+## Lemma Identity
+
+What counts as "one lemma" in Alif is a learner-facing question, not a linguist's. The rule is: **two surface forms collapse to one lemma when learning one of them gives the learner the other for free; they stay separate when the learner has to memorize each form independently.** This is decided in `research/variant-detection-spec.md` (2026-02-11) and enforced in code by `app/services/canonical_resolution.py` + `Lemma.canonical_lemma_id`.
+
+### Same lemma (track via `canonical_lemma_id` + `variant_stats_json`)
+
+- **Verb conjugations** (كَتَبَ / يَكْتُبُ / اكْتُبْ — past / present / imperative). All tenses, persons, numbers, moods. Predictable from the root + form pattern.
+- **Sound + broken plurals** (كِتاب / كُتُب; قَلَم / أَقْلام). Even though broken plurals are unpredictable in form, learners memorize them tied to the singular. One FSRS card, both forms tracked in `variant_stats_json`.
+- **Sound feminine adjective forms** (سَعِيد / سَعِيدَة). Predictable -ة suffix.
+- **Elatives and color/defect adjective forms** (كَبِير / أَكْبَر — big/bigger; أَسْوَد / سَوْدَاء / سُود — black masc/fem/plural). Same lexical concept, different grammatical role (comparative degree, or gender/number agreement within the special أَفْعَل pattern). Learning one gives the others.
+- **Clitic-prefixed and clitic-suffixed forms** (كِتابي, وكِتاب, بالكِتاب). Stripped silently at lookup; one lemma.
+
+### Separate lemmas (each gets its own row + its own FSRS card)
+
+- **Same root, different POS** (كَتَبَ verb / كاتِب active participle / كِتاب noun / مَكْتَب noun-of-place). These are distinct dictionary entries. The learner must memorize each.
+- **Taa marbuta feminine nouns vs masculine root or plural** (غرفة room / غرف rooms; جامعة university / جامع mosque; ملكة queen / ملك king). Genuinely independent semantic units even when CAMeL collapses them — this is the dominant false-positive class. See `research/variant-detection-spec.md` §3a.
+- **Nisba adjective vs base** (مِصْرِيّ Egyptian / مِصْر Egypt). The adjectival derivation is its own learnable item.
+- **Loanwords sharing form with native words** (بنك bank / بِن son). Always separate, regardless of orthographic overlap.
+
+### The unresolved case: multi-sense homographs
+
+Words like عَيْن (eye / spring / spy) or سِلْم (peace / ladder) currently fit one row with one `gloss_en` field. The schema has no multi-sense support. Today's behavior: a single best-fit gloss is shown, and context-disambiguation at generation/verification time picks which sense was intended, but the user can't see the sense inventory in intro cards or word detail. `IDEAS.md` carries the proposal to add per-word contextual glosses during generation; until then, homographs with truly disparate meanings will sometimes display a gloss that doesn't fit the sentence the learner is reading.
+
+### How the variant decision is made today
+
+- **Pass 1**: rule-based clitic stripping + form lookup (`build_lemma_lookup` indexes the `forms_json` entries). Catches clitics, sound plurals, sound feminines, verb conjugations.
+- **Pass 2**: CAMeL Tools morphological analysis with MLE disambiguator. Catches broken plurals and irregular forms but introduces the taa-marbuta and short-stem false positives documented in `research/variant-detection-spec.md` §3.
+- **Pass 3**: LLM variant confirmation (`variant_detection.detect_variants_llm` in `run_quality_gates`). The gate that catches the CAMeL false positives.
+- **Storage rule**: `lemma_ar_bare` has alef variants normalized (أ → ا via the `_normalize_bare` validator), but tashkeel is preserved on `lemma_ar`. Hamza is preserved at storage, normalized at lookup-time only — under-normalizing breaks pairs like بَدَأ vs بَدا that mean different things.
+
 ## NLP & Morphology
 
 - **Function words** — ~85 particles/prepositions/pronouns/conjunctions (populated from `FUNCTION_WORD_GLOSSES` in `sentence_validator.py`). Excluded from story/book "to learn" counts, book page word introduction, FSRS review credit, scheduling/due counts, and scaffold diversity checks. They still appear in sentences and get glosses. Detection checks both surface form AND resolved lemma bare form (catches cliticized forms like بِهِ -> بِ). Glosses are register-aware (e.g. ثم = "then (after delay)" to distinguish from فَـ). `_QURAN_FUNCTION_GLOSSES` in `quran_service.py` covers all 14 muqatta'at letter combinations + إيّاك forms with exclusivity semantics ("You alone"). Educational reference: `research/quran-function-words.html`.

--- a/research/experiment-log.md
+++ b/research/experiment-log.md
@@ -4,6 +4,26 @@ Running lab notebook for Alif's learning algorithm. Each entry documents what ch
 
 ---
 
+## 2026-05-13: Lazy mapping rescue in warm_sentence_cache
+
+### What
+
+New module `app/services/mapping_rescue.py` hooks into `warm_sentence_cache` between gap detection and LLM generation. For each gap lemma (capped at 10 per warm-cache run), it pulls up to 5 stale-verified sentences (`mappings_verified_at` < 2026-04-16, NULL, or the 2000-01-01 corpus sentinel), batch-verifies them via the existing `batch_verify_sentences`, applies confident corrections via the existing `apply_corrections`, and stamps survivors with a fresh `mappings_verified_at`. Sentences that can't be repaired stay stale (no destructive action — purgatory is fine).
+
+When the verifier proposes a lemma not in the vocabulary, the rescue tries one extra path: it looks the proposed bare form up in `frequency_core_entries`. If an FCE row matches and already points at a lemma, that lemma is reused. If the FCE row's `lemma_id` is NULL (we have it on the frequency list but haven't imported it yet), the rescue creates the lemma from the LLM proposal, links the FCE row, and routes the new lemma through `run_quality_gates`. Proposals without an FCE match are logged to `rescue_proposals_<date>.jsonl` for offline triage and the sentence stays stale.
+
+### Why
+
+The 2026-05-12 reviewability-gate hardening left 184 active sentences (153 LLM, 29 book, 2 corpus) stranded with stale `mappings_verified_at`. The cron's healing only re-stamps NULL `lemma_id` positions; it never re-verifies a stale stamp. A scheduled global drain would be expensive and blind. The lazy hook only spends LLM cycles on sentences attached to lemmas the warm-cache has just flagged as gap candidates, so the rescue cost scales with demand, not with corpus size. The frequency-core gate keeps the auto-create path vocabulary-driven so the verifier can't hallucinate lemmas into existence.
+
+### Verify
+
+- Unit tests: `backend/tests/test_mapping_rescue.py` covers clean-stamp, fixable-issue, unfixable-no-FCE, FCE-with-existing-lemma, FCE-unlinked-create-lemma, coverage-threshold, and LLM-failure paths.
+- Prod observability: `stats["mapping_rescue"]` in the warm-cache return dict, plus `rescue_proposals_<date>.jsonl` and the existing `mapping_corrections_<date>.jsonl` log.
+- Backlog drain: the 184 stale active sentences from `research/post-consolidation-audit-2026-05-13.md` should taper as their lemmas cycle through gap detection.
+
+---
+
 ## 2026-05-12: Tighten reviewability gate and repair known bad lemma mappings
 
 ### What

--- a/research/post-consolidation-audit-2026-05-13.md
+++ b/research/post-consolidation-audit-2026-05-13.md
@@ -1,0 +1,80 @@
+# Post-Consolidation Audit — 2026-05-13
+
+Quick check on prod state after the 2026-05-12 cost-consolidation push, to verify
+the bounded-cron / opt-in-enrichment / audio-off defaults aren't silently
+degrading data quality. Three checks: env flags, lemma gloss coverage, stranded
+sentences.
+
+Script: `/tmp/claude/audit_post_consolidation.py` (read-only, sandboxed).
+
+## 1. Service environment
+
+`systemctl show alif-backend -p Environment` reports **none** of the
+cost-consolidation flags are explicitly set:
+
+| Env var | Set? | Code default | Effective state |
+|---|---|---|---|
+| `ALIF_USE_LEGACY_BATCH` | unset | `"1"` | Legacy batch ON ✓ |
+| `ALIF_AUDIO_ENABLED` | unset | `False` | Audio gen OFF ✓ |
+| `ALIF_RUN_CRON_LEMMA_ENRICHMENT` | unset | `False` | Lemma enrichment OFF in cron |
+| `ALIF_RUN_CRON_CORPUS_ENRICHMENT` | unset | `False` | Corpus enrichment OFF in cron |
+| `ALIF_RUN_CRON_PREGENERATION` | unset | `False` | Pre-generation OFF in cron |
+
+Note: the earlier exploration assumed `ALIF_ENRICH_LEMMAS` and
+`ALIF_PREGEN_ENABLED` — the real names are `ALIF_RUN_CRON_*` (see
+`backend/scripts/update_material.py:97-105`). Behavior matches intent.
+
+## 2. Lemma gloss coverage
+
+The hard invariant: no lemma may have an empty `gloss_en` if it can be reached
+from an active sentence (CLAUDE.md "no words without English gloss — EVER").
+
+- **3129 lemmas total**, max id `3384`
+- **14 empty-gloss lemmas**, all `source="story_import"`, all
+  `word_category="junk"`, all gated on 2026-04-01 / 2026-04-15 (one batch).
+- **0 empty-gloss lemmas in the most recent 200 ids** — enrichment-opt-in is
+  *not currently biting* because there's no fresh import path running through
+  the cron.
+- **0 empty-gloss lemmas reachable from any active sentence** — the 14 junk
+  rows are quarantined by `word_category="junk"` filters.
+
+**Verdict:** safe today. Latent risk: if a new book/corpus import lands while
+the cron flags stay off, those lemmas will skip enrichment and may bypass the
+invariant at generation time. Track 1 follow-up: make sure book imports run
+through the synchronous enrichment path (not the cron-gated one).
+
+## 3. Stranded sentences (active but not reviewable)
+
+`reviewable_sentence_clauses()` requires `mappings_verified_at >= 2026-04-16`
+AND `!= '2000-01-01'` AND no NULL `lemma_id`s.
+
+- **1744 active sentences** total
+- **1560 currently reviewable** (89.4 %)
+- **184 stranded** (10.6 %), all due to stale `mappings_verified_at` —
+  zero with NULL verification, zero with the corpus sentinel
+  - 153 LLM-generated
+  - 29 book
+  - 2 corpus
+- **3 active sentences carry a NULL `lemma_id`** — storage gate passed,
+  reviewability blocked. Healer in `update_material.py` step 0b should remap
+  these next pass.
+
+**Verdict:** the stale-verification cohort is the operationally important one.
+These were generated/imported under the old pipeline (pre-2026-04-16) and have
+never been re-verified. The cron's healing only handles NULL lemma_ids — it
+does **not** trigger re-verification of sentences whose verification timestamp
+is stale. They will sit gated forever unless Track 2 explicitly sweeps them.
+
+## Summary
+
+| Finding | Severity | Action |
+|---|---|---|
+| Audio gen OFF | Intentional cost cut | Confirm with user that listening-mode degradation on new content is acceptable |
+| Enrichment OFF in cron | Latent | Verify book-import path uses synchronous enrichment, not cron flag |
+| 14 junk lemmas with empty gloss | Inert | None — not user-visible |
+| 184 stale-verification sentences | **Operational** | Track 2 sweep — these are exactly the kind of sentences the recurring mapping audit should re-verify |
+| 3 active NULL-lemma sentences | Self-healing | Wait one cron cycle, recheck |
+
+The cost consolidation looks well-executed. The one *non-cost* operational
+issue surfaced is the 184-sentence backlog — which Track 2 (recurring mapping
+audit) is already designed to drain.


### PR DESCRIPTION
## Summary

- New `app/services/mapping_rescue.py` hooks into `warm_sentence_cache` between gap detection and LLM generation. For each gap lemma, pulls up to 5 stale-verified sentences (`mappings_verified_at` < 2026-04-16, NULL, or the 2000-01-01 corpus sentinel), batch-verifies them via the existing `batch_verify_sentences`, applies confident corrections via the existing `apply_corrections`, and stamps survivors with a fresh `mappings_verified_at`.
- Verifier-proposed lemmas absent from the DB are gated by `frequency_core_entries`. If the bare form matches an FCE row whose `lemma_id IS NULL`, we create the lemma from the proposal and route it through `run_quality_gates`. Proposals without an FCE match are logged for offline triage; the sentence stays stale.
- Includes the Track 1 audit (`research/post-consolidation-audit-2026-05-13.md`) that surfaced the 184 stranded sentences this rescue path is meant to drain, and the Track 3 lemma-identity section in `docs/design-principles.md` codifying what counts as one lemma vs two (broken plurals, elatives, verb conjugations, same-root different-POS).

## Design notes

- **Lazy, not scheduled.** Rescue only runs on lemmas the warm cache has just flagged as gaps, so cost scales with demand instead of corpus size.
- **Write-lock safe.** Read phase pulls all snapshots and closes the DB before any LLM call; write phase reopens for a fast commit (CLAUDE.md Rule #10).
- **Doesn't touch `apply_corrections`.** The intentional `same_lemma` rejection there (load-bearing per the in-code guard block + memory `feedback_dont_weaken_same_lemma_gate`) is left alone. The frequency-gated proposal lives in `mapping_rescue`, so the existing reject path is unchanged.
- **Conservative caps:** 10 lemmas / 5 sentences per lemma / 30 sentences total per warm-cache run.

## Tests

- `backend/tests/test_mapping_rescue.py` (8 tests): clean stamp, fixable issue, unfixable-no-FCE, FCE-with-existing-lemma, FCE-unlinked-create-lemma, coverage-threshold, LLM-failure, no-stale-sentences.
- Full fast suite: 1121 passed, 9 deselected.