### PR TITLE
OCR: use CAMeL lex for lemma_ar; cleanup chimera + al-display rows

### DIFF
--- a/backend/app/services/ocr_service.py
+++ b/backend/app/services/ocr_service.py
@@ -369,7 +369,12 @@ def _step1_extract_words(image_bytes: bytes) -> list[str]:
 def _step2_morphology(words: list[str]) -> list[dict]:
     """Step 2: Use CAMeL Tools for morphological analysis of each word.
 
-    Returns list of dicts with: arabic, bare, root, base_lemma, pos.
+    Returns list of dicts with: arabic, bare, root, base_lemma,
+    base_lemma_vocalized, pos.
+    `base_lemma_vocalized` is the CAMeL `lex` with diacritics — used by
+    process_textbook_page as the canonical dictionary form for lemma_ar
+    so the al- prefix and other clitics don't leak into the stored
+    headword (e.g. surface "الْمَاشِي" → base_lemma_vocalized "ماشِي").
     Falls back to basic normalization if CAMeL Tools unavailable.
     """
     from app.services.morphology import (
@@ -390,6 +395,7 @@ def _step2_morphology(words: list[str]) -> list[dict]:
             "bare": bare,
             "root": None,
             "base_lemma": bare,
+            "base_lemma_vocalized": None,
             "pos": None,
         }
 
@@ -401,6 +407,7 @@ def _step2_morphology(words: list[str]) -> list[dict]:
                 lex = mle_result.get("lex")
                 if lex:
                     entry["base_lemma"] = normalize_alef(strip_diacritics(lex))
+                    entry["base_lemma_vocalized"] = lex
             else:
                 analyses = analyze_word_camel(word)
                 if analyses:
@@ -410,6 +417,7 @@ def _step2_morphology(words: list[str]) -> list[dict]:
                     lex = top.get("lex")
                     if lex:
                         entry["base_lemma"] = normalize_alef(strip_diacritics(lex))
+                        entry["base_lemma_vocalized"] = lex
 
         results.append(entry)
     return results
@@ -524,6 +532,7 @@ def extract_words_from_image(image_bytes: bytes) -> tuple[list[dict], int | None
             "pos": entry.get("pos"),
             "root": root_str,
             "base_lemma": base_lemma if base_lemma != bare else None,
+            "base_lemma_vocalized": entry.get("base_lemma_vocalized"),
         })
 
     return results, page_number
