### PR TITLE
Rare-word warning + per-word suspend

### DIFF
--- a/backend/app/routers/words.py
+++ b/backend/app/routers/words.py
@@ -2,6 +2,7 @@ import json
 import math
 from typing import Optional
 from fastapi import APIRouter, Depends, Query, HTTPException
+from pydantic import BaseModel
 from sqlalchemy import case, func
 from sqlalchemy.orm import Session
 
@@ -17,10 +18,16 @@ from app.models import (
     StoryWord,
     UserLemmaKnowledge,
 )
+from app.services.canonical_resolution import resolve_canonical_lemma_id
 from app.services.fsrs_service import create_new_card
 from app.services.grammar_service import seed_grammar_features
 from app.services.interaction_logger import log_interaction
 from app.services.word_selector import get_root_family
+
+
+class SuspendWordIn(BaseModel):
+    frequency_rank: int | None = None
+    source: str | None = None  # e.g. "rare_word_banner", "settings"
 
 
 def knowledge_score(fsrs_card_json, times_seen: int, times_correct: int) -> int:
@@ -488,36 +495,68 @@ def postpone_word(lemma_id: int, db: Session = Depends(get_db)):
 
 
 @router.post("/{lemma_id}/suspend")
-def suspend_word(lemma_id: int, db: Session = Depends(get_db)):
-    """Suspend a word — stops appearing in reviews."""
+def suspend_word(
+    lemma_id: int,
+    payload: SuspendWordIn | None = None,
+    db: Session = Depends(get_db),
+):
+    """Suspend a word — stops appearing in reviews and cascade-deactivates any
+    active sentences targeting it. Resolves variants to canonical before
+    touching ULK state (per CLAUDE.md: canonical is the unit of scheduling)."""
     lemma = db.query(Lemma).filter(Lemma.lemma_id == lemma_id).first()
     if not lemma:
         raise HTTPException(404, "Word not found")
 
+    canonical_id = resolve_canonical_lemma_id(db, lemma_id)
     existing = (
         db.query(UserLemmaKnowledge)
-        .filter(UserLemmaKnowledge.lemma_id == lemma_id)
+        .filter(UserLemmaKnowledge.lemma_id == canonical_id)
         .first()
     )
 
     if existing:
         previous_state = existing.knowledge_state
-        if previous_state == "suspended":
-            return {"lemma_id": lemma_id, "state": "suspended", "already_suspended": True}
-        existing.knowledge_state = "suspended"
-        db.commit()
+        already_suspended = previous_state == "suspended"
+        if not already_suspended:
+            existing.knowledge_state = "suspended"
     else:
         previous_state = None
-        ulk = UserLemmaKnowledge(
-            lemma_id=lemma_id,
+        already_suspended = False
+        db.add(UserLemmaKnowledge(
+            lemma_id=canonical_id,
             knowledge_state="suspended",
             source="study",
-        )
-        db.add(ulk)
-        db.commit()
+        ))
 
-    log_interaction(event="word_suspended", lemma_id=lemma_id, previous_state=previous_state)
-    return {"lemma_id": lemma_id, "state": "suspended", "previous_state": previous_state}
+    # Cascade-deactivate active sentences. Target either the canonical or the
+    # variant (a sentence imported pre-canonical-redirect can still hold the
+    # variant's id in target_lemma_id).
+    target_ids = {canonical_id, lemma_id}
+    deactivated = (
+        db.query(Sentence)
+        .filter(Sentence.target_lemma_id.in_(target_ids))
+        .filter(Sentence.is_active == True)  # noqa: E712
+        .update({"is_active": False}, synchronize_session=False)
+    )
+    db.commit()
+
+    log_interaction(
+        event="word_suspended",
+        lemma_id=lemma_id,
+        canonical_lemma_id=canonical_id,
+        previous_state=previous_state,
+        sentences_deactivated=deactivated,
+        frequency_rank=(payload.frequency_rank if payload else None),
+        source=(payload.source if payload else None),
+    )
+    return {
+        "lemma_id": lemma_id,
+        "canonical_lemma_id": canonical_id,
+        "state": "suspended",
+        "previous_state": previous_state,
+        "already_suspended": already_suspended,
+        "sentences_deactivated": deactivated,
+    }
 
 
 @router.post("/{lemma_id}/unsuspend")

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -458,6 +458,8 @@ class ReintroCardOut(BaseModel):
     wazn_meaning: str | None = None
     source: str | None = None
     intro_kind: str | None = None
