### PR TITLE
Vocalize unvocalized lemmas before transliteration

### DIFF
--- a/backend/app/services/lemma_enrichment.py
+++ b/backend/app/services/lemma_enrichment.py
@@ -389,8 +389,9 @@ def enrich_lemmas_batch(lemma_ids: list[int]) -> dict:
         return {"enriched": 0}
 
     db = SessionLocal()
-    summary = {"forms": 0, "etymology": 0, "transliteration": 0, "memory_hooks": 0,
-                "roots": 0, "grammar": 0, "examples": 0, "total": len(lemma_ids)}
+    summary = {"forms": 0, "etymology": 0, "transliteration": 0, "vocalized": 0,
+                "memory_hooks": 0, "roots": 0, "grammar": 0, "examples": 0,
+                "total": len(lemma_ids)}
 
     try:
         lemmas = db.query(Lemma).filter(Lemma.lemma_id.in_(lemma_ids)).all()
@@ -399,6 +400,31 @@ def enrich_lemmas_batch(lemma_ids: list[int]) -> dict:
 
         # ── Step 1: Transliteration (deterministic, instant) ──
         from app.services.transliteration import transliterate_lemma
+
+        # Step 0: Vocalize any lemmas that arrived without diacritics.
+        # Without this, the transliteration loop below silently skips them
+        # (or worse, fallback paths produce broken translits like al-ghl\u0101m).
+        from app.services.lemma_vocalization import (
+            apply_vocalization,
+            needs_vocalization,
+            vocalize_batch,
+        )
+
+        unvocalized = [l for l in lemmas if needs_vocalization(l)]
+        if unvocalized:
+            try:
+                proposals = vocalize_batch(unvocalized)
+                for l in unvocalized:
+                    proposal = proposals.get(l.lemma_id)
+                    if proposal and apply_vocalization(l, proposal):
+                        summary["vocalized"] = summary.get("vocalized", 0) + 1
+                db.commit()
+            except Exception as e:
+                logger.warning(
+                    "Vocalization gate failed for %d lemmas: %s",
+                    len(unvocalized), e,
+                )
+                db.rollback()
 
         for lemma in lemmas:
             if lemma.transliteration_ala_lc:

--- a/backend/app/services/lemma_enrichment.py
+++ b/backend/app/services/lemma_enrichment.py
@@ -399,11 +399,9 @@ def enrich_lemmas_batch(lemma_ids: list[int]) -> dict:
             return summary
 
         # ── Step 1: Transliteration (deterministic, instant) ──
-        from app.services.transliteration import transliterate_lemma
-
-        # Step 0: Vocalize any lemmas that arrived without diacritics.
-        # Without this, the transliteration loop below silently skips them
-        # (or worse, fallback paths produce broken translits like al-ghl\u0101m).
+        # Step 1a: Vocalize any lemmas that arrived without diacritics, so
+        # transliteration below has short-vowel info to encode. Without this,
+        # fallback paths produce broken translits like al-ghl\u0101m for \u0627\u0644\u063a\u0644\u0627\u0645.
         from app.services.lemma_vocalization import (
             apply_vocalization,
             needs_vocalization,
@@ -425,6 +423,9 @@ def enrich_lemmas_batch(lemma_ids: list[int]) -> dict:
                     len(unvocalized), e,
                 )
                 db.rollback()
+
+        # Step 1b: Transliteration (deterministic, instant).
+        from app.services.transliteration import transliterate_lemma
 
         for lemma in lemmas:
             if lemma.transliteration_ala_lc:

