### PR TITLE
In-app camera with burst capture for scan-pages

### DIFF
--- a/frontend/app.json
+++ b/frontend/app.json
@@ -29,7 +29,13 @@
     },
     "plugins": [
       "expo-router",
-      "expo-font"
+      "expo-font",
+      [
+        "expo-camera",
+        {
+          "cameraPermission": "Alif uses the camera to scan textbook pages and extract vocabulary."
+        }
+      ]
     ],
     "extra": {
       "apiUrl": "http://46.225.75.29:3000"

--- a/frontend/app/scanner.tsx
+++ b/frontend/app/scanner.tsx
@@ -14,6 +14,7 @@ import {
 import { useFocusEffect } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
 import * as ImagePicker from "expo-image-picker";
+import { CameraView, useCameraPermissions } from "expo-camera";
 import { colors, fonts, fontFamily } from "../lib/theme";
 import {
   scanTextbookPages,
@@ -39,6 +40,11 @@ export default function ScannerScreen() {
   const [loadingHistory, setLoadingHistory] = useState(false);
   const [expandedBatch, setExpandedBatch] = useState<string | null>(null);
   const [preserveKnown, setPreserveKnown] = useState(true);
+  const [cameraOpen, setCameraOpen] = useState(false);
+  const [cameraCaptures, setCameraCaptures] = useState<string[]>([]);
+  const [capturing, setCapturing] = useState(false);
+  const [cameraPermission, requestCameraPermission] = useCameraPermissions();
+  const cameraRef = useRef<CameraView>(null);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   useFocusEffect(
@@ -87,16 +93,42 @@ export default function ScannerScreen() {
   }
 
   async function takePhoto() {
-    const { status } = await ImagePicker.requestCameraPermissionsAsync();
-    if (status !== "granted") return;
-
-    const result = await ImagePicker.launchCameraAsync({
-      quality: 0.8,
-    });
-
-    if (!result.canceled && result.assets.length > 0) {
-      setSelectedImages((prev) => [...prev, result.assets[0].uri]);
+    if (!cameraPermission?.granted) {
+      const res = await requestCameraPermission();
+      if (!res.granted) return;
     }
+    setCameraCaptures([]);
+    setCameraOpen(true);
+  }
+
+  async function capturePhoto() {
+    if (capturing || !cameraRef.current) return;
+    setCapturing(true);
+    try {
+      const photo = await cameraRef.current.takePictureAsync({
+        quality: 0.8,
+        skipProcessing: true,
+      });
+      if (photo?.uri) {
+        setCameraCaptures((prev) => [...prev, photo.uri]);
+      }
+    } catch (e) {
+      console.error("Capture failed:", e);
+    } finally {
+      setCapturing(false);
+    }
+  }
+
+  function removeCameraCapture(index: number) {
+    setCameraCaptures((prev) => prev.filter((_, i) => i !== index));
+  }
+
+  function finishCameraSession(save: boolean) {
+    if (save && cameraCaptures.length > 0) {
+      setSelectedImages((prev) => [...prev, ...cameraCaptures]);
+    }
+    setCameraCaptures([]);
+    setCameraOpen(false);
   }
 
   function removeImage(index: number) {
@@ -564,6 +596,70 @@ export default function ScannerScreen() {
     );
   }
 
+  if (cameraOpen) {
+    return (
+      <View style={styles.cameraContainer}>
+        <CameraView
+          ref={cameraRef}
+          style={StyleSheet.absoluteFill}
+          facing="back"
+        />
+        <View style={styles.cameraTopBar}>
+          <Pressable
+            style={styles.cameraTopBtn}
+            onPress={() => finishCameraSession(false)}
+          >
+            <Ionicons name="close" size={26} color="#fff" />
+          </Pressable>
+          <Pressable
+            style={[
+              styles.cameraDoneBtn,
+              cameraCaptures.length === 0 && styles.cameraDoneBtnDim,
+            ]}
+            onPress={() => finishCameraSession(true)}
+            disabled={cameraCaptures.length === 0}
+          >
+            <Text style={styles.cameraDoneText}>
+              Done{cameraCaptures.length > 0 ? ` (${cameraCaptures.length})` : ""}
+            </Text>
+          </Pressable>
+        </View>
+
+        <View style={styles.cameraBottomBar}>
+          {cameraCaptures.length > 0 && (
+            <ScrollView
+              horizontal
+              showsHorizontalScrollIndicator={false}
+              style={styles.cameraStrip}
+              contentContainerStyle={styles.cameraStripContent}
+            >
+              {cameraCaptures.map((uri, idx) => (
+                <View key={`${uri}-${idx}`} style={styles.cameraThumbItem}>
+                  <Image source={{ uri }} style={styles.cameraThumb} />
+                  <Pressable
+                    style={styles.cameraThumbRemove}
+                    onPress={() => removeCameraCapture(idx)}
+                  >
+                    <Ionicons name="close-circle" size={20} color="#fff" />
+                  </Pressable>
+                </View>
+              ))}
+            </ScrollView>
+          )}
+          <View style={styles.cameraShutterRow}>
+            <Pressable
+              style={[styles.cameraShutter, capturing && styles.cameraShutterDim]}
+              onPress={capturePhoto}
+              disabled={capturing}
+            >
+              <View style={styles.cameraShutterInner} />
+            </Pressable>
+          </View>
+        </View>
+      </View>
+    );
+  }
+
   return (
     <View style={styles.container}>
       <View style={styles.tabRow}>
@@ -917,5 +1013,103 @@ const styles = StyleSheet.create({
     fontSize: fonts.small,
     textAlign: "center",
     lineHeight: 20,
+  },
+  cameraContainer: {
+    flex: 1,
+    backgroundColor: "#000",
+  },
+  cameraTopBar: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    right: 0,
+    paddingTop: 50,
+    paddingHorizontal: 16,
+    paddingBottom: 12,
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    backgroundColor: "rgba(0,0,0,0.4)",
+  },
+  cameraTopBtn: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    backgroundColor: "rgba(0,0,0,0.5)",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  cameraDoneBtn: {
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    borderRadius: 20,
+    backgroundColor: colors.gotIt,
+  },
+  cameraDoneBtnDim: {
+    backgroundColor: "rgba(255,255,255,0.15)",
+  },
+  cameraDoneText: {
+    color: "#fff",
+    fontSize: fonts.body,
+    fontWeight: "700",
+  },
+  cameraBottomBar: {
+    position: "absolute",
+    bottom: 0,
+    left: 0,
+    right: 0,
+    paddingBottom: 30,
+    paddingTop: 12,
+    backgroundColor: "rgba(0,0,0,0.4)",
+  },
+  cameraStrip: {
+    maxHeight: 80,
+    marginBottom: 12,
+  },
+  cameraStripContent: {
+    paddingHorizontal: 16,
+    gap: 8,
+  },
+  cameraThumbItem: {
+    position: "relative",
+    marginRight: 8,
+  },
+  cameraThumb: {
+    width: 60,
+    height: 70,
+    borderRadius: 8,
+    backgroundColor: "#333",
+    borderWidth: 1,
+    borderColor: "rgba(255,255,255,0.3)",
+  },
+  cameraThumbRemove: {
+    position: "absolute",
+    top: -6,
+    right: -6,
+    backgroundColor: "#000",
+    borderRadius: 10,
+  },
+  cameraShutterRow: {
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  cameraShutter: {
+    width: 72,
+    height: 72,
+    borderRadius: 36,
+    backgroundColor: "rgba(255,255,255,0.25)",
+    alignItems: "center",
+    justifyContent: "center",
+    borderWidth: 3,
+    borderColor: "#fff",
+  },
+  cameraShutterDim: {
+    opacity: 0.5,
+  },
+  cameraShutterInner: {
+    width: 56,
+    height: 56,
+    borderRadius: 28,
+    backgroundColor: "#fff",
   },
 });

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,6 +18,7 @@
         "@react-native-community/netinfo": "11.4.1",
         "expo": "~54.0.33",
         "expo-av": "~16.0.8",
+        "expo-camera": "~17.0.10",
         "expo-constants": "~18.0.13",
         "expo-font": "~14.0.11",
         "expo-image-picker": "^17.0.10",
@@ -7378,6 +7379,26 @@
       "resolved": "https://registry.npmjs.org/expo-av/-/expo-av-16.0.8.tgz",
       "integrity": "sha512-cmVPftGR/ca7XBgs7R6ky36lF3OC0/MM/lpgX/yXqfv0jASTsh7AYX9JxHCwFmF+Z6JEB1vne9FDx4GiLcGreQ==",
       "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*",
+        "react-native-web": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-web": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/expo-camera": {
+      "version": "17.0.10",
+      "resolved": "https://registry.npmjs.org/expo-camera/-/expo-camera-17.0.10.tgz",
+      "integrity": "sha512-w1RBw83mAGVk4BPPwNrCZyFop0VLiVSRE3c2V9onWbdFwonpRhzmB4drygG8YOUTl1H3wQvALJHyMPTbgsK1Jg==",
+      "license": "MIT",
+      "dependencies": {
+        "invariant": "^2.2.4"
+      },
       "peerDependencies": {
         "expo": "*",
         "react": "*",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
     "@react-native-community/netinfo": "11.4.1",
     "expo": "~54.0.33",
     "expo-av": "~16.0.8",
+    "expo-camera": "~17.0.10",
     "expo-constants": "~18.0.13",
     "expo-font": "~14.0.11",
     "expo-image-picker": "^17.0.10",


### PR DESCRIPTION
## Summary
- Replaces `ImagePicker.launchCameraAsync` (one-shot, re-launch per page) with an embedded `CameraView` from `expo-camera`.
- Tap Camera once → snap multiple pages with a shutter button without leaving the app → thumbnail strip shows captures → Done returns all pages to the upload list at once.
- Adds `expo-camera ~17.0.10` (SDK 54 compatible) and the matching `app.json` plugin entry for iOS permission strings.

## Notes for the device test
- `skipProcessing: true` is on the shutter — if photos come back rotated on iOS, remove that flag.
- Camera top bar uses a hardcoded `paddingTop: 50` for notch clearance (no SafeAreaView yet). Looks correct on iPhone with notch; may be off on edge cases.
- Headless web cannot verify the actual camera preview (no fake-device flag in the dev browser) — page renders cleanly and Camera click runs without JS error; live preview needs to be checked on the iPhone.