+    frequency_rank: int | None = None
+    frequency_source_count: int | None = None
 
 
 class ReintroResultIn(BaseModel):

--- a/backend/app/services/sentence_selector.py
+++ b/backend/app/services/sentence_selector.py
@@ -20,6 +20,7 @@ from app.services.fsrs_service import parse_json_column
 from app.services.transliteration import transliterate_arabic, transliterate_forms
 
 from app.models import (
+    FrequencyCoreEntry,
     GrammarFeature,
     LearnerSettings,
     Lemma,
@@ -1956,6 +1957,22 @@ def _build_reintro_cards(
         )
 
 
+    # Batch-lookup FrequencyCoreEntry by canonical lemma_id for the rare-word
+    # warning banner. NULL rank = not in the top-3000 frequency curriculum
+    # (FrequencyCoreEntry deliberately excludes function words; cards reach
+    # here only after _drop_function_and_proper_name_lemma_ids upstream).
+    fce_lookup_ids = {
+        (lemma.canonical_lemma_id or lemma.lemma_id) for lemma in lemmas[:limit]
+    }
+    fce_map: dict[int, tuple[int, int]] = {}
+    if fce_lookup_ids:
+        for row in (
+            db.query(FrequencyCoreEntry.lemma_id, FrequencyCoreEntry.core_rank, FrequencyCoreEntry.broad_source_count)
+            .filter(FrequencyCoreEntry.lemma_id.in_(fce_lookup_ids))
+            .all()
+        ):
+            fce_map[row.lemma_id] = (row.core_rank, row.broad_source_count)
+
     cards = []
     for lemma in lemmas[:limit]:
         k = ulk_map.get(lemma.lemma_id)
@@ -1965,6 +1982,9 @@ def _build_reintro_cards(
         family = []
         if root_obj:
             family = get_root_family(db, root_obj.root_id)
+
+        canon_id = lemma.canonical_lemma_id or lemma.lemma_id
+        fce_rank, fce_source_count = fce_map.get(canon_id, (None, None))
 
         card = {
             "lemma_id": lemma.lemma_id,
@@ -1989,6 +2009,8 @@ def _build_reintro_cards(
             "wazn": lemma.wazn,
             "wazn_meaning": lemma.wazn_meaning,
             "source": _display_source(k, lemma),
+            "frequency_rank": fce_rank,
+            "frequency_source_count": fce_source_count,
         }
         if intro_kind:
             card["intro_kind"] = intro_kind

--- a/backend/app/services/sentence_validator.py
+++ b/backend/app/services/sentence_validator.py
@@ -55,7 +55,8 @@ FUNCTION_WORD_GLOSSES: dict[str, str] = {
     # Single-letter clitics
     "ب": "in/by/with", "ل": "for/to", "ك": "like/as", "و": "and", "ف": "so/then",
     # Conjunctions
-    "او": "or", "أو": "or", "ان": "that", "أن": "that", "إن": "indeed",
+    "او": "or", "أو": "or", "ام": "or (disjunctive)", "أم": "or (disjunctive)",
+    "ان": "that", "أن": "that", "إن": "indeed",
     "لكن": "but", "ثم": "then (after delay)", "بل": "rather/nay",
     # Pronouns
     "انا": "I", "أنا": "I", "انت": "you (m)", "أنت": "you (m)",

--- a/backend/tests/test_suspend_and_flags.py
+++ b/backend/tests/test_suspend_and_flags.py
@@ -121,6 +121,138 @@ def test_unsuspend_not_found(client):
     assert resp.status_code == 404
 
 
+# --- Rare-word suspend: cascade-deactivate sentences + canonical resolution ---
+
+def test_suspend_cascade_deactivates_active_sentences(client, db_session):
+    """Suspending a word should deactivate any active sentences targeting it."""
+    lemma = _seed_word(db_session, arabic="نَادِر", bare="نادر", gloss="rare")
+    s1 = _seed_sentence(db_session, lemma, text="هَذَا نَادِرٌ جِدّاً")
+    s2 = _seed_sentence(db_session, lemma, text="كَلِمَةٌ نَادِرَة")
+    s1.is_active = True
+    s2.is_active = True
+    db_session.commit()
+
+    resp = client.post(f"/api/words/{lemma.lemma_id}/suspend")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["sentences_deactivated"] == 2
+    assert data["canonical_lemma_id"] == lemma.lemma_id
+
+    db_session.refresh(s1)
+    db_session.refresh(s2)
+    assert s1.is_active is False
+    assert s2.is_active is False
+
+
+def test_suspend_resolves_canonical(client, db_session):
+    """Suspending a variant should redirect to the canonical's ULK."""
+    canonical = _seed_word(db_session, arabic="قَرَأَ", bare="قرا", gloss="to read")
+    variant = Lemma(
+        lemma_ar="اقرئيه", lemma_ar_bare="اقرئيه", gloss_en="read.imp+pron",
+        source="test", canonical_lemma_id=canonical.lemma_id,
+    )
+    db_session.add(variant)
+    db_session.commit()
+
+    resp = client.post(f"/api/words/{variant.lemma_id}/suspend")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["canonical_lemma_id"] == canonical.lemma_id
+
+    canon_ulk = db_session.query(UserLemmaKnowledge).filter_by(lemma_id=canonical.lemma_id).first()
+    assert canon_ulk.knowledge_state == "suspended"
+
+
+def test_suspend_accepts_frequency_rank_payload(client, db_session):
+    """Endpoint accepts optional payload with frequency_rank — logged but not stored."""
+    lemma = _seed_word(db_session, arabic="فُلْكُلُورِيّ", bare="فلكلوري", gloss="folkloric")
+    resp = client.post(
+        f"/api/words/{lemma.lemma_id}/suspend",
+        json={"frequency_rank": 4735, "source": "rare_word_banner"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["state"] == "suspended"
+
+
+def test_suspend_idempotent_no_extra_cascade(client, db_session):
+    """Re-suspending already-suspended word doesn't re-deactivate sentences."""
+    lemma = _seed_word(db_session, arabic="مَهْجُور", bare="مهجور", gloss="abandoned")
+    s = _seed_sentence(db_session, lemma)
+    s.is_active = True
+    db_session.commit()
+
+    client.post(f"/api/words/{lemma.lemma_id}/suspend")
+    db_session.refresh(s)
+    assert s.is_active is False
+
+    resp = client.post(f"/api/words/{lemma.lemma_id}/suspend")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["already_suspended"] is True
+    assert data["sentences_deactivated"] == 0
+
+
+# --- frequency_rank on intro cards ---
+
+def test_intro_card_includes_frequency_fields(db_session):
+    """_build_reintro_cards should populate frequency_rank from FrequencyCoreEntry."""
+    from app.models import FrequencyCoreEntry
+    from app.services.sentence_selector import _build_reintro_cards
+
+    lemma = _seed_word(db_session, arabic="غَرِيب", bare="غريب", gloss="strange")
+    lemma.gates_completed_at = datetime.now(timezone.utc)
+    db_session.add(FrequencyCoreEntry(
+        core_rank=4500, lemma_id=lemma.lemma_id, lemma_key="غريب",
+        display_form="غَرِيب", broad_source_count=2,
+    ))
+    db_session.commit()
+
+    cards = _build_reintro_cards(db_session, {lemma.lemma_id})
+    assert len(cards) == 1
+    assert cards[0]["frequency_rank"] == 4500
+    assert cards[0]["frequency_source_count"] == 2
+
+
+def test_intro_card_frequency_null_when_not_in_core(db_session):
+    """Lemma with no FrequencyCoreEntry gets frequency_rank=None."""
+    from app.services.sentence_selector import _build_reintro_cards
+
+    lemma = _seed_word(db_session, arabic="مَخْفِيّ", bare="مخفي", gloss="hidden")
+    lemma.gates_completed_at = datetime.now(timezone.utc)
+    db_session.commit()
+
+    cards = _build_reintro_cards(db_session, {lemma.lemma_id})
+    assert len(cards) == 1
+    assert cards[0]["frequency_rank"] is None
+    assert cards[0]["frequency_source_count"] is None
+
+
+def test_intro_card_frequency_uses_canonical(db_session):
+    """For a variant lemma, FCE lookup should follow the canonical pointer."""
+    from app.models import FrequencyCoreEntry
+    from app.services.sentence_selector import _build_reintro_cards
+
+    canon = _seed_word(db_session, arabic="قَلَم", bare="قلم", gloss="pen")
+    canon.gates_completed_at = datetime.now(timezone.utc)
+    db_session.add(FrequencyCoreEntry(
+        core_rank=1200, lemma_id=canon.lemma_id, lemma_key="قلم",
+        display_form="قَلَم", broad_source_count=4,
+    ))
+    variant = Lemma(
+        lemma_ar="بِالقَلَم", lemma_ar_bare="بالقلم", gloss_en="with-the-pen",
+        source="test", canonical_lemma_id=canon.lemma_id,
+        gates_completed_at=datetime.now(timezone.utc),
+    )
+    db_session.add(variant)
+    db_session.commit()
+
+    cards = _build_reintro_cards(db_session, {variant.lemma_id})
+    assert len(cards) == 1
+    assert cards[0]["frequency_rank"] == 1200
+    assert cards[0]["frequency_source_count"] == 4
+
+
 # --- Reactivation Helper Tests ---
 
 def test_reactivate_if_suspended(db_session):

--- a/frontend/app/index.tsx
+++ b/frontend/app/index.tsx
@@ -35,6 +35,7 @@ import {
   getConfusionHelp,
   generateUuid,
   logCardShown,
+  suspendWord,
   BASE_URL,
 } from "../lib/api";
 import {
@@ -1997,6 +1998,15 @@ export function ReviewScreen({ fixedMode }: { fixedMode: ReviewMode }) {
     const knownSiblings = card.root_family.filter(
       (s) => (s.state === "known" || s.state === "learning") && s.lemma_id !== card.lemma_id
     );
+    const freqRank = card.frequency_rank ?? null;
+    const freqSourceCount = card.frequency_source_count ?? null;
+    // Rare-word banner: rank outside top-3000 OR no FCE entry at all OR very
+    // thinly-sourced (≤1 frequency list). Function words don't reach this
+    // render (filtered upstream).
+    const isRareWord =
+      freqRank === null ||
+      freqRank > 3000 ||
+      (freqSourceCount !== null && freqSourceCount <= 1);
     const eiHasMnemonic = !!card.memory_hooks?.mnemonic;
     const eiHasEtymology = !!card.etymology?.derivation;
     const eiHasFunFact = !!card.memory_hooks?.fun_fact;
@@ -2175,6 +2185,56 @@ export function ReviewScreen({ fixedMode }: { fixedMode: ReviewMode }) {
             )}
           </View>
         </ScrollView>
+
+        {isRareWord && (
+          <View
+            style={{
+              marginHorizontal: 16,
+              marginBottom: 8,
+              padding: 12,
+              backgroundColor: "#fff3cd",
+              borderRadius: 10,
+              borderWidth: 1,
+              borderColor: "#ffe69c",
+            }}
+          >
+            <Text style={{ fontSize: 13, fontWeight: "600", color: "#664d03", marginBottom: 4 }}>
+              {freqRank === null
+                ? "Uncommon word — not in the top-3000 frequency core"
+                : freqRank > 3000
+                ? `Uncommon word — frequency rank #${freqRank}`
+                : `Thinly-sourced — rank #${freqRank}, only in ${freqSourceCount ?? 0} frequency list${(freqSourceCount ?? 0) === 1 ? "" : "s"}`}
+            </Text>
+            <Text style={{ fontSize: 12, color: "#856404", marginBottom: 10 }}>
+              You can skip it permanently if it's not worth learning right now.
+            </Text>
+            <Pressable
+              style={{
+                alignSelf: "flex-start",
+                paddingVertical: 8,
+                paddingHorizontal: 14,
+                borderRadius: 8,
+                borderWidth: 1,
+                borderColor: "#856404",
+                backgroundColor: "transparent",
+              }}
+              onPress={() => {
+                const lemmaId = card.lemma_id;
+                shownIntroLemmaIdsRef.current.add(lemmaId);
+                suspendWord(lemmaId, {
+                  frequency_rank: freqRank,
+                  source: "rare_word_banner",
+                }).catch(() => {});
+                introScrollRef.current?.scrollTo({ y: 0, animated: false });
+                advanceAfterSubmit("understood");
+              }}
+            >
+              <Text style={{ color: "#856404", fontWeight: "600", fontSize: 13 }}>
+                Suspend this word
+              </Text>
+            </Pressable>
+          </View>
+        )}
 
         <View style={styles.reintroActions}>
           <Pressable

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1153,8 +1153,22 @@ export async function postponeWord(lemmaId: number): Promise<{ lemma_id: number;
   return fetchApi(`/api/words/${lemmaId}/postpone`, { method: "POST" });
 }
 
-export async function suspendWord(lemmaId: number): Promise<{ lemma_id: number; state: string }> {
-  return fetchApi(`/api/words/${lemmaId}/suspend`, { method: "POST" });
+export async function suspendWord(
+  lemmaId: number,
+  payload?: { frequency_rank?: number | null; source?: string },
+): Promise<{
+  lemma_id: number;
+  canonical_lemma_id?: number;
+  state: string;
+  previous_state?: string | null;
+  already_suspended?: boolean;
+  sentences_deactivated?: number;
+}> {
+  return fetchApi(`/api/words/${lemmaId}/suspend`, {
+    method: "POST",
+    body: payload ? JSON.stringify(payload) : undefined,
+    headers: payload ? { "Content-Type": "application/json" } : undefined,
+  });
 }
 
 export async function unsuspendWord(lemmaId: number): Promise<{ lemma_id: number; state: string }> {

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -434,6 +434,8 @@ export interface ReintroCard {
   wazn_meaning?: string | null;
   source?: string | null;
   intro_kind?: string | null;
+  frequency_rank?: number | null;
+  frequency_source_count?: number | null;
 }
 
 export interface VerseWord {


### PR DESCRIPTION
## Summary

- **Backend**: `ReintroCardOut` exposes `frequency_rank` + `frequency_source_count` (left-join `FrequencyCoreEntry` on canonical lemma_id). `POST /api/words/{id}/suspend` resolves canonical, cascade-deactivates sentences targeting either variant or canonical, accepts an optional `{frequency_rank, source}` payload that lands in the `word_suspended` interaction event.
- **Frontend**: yellow banner appears above the Continue button when an intro card surfaces a word with rank > 3000, no FCE entry at all, or `broad_source_count ≤ 1`. "Suspend this word" button posts to the endpoint with the rank for analytics and optimistically advances the card.

## Why source-count, not just rank

During the audit that motivated this feature, lemma #1379 كَتَم "hair dye plant" — surfaced to the user as a wrong-noun gloss on classical verb sentences — turned out to sit at FCE rank **1449** (well inside the top-3000) but with `broad_source_count=1` (single frequency list). Rank-only logic misses thinly-attested entries like this. The source-count gate catches them.

## Hard invariants respected

- Canonical lemma is the unit of scheduling — endpoint resolves via `resolve_canonical_lemma_id` and sets state on the canonical's ULK.
- SQLite write-lock discipline — endpoint is pure DB, no LLM in the path.
- Function words are filtered upstream from intro cards via `_drop_function_and_proper_name_lemma_ids`, so a card reaching the banner with `frequency_rank=None` is a real rare word, not an FCE-excluded function word.
- `أَم` (disjunctive "or") was added to `FUNCTION_WORDS` in a prior commit on main as preparation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)