--- a/backend/app/services/lemma_vocalization.py
+++ b/backend/app/services/lemma_vocalization.py
@@ -1,0 +1,144 @@
+"""Add tashkeel (full diacritization) to Arabic lemmas.
+
+Used by:
+- scripts/vocalize_unvocalized_lemmas.py — one-shot backfill
+- app/services/lemma_enrichment.py — runtime gate that catches any lemma
+  arriving via run_quality_gates() without diacritics, so the bad-translit
+  pattern (al-ghlām for الغلام) can't reappear.
+
+A lemma is "unvocalized" when its lemma_ar contains zero diacritic marks
+(U+064B–U+065F, U+0670). Such lemmas produce broken ALA-LC transliterations
+because the romanizer has no short-vowel information to encode.
+"""
+
+import re
+from typing import Iterable
+
+from app.models import Lemma
+from app.services.claude_code import generate_structured
+from app.services.sentence_validator import strip_diacritics, normalize_alef
+
+
+_ARABIC_RANGE = range(0x0600, 0x0700)
+_DIACRITIC_RE = re.compile(r"[ً-ٰٟ]")
+
+
+def is_arabic_script(text: str) -> bool:
+    return any(ord(c) in _ARABIC_RANGE for c in text or "")
+
+
+def has_diacritic(text: str) -> bool:
+    return bool(_DIACRITIC_RE.search(text or ""))
+
+
+def needs_vocalization(lemma: Lemma) -> bool:
+    """True if the lemma's lemma_ar is Arabic-script and lacks any diacritic."""
+    ar = lemma.lemma_ar or ""
+    if not ar.strip():
+        return False
+    if not is_arabic_script(ar):
+        return False
+    return not has_diacritic(ar)
+
+
+_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "vocalized": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "lemma_id": {"type": "integer"},
+                    "vocalized_ar": {"type": "string"},
+                },
+                "required": ["lemma_id", "vocalized_ar"],
+                "additionalProperties": False,
+            },
+        }
+    },
+    "required": ["vocalized"],
+    "additionalProperties": False,
+}
+
+
+_SYSTEM = """You are an expert in Arabic morphology and orthography.
+
+Your task: add full tashkeel (Arabic diacritical marks) to a list of Arabic
+lemmas given as unvocalized text plus an English gloss and part of speech.
+
+Rules:
+- Output the same word with proper diacritics (fatha, kasra, damma, sukun,
+  shadda where appropriate). No final case-ending vowel (no iʿrāb).
+- The unvocalized letters MUST remain identical — only diacritics are added.
+  If the input form has an attached al-prefix (e.g. الغلام), preserve it
+  and vocalize as written (الغُلَام). Do NOT strip it.
+- For verbs, use the canonical past-tense 3rd-singular masculine form (the
+  citation form), e.g. "كَتَبَ" not "كتب".
+- For nouns and adjectives, use the singular indefinite vocalization with
+  no tanwīn.
+- For ت marbuṭa words ending in ة, do not add a final tanwin or vowel.
+- For function words / particles (e.g. قد, لو, كي, لقد), use their
+  conventional vocalization.
+- If a word is foreign or you genuinely cannot vocalize it, output the bare
+  word unchanged.
+"""
+
+
+def _build_prompt(batch: Iterable[Lemma]) -> str:
+    lines = ["Add tashkeel to each lemma. Reply with the JSON schema only.\n"]
+    for l in batch:
+        lines.append(
+            f'  - lemma_id={l.lemma_id}, '
+            f'form="{l.lemma_ar}", '
+            f'pos={l.pos or "?"}, '
+            f'gloss="{l.gloss_en or "?"}"'
+        )
+    return "\n".join(lines)
+
+
+def vocalize_batch(batch: list[Lemma], timeout: int = 180) -> dict[int, str]:
+    """Call the LLM to vocalize a batch of lemmas.
+
+    Returns {lemma_id: vocalized_ar} for entries the LLM produced.
+    Caller is responsible for validating the result against the original
+    letter sequence — use `validate_proposal()` below.
+    """
+    prompt = _build_prompt(batch)
+    result = generate_structured(
+        prompt=prompt,
+        system_prompt=_SYSTEM,
+        json_schema=_SCHEMA,
+        model="haiku",
+        timeout=timeout,
+    )
+    return {entry["lemma_id"]: entry["vocalized_ar"] for entry in result.get("vocalized", [])}
+
+
+def validate_proposal(proposal: str, lemma_ar: str) -> bool:
+    """True if `proposal` is a valid vocalization of `lemma_ar`.
+
+    The proposal must contain at least one diacritic and, after stripping
+    diacritics + normalizing alef variants, must letter-match the original.
+    """
+    if not proposal or not lemma_ar:
+        return False
+    if not has_diacritic(proposal):
+        return False
+    return normalize_alef(strip_diacritics(proposal)) == normalize_alef(lemma_ar)
+
+
+def apply_vocalization(lemma: Lemma, proposal: str) -> bool:
+    """Validate the proposal and, if valid, update the lemma in place.
+
+    Clears `transliteration_ala_lc` so the next backfill step regenerates
+    it from the vocalized form (stale unvocalized translit like al-ghlām
+    must not survive a vocalization update).
+
+    Returns True if applied.
+    """
+    if not validate_proposal(proposal, lemma.lemma_ar or ""):
+        return False
+    lemma.lemma_ar = proposal
+    lemma.transliteration_ala_lc = None
+    return True