@@ -699,6 +708,17 @@ def process_textbook_page(
                 english = (word_data.get("english") or "").strip()
                 pos = word_data.get("pos")
                 root_str = word_data.get("root")
+                # Prefer CAMeL's vocalized lex for the headword when its
+                # stripped bare matches our chosen import_bare. This avoids
+                # storing al-prefixed surfaces like 'الْمَاشِي' as the
+                # displayed lemma_ar when CAMeL clearly canonicalized to
+                # 'ماشِي' (prc0='Al_det'). Falls back to the OCR surface if
+                # CAMeL gave nothing or its stripped form would change the
+                # bare key.
+                import_lemma_ar = arabic
+                base_voc = word_data.get("base_lemma_vocalized")
+                if base_voc and normalize_alef(strip_diacritics(base_voc)) == normalize_alef(import_bare):
+                    import_lemma_ar = base_voc
 
                 # Never create a Lemma without an English gloss
                 if not english:
@@ -729,7 +749,7 @@ def process_textbook_page(
                     lemma_gloss = f"(name) {english}"
 
                 new_lemma = Lemma(
-                    lemma_ar=arabic,
+                    lemma_ar=import_lemma_ar,
                     lemma_ar_bare=import_bare,
                     root_id=root_id,
                     pos=pos,

--- a/backend/scripts/apply_quran_inflected_cleanup_2026_05_15.py
+++ b/backend/scripts/apply_quran_inflected_cleanup_2026_05_15.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+"""One-off apply: cleanup_inflected_quran_lemmas.py dry-run → curated decisions.
+
+Audit ran 2026-05-15 on prod, found 71 source="quran" canonicals, of which
+26 needed action (5 LINK_EXISTING, 21 PROMOTE_NEW). Spot-check of the 21
+PROMOTE_NEW revealed CAMeL's MLE picked the wrong lex for ~7 of them
+(noun for verb, wrong root, Quranic-typography artifacts). This script:
+
+  - Applies the 5 LINK_EXISTING (link variant → existing canonical in DB)
+  - Applies 14 trustworthy PROMOTE_NEW (CAMeL lex matches gloss/pos)
+  - Applies 6 manually-overridden PROMOTE_NEW with corrected lex
+  - SUSPENDs 1 compound-particle row (#2872 يايها) — can't be cleanly
+    linked since it's a 2-word compound يا + أيُّها
+
+Each action includes the merge_variant data migration so sentence_words,
+review_logs, sentence target_lemma_ids, and ULK state move onto the
+canonical — leaving the variant row inert.
+
+Usage:
+    python3 scripts/apply_quran_inflected_cleanup_2026_05_15.py --dry-run
+    python3 scripts/apply_quran_inflected_cleanup_2026_05_15.py
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+BACKEND_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(BACKEND_ROOT))
+
+from app.database import SessionLocal  # noqa: E402
+from app.models import Lemma, Root, UserLemmaKnowledge  # noqa: E402
+from app.services.activity_log import log_activity  # noqa: E402
+from app.services.lemma_quality import run_quality_gates  # noqa: E402
+from app.services.morphology import is_valid_root  # noqa: E402
+from app.services.sentence_validator import (  # noqa: E402
+    build_lemma_lookup,
+    normalize_alef,
+    strip_diacritics,
+)
+from app.services.variant_detection import mark_variants  # noqa: E402
+from scripts.cleanup_lemma_variants import merge_variant  # noqa: E402
+
+AUDIT_REPORT = BACKEND_ROOT / "data" / "inflected_quran_audit.json"
+
+# ---------- 2 LINK_EXISTING after the 2026-05-15 audit re-run with direct
+# bare-form SQL lookup (build_lemma_lookup's generated forms had previously
+# produced bogus links into other inflected rows / proper names).
+LINK_EXISTING: list[tuple[int, int, str]] = [
+    (2879, None, "مثله → مِثْل #3083 (noun, scaffold)"),
+    (2904, None, "يفسد → أَفْسَد #3353 (verb, audit_2026-05-06)"),
+]
+
+# ---------- 17 trustworthy PROMOTE_NEW (CAMeL's lex from audit JSON).
+# Three IDs (2828, 2856, 2884) moved from LINK_EXISTING after the re-audit
+# correctly rejected their previous (bogus) link targets.
+TRUSTED_PROMOTE_IDS: set[int] = {
+    2825, 2828, 2853, 2855, 2856, 2857, 2859, 2867, 2868, 2869,
+    2878, 2884, 2886, 2888, 2889, 2891, 2896,
+}
+
+# ---------- 6 manual overrides where CAMeL's lex was wrong
+# (orphan_id, lex_vocalized, lex_bare, gloss_en, pos, root_dotted, note)
+MANUAL_OVERRIDES: list[tuple[int, str, str, str, str, str, str]] = [
+    (2818, "هَدَى",   "هدى", "to guide",            "verb", "ه.د.ي", "CAMeL picked verbal noun هَدْي"),
+    (2849, "خَلَا",   "خلا", "to be alone, pass",   "verb", "خ.ل.و", "CAMeL picked noun خِلْو"),
+    (2863, "ظُلْمَة", "ظلمة", "darkness",            "noun", "ظ.ل.م", "CAMeL picked verb ظَلَم"),
+    (2883, "حَجَر",   "حجر", "stone",               "noun", "ح.ج.ر", "CAMeL picked agent noun حَجّار"),
+    (2892, "نَقَض",   "نقض", "to break, undo",      "verb", "ن.ق.ض", "CAMeL picked ٱنْقَضَى (different root)"),
+    (2908, "نَبَّأ",  "نبأ", "to inform",           "verb", "ن.ب.أ", "CAMeL picked Quranic typography artifact"),
+]
+
+# ---------- Suspend: compound particle that can't be cleanly canonicalized
+SUSPEND_IDS: list[tuple[int, str]] = [
+    (2872, "يايها — Quranic vocative compound يا + أيُّها; no single canonical"),
+]
+
+
+def _resolve_root_id(db, root_str: str | None) -> int | None:
+    if not root_str:
+        return None
+    import re as _re
+    cleaned = _re.sub(r'[^؀-ۿ.]', '', root_str)
+    if not cleaned or not is_valid_root(cleaned):
+        return None
+    root = db.query(Root).filter(Root.root == cleaned).first()
+    if not root:
+        root = Root(root=cleaned)
+        db.add(root)
+        db.flush()
+    return root.root_id
+
+
+def _find_or_create_canonical(
+    db,
+    lemma_lookup: dict[str, int],
+    lex_vocalized: str,
+    lex_bare: str,
+    gloss_en: str,
+    pos: str,
+    root_str: str | None,
+    dry_run: bool,
+    variant_id: int | None = None,
+) -> tuple[int, bool]:
+    """Return (canonical_lemma_id, created_new). Direct-bare SQL lookup against
+    non-variant rows, POS-filtered, never reusing the variant itself. If no
+    suitable canonical exists, create one."""
+    bare_norm = normalize_alef(lex_bare)
+    candidates = (
+        db.query(Lemma)
+        .filter(
+            Lemma.lemma_ar_bare == bare_norm,
+            Lemma.canonical_lemma_id.is_(None),
+        )
+        .all()
+    )
+    cp = (pos or "").lower()
+    def _ok(c):
+        if c.lemma_id == variant_id:
+            return False
+        if c.word_category == "proper_name" or (c.pos or "").lower() == "noun_prop":
+            return False
+        cpos = (c.pos or "").lower()
+        if cp.startswith("verb"):
+            return cpos.startswith("verb")
+        if cp.startswith("noun") or cp.startswith("adj"):
+            return cpos.startswith("noun") or cpos.startswith("adj")
+        return cpos == cp
+    valid = [c for c in candidates if _ok(c)]
+    if valid:
+        valid.sort(key=lambda c: (c.source == "quran", c.lemma_id))
+        return valid[0].lemma_id, False
+
+    if dry_run:
+        print(f"  [dry] would CREATE canonical: {lex_vocalized} ({lex_bare}) - {gloss_en}")
+        return -1, True
+
+    new_canonical = Lemma(
+        lemma_ar=lex_vocalized,
+        lemma_ar_bare=lex_bare,
+        gloss_en=gloss_en,
+        pos=pos,
+        source="quran",
+        root_id=_resolve_root_id(db, root_str),
+        word_category=None,
+    )
+    db.add(new_canonical)
+    db.flush()
+
+    if not db.query(UserLemmaKnowledge).filter(
+        UserLemmaKnowledge.lemma_id == new_canonical.lemma_id
+    ).first():
+        db.add(UserLemmaKnowledge(
+            lemma_id=new_canonical.lemma_id,
+            knowledge_state="encountered",
+            source="quran",
+            total_encounters=0,
+        ))
+    try:
+        run_quality_gates(db, [new_canonical.lemma_id], background_enrich=False)
+    except Exception as e:
+        print(f"  quality_gates warning for {lex_bare}: {e}", file=sys.stderr)
+
+    lemma_lookup[normalize_alef(lex_bare)] = new_canonical.lemma_id
+    return new_canonical.lemma_id, True
+
+
+def _apply_action(db, lemma_lookup, audit_index, variant_id, canonical_id, note,
+                  dry_run, source_label, form_key="inflected"):
+    variant = db.get(Lemma, variant_id)
+    canonical = db.get(Lemma, canonical_id)
+    if not variant or not canonical:
+        print(f"  SKIP #{variant_id}: missing variant or canonical", file=sys.stderr)
+        return False
+    if variant.canonical_lemma_id is not None:
+        print(f"  SKIP #{variant_id}: already linked to #{variant.canonical_lemma_id}")
+        return False
+
+    print(f"  {source_label} #{variant_id} {variant.lemma_ar_bare} → "
+          f"#{canonical_id} {canonical.lemma_ar_bare} ({note})")
+
+    if dry_run:
+        merge_variant(db, variant_id, canonical_id, form_key, dry_run=True)
+        return True
+
+    mark_variants(db, [(variant_id, canonical_id, form_key,
+                        {"source": "apply_quran_inflected_cleanup_2026_05_15"})])
+    merge_variant(db, variant_id, canonical_id, form_key, dry_run=False)
+    return True
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    if not AUDIT_REPORT.exists():
+        print(f"ERROR: audit report not found at {AUDIT_REPORT}", file=sys.stderr)
+        print("Run cleanup_inflected_quran_lemmas.py --dry-run first.", file=sys.stderr)
+        sys.exit(1)
+
+    audit = json.loads(AUDIT_REPORT.read_text())
+    audit_index = {item["lemma_id"]: item for item in audit["items"]}
+
+    db = SessionLocal()
+    try:
+        lemma_lookup = build_lemma_lookup(db.query(Lemma).all())
+
+        applied = {"link_existing": 0, "promote_trusted": 0, "manual": 0, "suspended": 0}
+
+        # 1. LINK_EXISTING — read canonical_id from the audit JSON
+        print("\n=== Phase 1: LINK_EXISTING (5) ===")
+        for variant_id, _, note in LINK_EXISTING:
+            entry = audit_index.get(variant_id)
+            if not entry:
+                print(f"  SKIP #{variant_id}: not in audit JSON", file=sys.stderr)
+                continue
+            canonical_id = entry.get("canonical_id")
+            if not canonical_id:
+                print(f"  SKIP #{variant_id}: no canonical_id in audit", file=sys.stderr)
+                continue
+            if _apply_action(db, lemma_lookup, audit_index, variant_id, canonical_id,
+                             note, args.dry_run, "LINK"):
+                applied["link_existing"] += 1
+            if not args.dry_run:
+                db.commit()
+
+        # 2. TRUSTED PROMOTE_NEW — use CAMeL's lex from audit
+        print(f"\n=== Phase 2: PROMOTE_NEW trusted ({len(TRUSTED_PROMOTE_IDS)}) ===")
+        for variant_id in sorted(TRUSTED_PROMOTE_IDS):
+            entry = audit_index.get(variant_id)
+            if not entry:
+                print(f"  SKIP #{variant_id}: not in audit", file=sys.stderr)
+                continue
+            variant = db.get(Lemma, variant_id)
+            if not variant:
+                continue
+            lex_vocalized = entry["lex_vocalized"]
+            lex_bare = entry["lex_bare"]
+            gloss = (variant.gloss_en or "").strip() or "(no gloss)"
+            pos = entry.get("camel_pos") or variant.pos or "noun"
+            camel_root = entry.get("camel_root")
+            if isinstance(camel_root, str) and "." not in camel_root and 1 < len(camel_root) <= 5:
+                camel_root = ".".join(list(camel_root))
+
+            canonical_id, created = _find_or_create_canonical(
+                db, lemma_lookup, lex_vocalized, lex_bare,
+                gloss_en=gloss, pos=pos, root_str=camel_root, dry_run=args.dry_run,
+                variant_id=variant_id,
+            )
+            if canonical_id < 0:
+                continue
+            if canonical_id == variant_id:
+                print(f"  SKIP #{variant_id}: would link to self", file=sys.stderr)
+                continue
+            note = f"CAMeL lex (created={created})"
+            if _apply_action(db, lemma_lookup, audit_index, variant_id, canonical_id,
+                             note, args.dry_run, "PROMOTE"):
+                applied["promote_trusted"] += 1
+            if not args.dry_run:
+                db.commit()
+
+        # 3. MANUAL_OVERRIDES — corrected lex
+        print(f"\n=== Phase 3: MANUAL_OVERRIDES ({len(MANUAL_OVERRIDES)}) ===")
+        for variant_id, lex_voc, lex_bare, gloss, pos, root_str, note in MANUAL_OVERRIDES:
+            canonical_id, created = _find_or_create_canonical(
+                db, lemma_lookup, lex_voc, lex_bare,
+                gloss_en=gloss, pos=pos, root_str=root_str, dry_run=args.dry_run,
+                variant_id=variant_id,
+            )
+            if canonical_id < 0:
+                continue
+            if canonical_id == variant_id:
+                print(f"  SKIP #{variant_id}: would link to self", file=sys.stderr)
+                continue
+            full_note = f"{note} → use {lex_voc} (created={created})"
+            if _apply_action(db, lemma_lookup, audit_index, variant_id, canonical_id,
+                             full_note, args.dry_run, "MANUAL"):
+                applied["manual"] += 1
+            if not args.dry_run:
+                db.commit()
+
+        # 4. SUSPEND — compound particles with no single canonical
+        print(f"\n=== Phase 4: SUSPEND ({len(SUSPEND_IDS)}) ===")
+        for variant_id, note in SUSPEND_IDS:
+            ulk = (db.query(UserLemmaKnowledge)
+                   .filter(UserLemmaKnowledge.lemma_id == variant_id).first())
+            print(f"  SUSPEND #{variant_id}: {note}")
+            if args.dry_run:
+                continue
+            if ulk:
+                ulk.knowledge_state = "suspended"
+                ulk.experiment_group = None
+                ulk.experiment_intro_shown_at = None
+            applied["suspended"] += 1
+            db.commit()
+
+        # Summary
+        print(f"\nApplied: {applied}")
+
+        if not args.dry_run:
+            log_activity(
+                db,
+                event_type="manual_action",
+                summary=(
+                    "Quran inflected-lemma curated cleanup: "
+                    f"link_existing={applied['link_existing']} "
+                    f"promote_trusted={applied['promote_trusted']} "
+                    f"manual={applied['manual']} "
+                    f"suspended={applied['suspended']}"
+                ),
+                detail={
+                    "script": "apply_quran_inflected_cleanup_2026_05_15",
+                    **applied,
+                    "trusted_ids": sorted(TRUSTED_PROMOTE_IDS),
+                    "manual_overrides": [
+                        {"id": v[0], "lex": v[1], "gloss": v[3], "note": v[6]}
+                        for v in MANUAL_OVERRIDES
+                    ],
+                    "suspend_ids": [v[0] for v in SUSPEND_IDS],
+                },
+            )
+            db.commit()
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/cleanup_inflected_quran_lemmas.py
+++ b/backend/scripts/cleanup_inflected_quran_lemmas.py
@@ -74,12 +74,40 @@ from app.services.sentence_validator import (  # noqa: E402
     strip_diacritics,
 )
 from app.services.variant_detection import mark_variants  # noqa: E402
+from sqlalchemy.orm import Session  # noqa: E402
 
 REPORT_FILE = BACKEND_ROOT / "data" / "inflected_quran_audit.json"
 
 
-def _classify(lemma: Lemma, lemma_lookup: dict[str, int]) -> dict[str, Any]:
-    """Run CAMeL on a lemma and return classification info."""
+def _pos_compatible(camel_pos: str, candidate_pos: str | None,
+                    candidate_word_category: str | None) -> bool:
+    """Conservative POS gate for canonical linking.
+
+    - Never link a common form to a proper-name lemma (Salih the name
+      vs salih "righteous"): word_category='proper_name' OR pos='noun_prop'.
+    - Verbs must link to verbs. Nouns may link to nouns/adjs (Arabic
+      substantive overlap), never to verbs.
+    """
+    cand_pos = (candidate_pos or "").lower()
+    if candidate_word_category == "proper_name" or cand_pos == "noun_prop":
+        return False
+    cp = (camel_pos or "").lower()
+    if cp.startswith("verb"):
+        return cand_pos.startswith("verb")
+    if cp.startswith("noun") or cp.startswith("adj"):
+        return cand_pos.startswith("noun") or cand_pos.startswith("adj")
+    if cp.startswith("part") or cp == "particle":
+        return cand_pos.startswith("part") or cand_pos == "particle"
+    return cand_pos == cp
+
+
+def _classify(db: Session, lemma: Lemma) -> dict[str, Any]:
+    """Run CAMeL on a lemma and return classification info.
+
+    Uses DIRECT lemma_ar_bare equality on non-variant Lemma rows (not
+    build_lemma_lookup, which generates conjugation forms — that lookup
+    would falsely match a variant's own inflections back to itself).
+    """
     surface = lemma.lemma_ar or lemma.lemma_ar_bare or ""
     if not surface:
         return {"verdict": "NO_CAMEL", "reason": "empty surface"}
@@ -106,9 +134,35 @@ def _classify(lemma: Lemma, lemma_lookup: dict[str, int]) -> dict[str, Any]:
     if lex_bare == own_bare:
         return {"verdict": "LOOKS_CANONICAL", **info}
 
-    canonical_id = lemma_lookup.get(lex_bare)
-    if canonical_id is not None and canonical_id != lemma.lemma_id:
-        return {"verdict": "LINK_EXISTING", "canonical_id": canonical_id, **info}
+    candidates = (
+        db.query(Lemma)
+        .filter(
+            Lemma.lemma_ar_bare == lex_bare,
+            Lemma.lemma_id != lemma.lemma_id,
+            Lemma.canonical_lemma_id.is_(None),
+        )
+        .all()
+    )
+    valid = [
+        c for c in candidates
+        if _pos_compatible(info["camel_pos"], c.pos, c.word_category)
+    ]
+
+    if valid:
+        valid.sort(key=lambda c: (c.source == "quran", c.lemma_id))
+        return {
+            "verdict": "LINK_EXISTING",
+            "canonical_id": valid[0].lemma_id,
+            "canonical_lemma_ar": valid[0].lemma_ar,
+            "canonical_pos": valid[0].pos,
+            "canonical_source": valid[0].source,
+            "candidates_rejected": [
+                {"id": c.lemma_id, "pos": c.pos, "wc": c.word_category,
+                 "gloss": c.gloss_en, "source": c.source}
+                for c in candidates if c not in valid
+            ],
+            **info,
+        }
 
     return {"verdict": "PROMOTE_NEW", **info}
 
@@ -281,7 +335,7 @@ def main() -> None:
         detailed: list[dict[str, Any]] = []
 
         for lemma in quran_candidates:
-            classification = _classify(lemma, lemma_lookup)
+            classification = _classify(db, lemma)
             verdict = classification["verdict"]
             verdicts[verdict] += 1
             detailed.append({

--- a/backend/scripts/cleanup_ocr_lemma_corruption_2026_05_15.py
+++ b/backend/scripts/cleanup_ocr_lemma_corruption_2026_05_15.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""OCR textbook_scan cleanup: al-display fixes, chimera suspends, manual fixes.
+
+Pre-existing OCR-imported lemmas that have one or more of:
+  Phase A — `lemma_ar` retains the textbook surface with an integrated al-
+            prefix, while `lemma_ar_bare` correctly omits it. Display-only
+            bug: the user sees "الْمَاشِي" instead of "ماشِي" on intro
+            cards. Fix by re-analyzing the stored surface with CAMeL, and
+            if `prc0='Al_det'`, replacing `lemma_ar` with the CAMeL lex.
+
+  Phase B — Cross-root chimera lemmas where `lemma_ar`'s root differs from
+            `lemma_ar_bare`'s root. Three confirmed cases:
+              - #2307 lemma_ar='آنِسَة' bare='نسي' gloss='Miss'  → bare belongs
+                to "to forget" but the gloss/display says "Miss". 129 SW +
+                27 RL + 38 sentence target refs all wrongly attribute "Miss"
+                to "to forget" surfaces.
+              - #3450 'فارسٌ' / 'عشب' / 'horseman'
+              - #3452 'اشتدَّ' / 'طعام' / 'to intensify'
+            Action: suspend ULK and NULL out downstream refs so the cron
+            re-resolves them via the comprehensive lemma lookup.
+
+  Phase C — #1527 إلزامي with corrupted bare 'زامي' (CAMeL mis-stripped
+            integral إل as a clitic). Set bare to 'الزامي' (matching how
+            the integral-al lemmas like الذي/التي are stored).
+
+Each phase is independently runnable with --phase A|B|C.
+
+Usage:
+    python3 scripts/cleanup_ocr_lemma_corruption_2026_05_15.py --dry-run
+    python3 scripts/cleanup_ocr_lemma_corruption_2026_05_15.py --phase A
+    python3 scripts/cleanup_ocr_lemma_corruption_2026_05_15.py
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from collections import Counter
+from pathlib import Path
+
+BACKEND_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(BACKEND_ROOT))
+
+from app.database import SessionLocal  # noqa: E402
+from app.models import (  # noqa: E402
+    Lemma, ReviewLog, Sentence, SentenceWord, StoryWord, UserLemmaKnowledge,
+)
+from app.services.activity_log import log_activity  # noqa: E402
+from app.services.morphology import (  # noqa: E402
+    CAMEL_AVAILABLE, analyze_word_camel, get_best_lemma_mle,
+)
+from app.services.sentence_validator import (  # noqa: E402
+    normalize_alef, strip_diacritics,
+)
+
+
+CHIMERA_IDS = [2307, 3450, 3452]
+
+
+def phase_a(db, dry_run: bool) -> dict:
+    """Fix lemmas where stored lemma_ar has an al- prefix the bare omits.
+
+    Re-analyzes each candidate with CAMeL. If the top analysis says
+    prc0='Al_det', replaces lemma_ar with the CAMeL lex (canonical vocalized
+    form without al-). Skips cases where CAMeL doesn't see Al_det (could be
+    integral-al lemma like الذي, or analysis is ambiguous).
+    """
+    print("\n=== Phase A: al-display fixes ===")
+    candidates = []
+    for l in db.query(Lemma).filter(Lemma.canonical_lemma_id.is_(None)).all():
+        if not l.lemma_ar or not l.lemma_ar_bare:
+            continue
+        ar_stripped = normalize_alef(strip_diacritics(l.lemma_ar))
+        bare_norm = normalize_alef(l.lemma_ar_bare)
+        if ar_stripped.startswith("ال") and not bare_norm.startswith("ال") and ar_stripped != bare_norm:
+            candidates.append(l)
+
+    counts = {"updated": 0, "skipped_integral_al": 0, "skipped_no_camel": 0,
+              "skipped_mismatch": 0}
+    print(f"  Found {len(candidates)} candidates")
+
+    for l in candidates:
+        analyses = analyze_word_camel(l.lemma_ar)
+        if not analyses:
+            counts["skipped_no_camel"] += 1
+            continue
+        # Find the top analysis whose stripped lex matches our bare (so we
+        # don't accidentally re-write the lemma into a different sense)
+        chosen = None
+        for a in analyses[:5]:
+            lex = a.get("lex") or ""
+            if not lex:
+                continue
+            if normalize_alef(strip_diacritics(lex)) == normalize_alef(l.lemma_ar_bare):
+                chosen = a
+                break
+        if chosen is None:
+            counts["skipped_mismatch"] += 1
+            continue
+        prc0 = chosen.get("prc0") or ""
+        if "Al_det" not in prc0:
+            # CAMeL doesn't see the al- as the definite article — could be
+            # integral. Be conservative: leave alone.
+            counts["skipped_integral_al"] += 1
+            continue
+        new_ar = chosen["lex"]
+        print(f"  #{l.lemma_id} {l.lemma_ar!r} → {new_ar!r}  (bare={l.lemma_ar_bare!r} gloss={l.gloss_en!r})")
+        if not dry_run:
+            l.lemma_ar = new_ar
+        counts["updated"] += 1
+
+    if not dry_run:
+        db.commit()
+    print(f"  Result: {counts}")
+    return counts
+
+
+def phase_b(db, dry_run: bool) -> dict:
+    """Suspend chimera lemmas and NULL out downstream refs."""
+    print("\n=== Phase B: chimera suspend + downstream NULL ===")
+    counts = {"suspended": 0, "sw_nulled": 0, "stw_nulled": 0,
+              "sentence_target_nulled": 0}
+
+    for lid in CHIMERA_IDS:
+        l = db.get(Lemma, lid)
+        if not l:
+            print(f"  SKIP #{lid}: missing")
+            continue
+        ulk = db.query(UserLemmaKnowledge).filter(
+            UserLemmaKnowledge.lemma_id == lid
+        ).first()
+
+        # Count what we're about to NULL
+        sw_count = db.query(SentenceWord).filter(SentenceWord.lemma_id == lid).count()
+        stw_count = db.query(StoryWord).filter(StoryWord.lemma_id == lid).count()
+        st_count = db.query(Sentence).filter(Sentence.target_lemma_id == lid).count()
+
+        print(f"  #{lid} {l.lemma_ar!r}/{l.lemma_ar_bare!r} gloss={l.gloss_en!r}")
+        print(f"    suspending ULK; NULLing {sw_count} SW + {stw_count} StoryWord "
+              f"+ {st_count} sentence targets")
+
+        if dry_run:
+            continue
+
+        if ulk and ulk.knowledge_state != "suspended":
+            ulk.knowledge_state = "suspended"
+            ulk.experiment_group = None
+            ulk.experiment_intro_shown_at = None
+            counts["suspended"] += 1
+
+        # NULL refs — the comprehensive lookup will retry on next cron pass
+        if sw_count:
+            db.query(SentenceWord).filter(SentenceWord.lemma_id == lid).update(
+                {"lemma_id": None}, synchronize_session=False
+            )
+            counts["sw_nulled"] += sw_count
+        if stw_count:
+            db.query(StoryWord).filter(StoryWord.lemma_id == lid).update(
+                {"lemma_id": None}, synchronize_session=False
+            )
+            counts["stw_nulled"] += stw_count
+        if st_count:
+            db.query(Sentence).filter(Sentence.target_lemma_id == lid).update(
+                {"target_lemma_id": None}, synchronize_session=False
+            )
+            counts["sentence_target_nulled"] += st_count
+
+        # Tag the lemma so it's obvious in future audits
+        existing_note = l.decomposition_note or {}
+        if isinstance(existing_note, str):
+            import json
+            try:
+                existing_note = json.loads(existing_note)
+            except Exception:
+                existing_note = {}
+        existing_note["chimera"] = True
+        existing_note["chimera_reason"] = (
+            f"lemma_ar={l.lemma_ar!r} / bare={l.lemma_ar_bare!r} — root mismatch; "
+            f"suspended 2026-05-15"
+        )
+        l.decomposition_note = existing_note
+
+        db.commit()
+
+    print(f"  Result: {counts}")
+    return counts
+
+
+def phase_c(db, dry_run: bool) -> dict:
+    """Fix #1527 إِلْزامِيّ — corrupted bare 'زامي' should be 'الزامي'.
+
+    CAMeL mis-stripped the integral إل as if it were al- + ل clitic. The
+    correct unvocalized bare is 'الزامي' (matching how الذي/التي/الآن are
+    stored — al- integral, kept in the bare).
+    """
+    print("\n=== Phase C: #1527 إلزامي bare correction ===")
+    counts = {"updated": 0}
+    l = db.get(Lemma, 1527)
+    if not l:
+        print("  SKIP: #1527 missing")
+        return counts
+    print(f"  #1527 lemma_ar={l.lemma_ar!r} current bare={l.lemma_ar_bare!r}")
+    new_bare = "الزامي"
+    if l.lemma_ar_bare == new_bare:
+        print("  Already correct, skipping")
+        return counts
+    print(f"  Setting bare → {new_bare!r}")
+    if not dry_run:
+        l.lemma_ar_bare = new_bare
+        db.commit()
+    counts["updated"] = 1
+    print(f"  Result: {counts}")
+    return counts
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument(
+        "--phase", choices=["A", "B", "C", "all"], default="all",
+        help="Run only one phase (default: all)",
+    )
+    args = parser.parse_args()
+
+    if not CAMEL_AVAILABLE:
+        print("CAMeL Tools not available", file=sys.stderr)
+        sys.exit(1)
+
+    db = SessionLocal()
+    summary = {}
+    try:
+        if args.phase in ("A", "all"):
+            summary["phase_a"] = phase_a(db, args.dry_run)
+        if args.phase in ("B", "all"):
+            summary["phase_b"] = phase_b(db, args.dry_run)
+        if args.phase in ("C", "all"):
+            summary["phase_c"] = phase_c(db, args.dry_run)
+
+        if args.dry_run:
+            print("\nDry run — no DB writes.")
+        else:
+            log_activity(
+                db,
+                event_type="manual_action",
+                summary=(
+                    "OCR lemma corruption cleanup: "
+                    f"phase_a={summary.get('phase_a', {}).get('updated', 0)} updated, "
+                    f"phase_b={summary.get('phase_b', {}).get('suspended', 0)} chimeras suspended, "
+                    f"phase_c={summary.get('phase_c', {}).get('updated', 0)} bare-fixed"
+                ),
+                detail={
+                    "script": "cleanup_ocr_lemma_corruption_2026_05_15",
+                    **summary,
+                    "chimera_ids": CHIMERA_IDS,
+                },
+            )
+            db.commit()
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/split_nzl_homograph_2026_05_15.py
+++ b/backend/scripts/split_nzl_homograph_2026_05_15.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Split the Form I/II/IV merge on canonical #3569 into homograph canonicals.
+
+The Quran inflected-lemma cleanup (2026-05-15) created canonical #3569 with
+lemma_ar="نَزَل" (Form I "to descend") but linked three different verb forms
+to it because they share the unvocalized bare "نزل":
+  - #2828 انزل  → أَنْزَلَ (Form IV "to bring down")  — gloss leaked into #3569
+  - #2878 نزلنا → نَزَّلَ  (Form II "to send down")    — different sense
+  - #3569 itself = Form I
+
+This script creates two homograph canonicals (Form II and Form IV) using the
+ALLOW_HOMOGRAPH precedent (lemma_ar_bare has no DB unique constraint), then
+re-links the variants and cleans Form I's lemma_ar / gloss / forms_json.
+
+Data attached to #3569 from prior merging is NOT moved back — the sentence
+context determines which sense each row represented, and that signal was
+discarded during merge. Future imports of these forms will lemmatize to the
+correct homograph via CAMeL's vocalized lex (matched by lemma_ar / vocalized
+form), not the shared bare.
+
+Usage:
+    python3 scripts/split_nzl_homograph_2026_05_15.py --dry-run
+    python3 scripts/split_nzl_homograph_2026_05_15.py
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+BACKEND_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(BACKEND_ROOT))
+
+from app.database import SessionLocal  # noqa: E402
+from app.models import Lemma, Root, UserLemmaKnowledge  # noqa: E402
+from app.services.activity_log import log_activity  # noqa: E402
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    db = SessionLocal()
+    try:
+        nzl_root = db.query(Root).filter(Root.root == "ن.ز.ل").first()
+        if not nzl_root:
+            print("ERROR: root ن.ز.ل not in DB", file=sys.stderr)
+            sys.exit(1)
+        root_id = nzl_root.root_id
+
+        form1 = db.get(Lemma, 3569)  # current "merged" canonical
+        v2828 = db.get(Lemma, 2828)  # Form IV variant
+        v2878 = db.get(Lemma, 2878)  # Form II variant
+        for tag, l in (("Form I #3569", form1), ("#2828 (Form IV)", v2828),
+                       ("#2878 (Form II)", v2878)):
+            if l is None:
+                print(f"ERROR: lemma for {tag} missing", file=sys.stderr)
+                sys.exit(1)
+            print(f"  {tag}: lemma_ar={l.lemma_ar!r} bare={l.lemma_ar_bare!r} "
+                  f"canonical_id={l.canonical_lemma_id}")
+
+        # Verify pre-condition: both variants currently point at #3569
+        if v2828.canonical_lemma_id != 3569 or v2878.canonical_lemma_id != 3569:
+            print(f"ERROR: expected both variants to point at #3569, got "
+                  f"{v2828.canonical_lemma_id} and {v2878.canonical_lemma_id}",
+                  file=sys.stderr)
+            sys.exit(1)
+
+        # Step 1: Fix Form I canonical (#3569) — clean gloss, clean forms_json
+        # Keep lemma_ar='نَزَل' (Form I citation), update gloss to be unambiguously Form I.
+        new_form1_gloss = "to descend, come down (Form I)"
+        new_form1_lemma_ar = "نَزَلَ"  # add fatha for 3ms perfect
+        clean_forms_json = {
+            "verb_form": "I",
+            "present": "يَنْزِلُ",
+            "past_3fs": "نَزَلَتْ",
+            "past_3p": "نَزَلُوا",
+            "past_1s": "نَزَلْتُ",
+            "past_3fp": "نَزَلْنَ",
+            "present_3fp": "يَنْزِلْنَ",
+            "present_3mp": "يَنْزِلُونَ",
+            "masdar": "نُزُول",
+            "active_participle": "نَازِل",
+            "passive_participle": "مَنْزُول",
+            "imperative": "اِنْزِلْ",
+        }
+        print()
+        print(f"Step 1: clean Form I #{form1.lemma_id}")
+        print(f"  lemma_ar: {form1.lemma_ar!r} -> {new_form1_lemma_ar!r}")
+        print(f"  gloss:    {form1.gloss_en!r} -> {new_form1_gloss!r}")
+        print(f"  forms_json: dropping 'inflected' key (Form IV pollution)")
+        if not args.dry_run:
+            form1.lemma_ar = new_form1_lemma_ar
+            form1.gloss_en = new_form1_gloss
+            form1.forms_json = clean_forms_json
+            db.flush()
+
+        # Step 2: Create Form II homograph canonical
+        print()
+        print("Step 2: create Form II homograph canonical (لNَزَّلَ, bare=نزل)")
+        if args.dry_run:
+            print("  [dry] would CREATE")
+            form2_id = -1
+        else:
+            form2 = Lemma(
+                lemma_ar="نَزَّلَ",
+                lemma_ar_bare="نزل",
+                gloss_en="to send down, reveal (Form II causative)",
+                pos="verb",
+                source="quran",
+                root_id=root_id,
+                word_category=None,
+                forms_json={
+                    "verb_form": "II",
+                    "present": "يُنَزِّلُ",
+                    "past_1p": "نَزَّلْنَا",
+                    "masdar": "تَنْزِيل",
+                    "active_participle": "مُنَزِّل",
+                    "passive_participle": "مُنَزَّل",
+                },
+            )
+            db.add(form2)
+            db.flush()
+            form2_id = form2.lemma_id
+            db.add(UserLemmaKnowledge(
+                lemma_id=form2_id,
+                knowledge_state="encountered",
+                source="quran",
+                total_encounters=0,
+            ))
+            print(f"  created Form II #{form2_id}")
+
+        # Step 3: Create Form IV homograph canonical
+        print()
+        print("Step 3: create Form IV homograph canonical (أَنْزَلَ, bare=نزل)")
+        if args.dry_run:
+            print("  [dry] would CREATE")
+            form4_id = -1
+        else:
+            form4 = Lemma(
+                lemma_ar="أَنْزَلَ",
+                lemma_ar_bare="نزل",
+                gloss_en="to bring down, send down (Form IV)",
+                pos="verb",
+                source="quran",
+                root_id=root_id,
+                word_category=None,
+                forms_json={
+                    "verb_form": "IV",
+                    "present": "يُنْزِلُ",
+                    "past_1s": "أَنْزَلْتُ",
+                    "masdar": "إِنْزَال",
+                    "active_participle": "مُنْزِل",
+                    "passive_participle": "مُنْزَل",
+                },
+            )
+            db.add(form4)
+            db.flush()
+            form4_id = form4.lemma_id
+            db.add(UserLemmaKnowledge(
+                lemma_id=form4_id,
+                knowledge_state="encountered",
+                source="quran",
+                total_encounters=0,
+            ))
+            print(f"  created Form IV #{form4_id}")
+
+        # Step 4: Re-link variants to their proper homographs
+        print()
+        print("Step 4: re-link variants to proper homographs")
+        if not args.dry_run:
+            v2828.canonical_lemma_id = form4_id
+            v2878.canonical_lemma_id = form2_id
+            db.flush()
+        print(f"  #2828 (انزل أَنْزَلَ 'to bring down') → Form IV #{form4_id}")
+        print(f"  #2878 (نزلنا 'we sent down') → Form II #{form2_id}")
+
+        if args.dry_run:
+            db.rollback()
+            print("\nDry run — no DB writes.")
+            return
+
+        db.commit()
+        log_activity(
+            db,
+            event_type="manual_action",
+            summary="Split ن.ز.ل Form I/II/IV merge into homograph canonicals",
+            detail={
+                "script": "split_nzl_homograph_2026_05_15",
+                "form1_id": form1.lemma_id,
+                "form2_id": form2_id,
+                "form4_id": form4_id,
+                "relinked": {"#2828": form4_id, "#2878": form2_id},
+            },
+        )
+        db.commit()
+        print(f"\nDone: Form I=#{form1.lemma_id} Form II=#{form2_id} Form IV=#{form4_id}")
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- OCR textbook-scan path now stores CAMeL's vocalized lex as \`lemma_ar\` when its stripped bare matches \`lemma_ar_bare\` — eliminating al-prefix leak (e.g. \`الْمَاشِي\` → \`ماشِي\`). 114 existing rows fixed; future imports won't reproduce.
- 3 cross-root chimera lemmas (#2307 آنِسَة/نسي/Miss, #3450 فارس/عشب, #3452 اشتد/طعام) suspended and 172 downstream refs NULL'd for cron re-resolution. The #2307 case was the "Anisa/forget" mismapping Stian saw in a story today.
- #1527 إلزامي bare corrected (CAMeL had mis-stripped integral إل).

Bundles three Quran cleanup scripts run earlier today (\`cleanup_inflected_quran_lemmas\`, \`apply_quran_inflected_cleanup_2026_05_15\`, \`split_nzl_homograph_2026_05_15\`).

## Tests
- 26 OCR tests pass.
- Cleanup applied to prod via the one-off scripts; backups at \`/opt/alif-backups/alif_pre_ocr_cleanup_*.db\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)