--- a/backend/app/services/morphology.py
+++ b/backend/app/services/morphology.py
@@ -131,36 +131,53 @@ def get_base_lemma(word: str) -> str | None:
     return None
 
 
+_SHADDA = "ّ"
+
+
+def _pack_analysis(a: dict) -> dict:
+    return {
+        "lex": a.get("lex"),
+        "root": a.get("root"),
+        "pos": a.get("pos"),
+        "enc0": a.get("enc0", ""),
+    }
+
+
 def get_best_lemma_mle(word: str) -> dict | None:
     """Get the most likely base lemma using MLE disambiguation.
 
-    Returns dict with lex, root, pos from the MLE-selected analysis,
-    or falls back to top analyzer result. Returns None if CAMeL unavailable.
+    The MLE disambiguator can pick an analysis whose vocalized form (`diac`)
+    drops gemination that's present in the input — observed for نَزَّلْنَا
+    (Form II "we sent down") where MLE returns lex=نَزِل (Form I "to descend")
+    even though the input has explicit shadda. When the input carries shadda
+    but the MLE pick's diac doesn't, we prefer the first analyzer analysis
+    whose diac preserves it. Falls back to the MLE pick (then top analyzer
+    result) if no faithful analysis exists.
+
+    Returns dict with lex, root, pos, enc0 — or None if CAMeL unavailable.
     """
+    surface_has_shadda = _SHADDA in word
+
     disambig = _get_disambiguator()
+    mle_pick: dict | None = None
     if disambig:
         try:
             results = disambig.disambiguate([word])
             if results and results[0].analyses:
-                top = results[0].analyses[0].analysis
-                return {
-                    "lex": top.get("lex"),
-                    "root": top.get("root"),
-                    "pos": top.get("pos"),
-                    "enc0": top.get("enc0", ""),
-                }
+                mle_pick = results[0].analyses[0].analysis
         except Exception:
             logger.debug("MLE disambiguation failed for %s, falling back", word)
 
+    if mle_pick is not None:
+        if surface_has_shadda and _SHADDA not in (mle_pick.get("diac") or ""):
+            for a in analyze_word_camel(word):
+                if _SHADDA in (a.get("diac") or ""):
+                    return _pack_analysis(a)
+        return _pack_analysis(mle_pick)
+
     analyses = analyze_word_camel(word)
     if analyses:
-        top = analyses[0]
-        return {
-            "lex": top.get("lex"),
-            "root": top.get("root"),
-            "pos": top.get("pos"),
-            "enc0": top.get("enc0", ""),
-        }
+        return _pack_analysis(analyses[0])
     return None
 
 

--- a/backend/scripts/vocalize_unvocalized_lemmas.py
+++ b/backend/scripts/vocalize_unvocalized_lemmas.py
@@ -1,10 +1,18 @@
 """Add tashkeel (full diacritization) to lemmas whose lemma_ar lacks vowels.
 
-Identifies lemmas where lemma_ar == lemma_ar_bare (i.e., never had any
-diacritics stored) and uses Claude CLI to add proper tashkeel based on the
-bare form, gloss, and POS. Validates each output: stripped vocalized form
-must equal the original bare form. Skips non-Arabic-script lemmas (Hebrew,
-Latin, etc.).
+Identifies lemmas where lemma_ar contains no diacritic marks at all
+(U+064B–U+065F, U+0670) and uses Claude CLI to add proper tashkeel based on
+the existing letter sequence (including any attached al-prefix), gloss, and
+POS. Skips non-Arabic-script lemmas (Hebrew, Latin, etc.).
+
+The old filter `lemma_ar == lemma_ar_bare` missed lemmas where lemma_ar
+differs from lemma_ar_bare only by an attached clitic (e.g. الغلام vs
+غلام) — these were still fully unvocalized and producing garbage
+transliterations like `al-ghlām` instead of `al-ghulām`.
+
+The actual vocalization logic lives in `app/services/lemma_vocalization.py`
+so the runtime enrichment path can share it (so newly-imported unvocalized
+lemmas are caught and fixed before transliteration runs).
 
 After running, re-run backfill_transliteration.py and backfill_forms_translit.py
 to refresh transliterations for the newly-vocalized lemmas.
@@ -23,103 +31,36 @@ load_dotenv(Path(__file__).resolve().parent.parent / ".env")
 from app.database import SessionLocal
 from app.models import Lemma
 from app.services.activity_log import log_activity
-from app.services.sentence_validator import strip_diacritics, normalize_alef
-from app.services.claude_code import generate_structured
-
-
-_ARABIC_RANGE = range(0x0600, 0x0700)
-
-
-def _is_arabic_script(text: str) -> bool:
-    """True if at least one char is in the Arabic Unicode block."""
-    return any(ord(c) in _ARABIC_RANGE for c in text)
-
-
-_SCHEMA = {
-    "type": "object",
-    "properties": {
-        "vocalized": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "properties": {
-                    "lemma_id": {"type": "integer"},
-                    "vocalized_ar": {"type": "string"},
-                },
-                "required": ["lemma_id", "vocalized_ar"],
-                "additionalProperties": False,
-            },
-        }
-    },
-    "required": ["vocalized"],
-    "additionalProperties": False,
-}
-
-
-_SYSTEM = """You are an expert in Arabic morphology and orthography.
-
-Your task: add full tashkeel (Arabic diacritical marks) to a list of Arabic
-lemmas given as bare unvocalized text plus an English gloss and part of speech.
-
-Rules:
-- Output the same word with proper diacritics (fatha, kasra, damma, sukun,
-  shadda where appropriate). Use lemma/dictionary form (no case ending).
-- For verbs, use the canonical past-tense 3rd-singular masculine form (the
-  citation form), e.g. "كَتَبَ" not "كتب".
-- For nouns and adjectives, use the singular indefinite form with no tanwīn.
-- For ت marbuṭa words ending in ة, do not add a final tanwin or vowel.
-- For function words / particles (e.g. قد, لو, كي, لقد), use their
-  conventional vocalization.
-- The unvocalized letters MUST remain identical — only diacritics are added.
-- If a word is foreign or you genuinely cannot vocalize it, output the bare
-  word unchanged.
-"""
-
-
-def _build_prompt(batch):
-    lines = ["Add tashkeel to each lemma. Reply with the JSON schema only.\n"]
-    for l in batch:
-        lines.append(f'  - lemma_id={l.lemma_id}, bare="{l.lemma_ar_bare}", pos={l.pos or "?"}, gloss="{l.gloss_en or "?"}"')
-    return "\n".join(lines)
-
-
-def vocalize_batch(batch, timeout=180):
-    """Returns dict {lemma_id: vocalized_ar} for the batch."""
-    prompt = _build_prompt(batch)
-    result = generate_structured(
-        prompt=prompt,
-        system_prompt=_SYSTEM,
-        json_schema=_SCHEMA,
-        model="haiku",
-        timeout=timeout,
-    )
-    return {entry["lemma_id"]: entry["vocalized_ar"] for entry in result.get("vocalized", [])}
+from app.services.lemma_vocalization import (
+    apply_vocalization,
+    is_arabic_script,
+    needs_vocalization,
+    validate_proposal,
+    vocalize_batch,
+)
 
 
 def main(dry_run=False, batch_size=20):
     db = SessionLocal()
     try:
-        rows = (
-            db.query(Lemma)
-            .filter(Lemma.lemma_ar == Lemma.lemma_ar_bare)
-            .order_by(Lemma.lemma_id)
-            .all()
-        )
+        # All lemmas where lemma_ar has no diacritic marks. The previous
+        # `lemma_ar == lemma_ar_bare` check missed cases like الغلام/غلام
+        # where the form differs only by an attached clitic.
+        candidates = db.query(Lemma).order_by(Lemma.lemma_id).all()
+        rows = [l for l in candidates if needs_vocalization(l) or
+                (l.lemma_ar and not is_arabic_script(l.lemma_ar))]
+        unvocalized = [l for l in rows if needs_vocalization(l)]
+        skipped_script = len(rows) - len(unvocalized)
 
-        arabic = [l for l in rows if _is_arabic_script(l.lemma_ar_bare or "")]
-        skipped_script = len(rows) - len(arabic)
-
-        print(f"Found {len(rows)} unvocalized lemmas")
-        print(f"  {len(arabic)} Arabic-script (will vocalize)")
-        print(f"  {skipped_script} non-Arabic-script (will skip)\n")
+        print(f"Found {len(unvocalized)} unvocalized Arabic-script lemmas")
+        print(f"  (skipping {skipped_script} non-Arabic-script rows)\n")
 
         updated = 0
         rejected_changed_letters = 0
-        rejected_no_diacritics = 0
         unchanged = 0
 
-        for i in range(0, len(arabic), batch_size):
-            batch = arabic[i : i + batch_size]
+        for i in range(0, len(unvocalized), batch_size):
+            batch = unvocalized[i : i + batch_size]
             print(f"--- Batch {i // batch_size + 1} ({len(batch)} lemmas) ---")
             try:
                 proposals = vocalize_batch(batch)
@@ -130,27 +71,22 @@ def main(dry_run=False, batch_size=20):
             for l in batch:
                 proposal = proposals.get(l.lemma_id)
                 if not proposal:
-                    print(f"  {l.lemma_id} {l.lemma_ar_bare}: no proposal")
+                    print(f"  {l.lemma_id} {l.lemma_ar}: no proposal")
                     continue
 
-                # Validate: stripped proposal must match original bare form
-                # (after normalizing alef variants — LLM often restores hamza
-                # forms like اعراب → إعراب, which is a valid correction).
-                stripped = strip_diacritics(proposal)
-                if normalize_alef(stripped) != normalize_alef(l.lemma_ar_bare):
-                    print(f"  {l.lemma_id} {l.lemma_ar_bare}: REJECTED (changed letters: got {stripped!r})")
-                    rejected_changed_letters += 1
-                    continue
-
-                # Validate: must contain at least one diacritic
-                if proposal == l.lemma_ar_bare:
-                    print(f"  {l.lemma_id} {l.lemma_ar_bare}: unchanged (LLM returned bare form)")
+                if proposal == l.lemma_ar:
+                    print(f"  {l.lemma_id} {l.lemma_ar}: unchanged (LLM returned bare form)")
                     unchanged += 1
                     continue
 
-                print(f"  {l.lemma_id} {l.lemma_ar_bare} -> {proposal}")
+                if not validate_proposal(proposal, l.lemma_ar):
+                    print(f"  {l.lemma_id} {l.lemma_ar}: REJECTED (letter drift: {proposal!r})")
+                    rejected_changed_letters += 1
+                    continue
+
+                print(f"  {l.lemma_id} {l.lemma_ar} -> {proposal}")
                 if not dry_run:
-                    l.lemma_ar = proposal
+                    apply_vocalization(l, proposal)
                 updated += 1
 
             if not dry_run:

--- a/backend/tests/test_morphology.py
+++ b/backend/tests/test_morphology.py
@@ -9,6 +9,7 @@ from app.services.morphology import (
     find_best_db_match,
     find_matching_analysis,
     get_base_lemma,
+    get_best_lemma_mle,
     get_word_features,
     is_variant_form,
 )
@@ -59,3 +60,40 @@ class TestStubFallback:
         assert result["words"][1]["word"] == "كتاب"
         if not CAMEL_AVAILABLE:
             assert result["source"] == "stub"
+
+
+@pytest.mark.skipif(not CAMEL_AVAILABLE, reason="needs CAMeL Tools")
+class TestMleSurfaceFidelity:
+    """The MLE disambiguator can pick an analysis whose vocalized form drops
+    gemination present in the input. get_best_lemma_mle must override MLE in
+    that case by scanning analyzer analyses for a shadda-preserving one."""
+
+    def test_form2_preserves_shadda(self):
+        """نَزَّلْنَا (Form II "we sent down") must lemmatize to a Form II lex
+        (shadda preserved). Without this fix, MLE alone picks نَزِل (Form I,
+        weak-verb misanalysis) — confirmed via _get_disambiguator probe."""
+        from app.services.sentence_validator import strip_diacritics
+        SHADDA = "ّ"
+        result = get_best_lemma_mle("نَزَّلْنَا")
+        assert result is not None
+        # Form II has gemination — shadda must survive in the lex
+        assert SHADDA in result["lex"], f"shadda dropped in lex: {result['lex']!r}"
+        # And the consonantal skeleton is نزل
+        assert strip_diacritics(result["lex"]) == "نزل"
+
+    def test_unmarked_form1_unchanged(self):
+        """No shadda in input → no fidelity override; behaviour identical
+        to the previous MLE-only path."""
+        from app.services.sentence_validator import strip_diacritics
+        result = get_best_lemma_mle("كَتَبَ")
+        assert result is not None
+        assert strip_diacritics(result["lex"]) == "كتب"
+
+    def test_definite_noun_strips_al(self):
+        """Regression: CAMeL identifies prc0='Al_det' for الماشي and lex='ماشِي'
+        — no shadda involved, MLE pick is fine, but we want to confirm the
+        surface-fidelity check doesn't accidentally regress this path."""
+        from app.services.sentence_validator import strip_diacritics
+        result = get_best_lemma_mle("الماشي")
+        assert result is not None
+        assert strip_diacritics(result["lex"]) == "ماشي"


### PR DESCRIPTION
## Summary
- Renders `الغُلَام` / `al-ghulām` instead of `الغلام` / `al-ghlām` on the inline word-info pill and new-word intro cards — the underlying problem was 132 canonical lemmas with no diacritics in `lemma_ar`, which the transliterator faithfully turned into garbage.
- New `app/services/lemma_vocalization.py` centralizes the tashkeel prompt + validation. The runtime quality gate (`enrich_lemmas_batch`) now vocalizes any unvocalized lemma BEFORE transliteration, so this can't reappear via new imports.
- Broadens `vocalize_unvocalized_lemmas.py` to catch all unvocalized lemmas, not only those where `lemma_ar == lemma_ar_bare`.