### PR TITLE
Enforce 30/day intro cap at start_acquisition chokepoint

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -69,6 +69,9 @@ Prefer focused sessions. If a task has 4+ distinct parts, suggest breaking into 
 ## Target vs Collateral Words Are Equal
 - [Details](feedback_target_collateral_equal.md) — No distinction between target and collateral words for learning, credit, or intro cards. Repeated user feedback.
 
+## System-wide Caps Belong at the Chokepoint
+- [Details](feedback_intro_cap_chokepoint.md) — Daily intro cap lived in one caller for years; five other callers proliferated and bypassed it. Move caps into start_acquisition itself, not the auto-intro caller.
+
 ## Intro Card Overload (fixed 2026-03-30)
 - [Details](feedback_intro_card_overload.md) — Fixed: interleaved among sentences, dynamic cap. Never front-load.
 
@@ -131,6 +134,9 @@ Prefer focused sessions. If a task has 4+ distinct parts, suggest breaking into 
 
 ## Clitic-leftover audit — 95 lemmas, 88 cleaned (done 2026-05-06)
 - [Details](project_clitic_my_leftover_audit.md) — Broadened from 35 "my X" to all proclitics+enclitics. 75 ALREADY_LINKED stale-wiring cleanups, 7 link-to-existing, 6 create-new-canonical (ميثاق, طغيان, تجارة, اتقى, افسد, مجال). Script: `backend/scripts/cleanup_clitic_leftovers.py`.
+
+## iOS EAS Dev Build Gotchas (2026-05-14)
+- [Details](project_ios_dev_build_gotchas.md) — ATS arbitrary-loads required for Hetzner dev server, icon source HTMLs in `frontend/assets/sources/`, CgBI PNGs aren't broken, Apple PLA periodically blocks builds.
 
 ## Architecture Notes (not in CLAUDE.md)
 - FSRS stability floor: "known" with stability < 1.0 -> "lapsed"

--- a/.claude/memory/feedback_intro_cap_chokepoint.md
+++ b/.claude/memory/feedback_intro_cap_chokepoint.md
@@ -1,0 +1,16 @@
+---
+name: feedback-intro-cap-chokepoint
+description: "Put system-wide caps inside the single function every caller goes through, not in one caller. The 30/day intro cap was bypassable for ~3 years because it lived in _auto_introduce_words instead of start_acquisition."
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 2fdc3a88-21a5-478b-b99b-decfa1630333
+---
+
+System-wide caps must live at the chokepoint that every caller goes through, not in a single caller. Otherwise the cap silently rots as new callers proliferate.
+
+**Why:** The 30/day intro cap (`DAILY_AUTO_INTRO_TARGET`) sat inside `_auto_introduce_words()` for the whole life of the algorithm-redesign experiment. Five other callers of `start_acquisition()` accumulated over time (OCR collateral-promotion, sentence-review collateral, Quran promotion, cold session-build promoter, manual `introduce_word`), all bypassing the cap. By 2026-05-15 the user was getting 39 intros/day with 0 going through the capped path — the official gate had become decorative. Fix on `sh/intro-cap-enforcement` moved the cap into `start_acquisition()` itself.
+
+**How to apply:** Whenever you're tempted to add a guard at one specific call site, ask "is there a function every caller goes through?" If yes, put the guard *there*. If no, ask whether one *should* exist. A wrapper function with a free-pass parameter is worse than no chokepoint — easier to forget, easier to bypass with "just this once" callers. See `start_acquisition` in `acquisition_service.py` for the pattern (cap at function entry, fall back to a non-promoted state instead of raising, callers check resulting state).
+
+Related: [[feedback-target-collateral-equal]] (every word in every sentence earns credit — collateral promotions are the SECOND-largest source of cap bypass), [[feedback-check-prior-work-first]] (long-iterated areas like the scheduler usually have N-1 fixes that didn't fully close the loop).

--- a/.claude/memory/project_ios_dev_build_gotchas.md
+++ b/.claude/memory/project_ios_dev_build_gotchas.md
@@ -1,0 +1,44 @@
+---
+name: project-ios-dev-build-gotchas
+description: "Non-obvious gotchas when rebuilding the Alif iOS EAS dev client and connecting it to the Hetzner dev server — ATS exception, icon source HTMLs, CgBI PNGs, Apple PLA blocks."
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: 1e44f379-78ca-46c7-8a87-654b233124b2
+---
+
+The 2026-05-14 rebuild surfaced four issues, three of them silent. Keep these together — they all live on the path "user needs a new dev build for a native module" and all need to be checked in advance.
+
+## 1. iOS ATS blocks plain-HTTP loads to the dev server
+
+**Fact:** The Hetzner Expo dev server at `alifstian.duckdns.org:8081` is plain HTTP. iOS dev clients require `NSAllowsArbitraryLoads: true` in `Info.plist` or the dev client cannot fetch the JS bundle. Symptom: "Failed to connect to http://alifstian.duckdns.org:8081" in the dev launcher. Chrome on the same iPhone *can* reach the URL (Chrome ships its own ATS exception), which is misleading.
+
+**Why:** It's the standard public-internet HTTP block. Expo Go has its own ATS exception built in, so users on Expo Go don't hit this — only custom dev clients.
+
+**How to apply:** `frontend/app.json` → `ios.infoPlist.NSAppTransportSecurity.NSAllowsArbitraryLoads = true` (committed in `6b63ded`). If a future build is missing it and connection fails, that's the first thing to check.
+
+## 2. Icon source HTMLs must be committed, not just generated
+
+**Fact:** Variant H "Framed" (`ألف` in Scheherazade New on `#0f0f1a`, thin rounded inner border) was generated locally on 2026-03-04 via the `icon-generation` skill but the resulting PNGs were never `git add`'d. Every iOS build since the initial commit shipped the gray-with-3-circles Expo placeholder.
+
+**Why:** `git log frontend/assets/icon.png` only shows the initial Feb 8 commit (placeholder) and my 2026-05-14 restoration. The intermediate "working" build referenced the locally-generated file via the user's working tree.
+
+**How to apply:** Source HTMLs are now committed at `frontend/assets/sources/{icon,adaptive-icon}.html` so they can be regenerated identically. If the user reports "icon is missing on home screen", first check whether `frontend/assets/icon.png` is currently a real icon or the placeholder, *before* hypothesising about iOS-side caching or build-pipeline bugs.
+
+## 3. CgBI PNGs in the .ipa look broken to non-Apple tooling
+
+**Fact:** `file /tmp/.../AppIcon60x60@2x.png` reports `PNG image data (CgBI), 120 x 120, 8-bit/color RGBA`. PIL fails to load it with "broken data stream when reading image file". That's not a corruption bug — CgBI is Apple's proprietary BGRA-byteorder PNG variant with non-standard zlib compression, readable by iOS only.
+
+**Why:** Spent meaningful time today thinking the EAS build pipeline was producing corrupt icons and shipped a no-op "fix" before noticing `(CgBI)` in `file` output.
+
+**How to apply:** Don't try to verify iOS app icons with PIL or non-Apple tooling. Use `sips -g pixelWidth ...` or extract via `xcrun assetutil --info Assets.car` instead. If you must look at the icon, render the *source* PNG that went into the build, not the embedded one.
+
+## 4. Apple Program License Agreement (PLA) blocks EAS builds periodically
+
+**Fact:** EAS dev builds fail with `Apple 403 detected - Access forbidden. PLA Update available — You currently don't have access to this membership resource. To resolve this issue, agree to the latest Program License Agreement in your developer account.` This is not an EAS or credential bug — Apple periodically pushes a new agreement that must be accepted at developer.apple.com/account/.
+
+**Why:** Happened 2026-05-14. The first build attempt that session failed with this error; second attempt (after the user accepted the PLA) succeeded.
+
+**How to apply:** If `./scripts/build.sh alif development` fails with "PLA Update available" or "Access forbidden", tell the user to sign in to developer.apple.com/account, accept the banner, and re-run the build. No code/config change required.
+
+See also [[feedback-ats-arbitrary-loads]] and [[feedback-icon-source-control]] if those memories exist; otherwise this file is the primary record.

--- a/IDEAS.md
+++ b/IDEAS.md
@@ -4,6 +4,21 @@
 
 ---
 
+## ✅ [DONE 2026-05-15] Enforce daily intro cap at chokepoint + smooth intro cards per session
+
+Prod prompted by 39 intros today (28 textbook_scan, 9 collateral, 1 book, 1 quran, 0 via the official `_auto_introduce_words` path that was the only one checking the daily cap). User saw sessions with 10-15 intro cards crammed up front because `_build_intro_cards` had an explicit "first-time intro cards are not capped" and `_ensure_session_words_have_intro_state` mass-promoted every encountered word at session-build time.
+
+Fix (branch `sh/intro-cap-enforcement`):
+1. **`start_acquisition()` enforces the daily cap (30/day) for every caller** — single chokepoint. When the cap is hit, new ULKs are created as `encountered` instead of `acquiring`; existing encountered ULKs are left in place. `leech_reintro` bypasses (re-introduction of known words).
+2. **`_ensure_session_words_have_intro_state` per-session cap of 6** — cold promoter no longer mass-promotes; the rest stay encountered until a later session.
+3. **`_build_intro_cards` first-time cards capped at `INTRO_NEW_CARDS_PER_SESSION = 6`** — was uncapped.
+4. **Comprehensibility gate counts `is_fresh_today` acquiring words as unknown** — sentence-with-many-just-promoted-words no longer reads as comprehensible. Fresh = acquired today, `times_correct == 0`; clears as soon as you successfully review the word once.
+5. Callers in `sentence_review_service.py` check `ulk.knowledge_state == "acquiring"` after `start_acquisition` to decide between acquisition-review and a quiet `total_encounters` bump.
+
+Reasoning notes saved in 2026-05-15 entry in `research/experiment-log.md`. Tests added: `test_acquisition.py::test_daily_cap_*` (5 cases).
+
+---
+
 ## 🔵 [OPEN 2026-05-15] Vocalized-aware lemma identity for homographs
 
 Today's Form I/II/IV cleanup on the ن.ز.ل root revealed a structural limitation: `lemma_ar_bare` is the unit of dedup (via `build_lemma_lookup`), but `strip_diacritics` removes shadda — so نَزَلَ (Form I "descend") and نَزَّلَ (Form II "send down") collapse to the same bare key `نزل`. They are dictionary-distinct verbs with different patterns, glosses, and conjugation paradigms, but the lookup can't tell them apart.

--- a/backend/app/services/acquisition_service.py
+++ b/backend/app/services/acquisition_service.py
@@ -66,17 +66,46 @@ def _reviews_span_calendar_days(db: Session, lemma_id: int, min_days: int) -> bo
     return len(dates) >= min_days
 
 
+DAILY_INTRO_CAP = 30  # ceiling on new acquiring promotions per UTC day; see start_acquisition
+
+
+def _daily_intro_count(db: Session, today_start: datetime) -> int:
+    """Count today's acquisitions that count toward the daily cap.
+
+    leech_reintro is excluded — those are re-introductions of words the
+    learner already knew, not net-new vocabulary.
+    """
+    return (
+        db.query(UserLemmaKnowledge)
+        .filter(
+            UserLemmaKnowledge.acquisition_started_at >= today_start,
+            (
+                UserLemmaKnowledge.source.is_(None)
+                | (UserLemmaKnowledge.source != "leech_reintro")
+            ),
+        )
+        .count()
+    )
+
+
 def start_acquisition(
     db: Session,
     lemma_id: int,
     source: str = "study",
     due_immediately: bool = False,
+    enforce_daily_cap: bool = True,
 ) -> UserLemmaKnowledge:
     """Start the acquisition process for a word.
 
     Creates or transitions ULK to acquiring state with box 1.
     If due_immediately=True, word is due right now (for auto-intro in current session).
     Otherwise, first review is due after BOX_INTERVALS[1] (4 hours).
+
+    When enforce_daily_cap is True (default) and the daily cap is hit, the
+    word is left in (or created in) `encountered` state instead of being
+    promoted. Callers must check `ulk.knowledge_state == "acquiring"` if
+    they need to behave differently when promotion was deferred.
+    leech_reintro bypasses the cap (re-introducing a known word).
     """
     from app.services.canonical_resolution import resolve_canonical_lemma_id
 
@@ -101,6 +130,39 @@ def start_acquisition(
     # Don't demote a known/learning canonical back to acquiring just because a
     # variant collateral path landed here. Return the existing row unchanged.
     if ulk and ulk.knowledge_state in ("known", "learning"):
+        return ulk
+
+    # Already acquiring — nothing to do, return as-is (not a new intro).
+    if ulk and ulk.knowledge_state == "acquiring":
+        return ulk
+
+    cap_hit = False
+    if enforce_daily_cap and source != "leech_reintro":
+        today_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
+        if _daily_intro_count(db, today_start) >= DAILY_INTRO_CAP:
+            cap_hit = True
+            logger.info(
+                "Daily intro cap (%d) reached; lemma %s stays in encountered (source=%r)",
+                DAILY_INTRO_CAP, lemma_id, source,
+            )
+
+    if cap_hit:
+        if ulk:
+            # Don't promote — keep whatever state it was in (encountered, or other).
+            return ulk
+        # New unseen word — record it as encountered so it's tracked, but don't
+        # consume an intro slot today. It can be promoted on a future day.
+        ulk = UserLemmaKnowledge(
+            lemma_id=lemma_id,
+            knowledge_state="encountered",
+            source=source,
+            fsrs_card_json=None,
+            times_seen=0,
+            times_correct=0,
+            total_encounters=0,
+        )
+        db.add(ulk)
+        db.flush()
         return ulk
 
     if ulk:

--- a/backend/app/services/sentence_review_service.py
+++ b/backend/app/services/sentence_review_service.py
@@ -226,16 +226,23 @@ def submit_sentence_review(
         # Auto-introduce encountered words on collateral appearance —
         # every word in every sentence earns review credit, no exceptions.
         # Familiar words graduate instantly via Tier 0 (first correct → FSRS).
+        # The daily intro cap inside start_acquisition may defer promotion
+        # (leaves the word encountered); track the "deferred" state so we
+        # bump total_encounters but skip the acquisition-review submission.
+        cap_deferred = False
         if effective_lemma_id in encountered_lemma_ids:
             from app.services.acquisition_service import start_acquisition
-            start_acquisition(
+            promoted_ulk = start_acquisition(
                 db,
                 lemma_id=effective_lemma_id,
                 source="collateral",
                 due_immediately=False,
             )
-            acquiring_lemma_ids.add(effective_lemma_id)
-            encountered_lemma_ids.discard(effective_lemma_id)
+            if promoted_ulk.knowledge_state == "acquiring":
+                acquiring_lemma_ids.add(effective_lemma_id)
+                encountered_lemma_ids.discard(effective_lemma_id)
+            else:
+                cap_deferred = True
         # After redirect, multiple variant lemma_ids may map to the same canonical
         if effective_lemma_id in processed_effective_ids:
             continue
@@ -270,7 +277,8 @@ def submit_sentence_review(
             )
         )
 
-        # Auto-introduce unknown words into acquisition instead of straight to FSRS
+        # Auto-introduce unknown words into acquisition instead of straight to FSRS.
+        # Cap may defer promotion — in that case the new ULK is in 'encountered'.
         if effective_lemma_id not in knowledge_map:
             from app.services.acquisition_service import start_acquisition, submit_acquisition_review as _sar
             new_ulk = start_acquisition(
@@ -280,7 +288,18 @@ def submit_sentence_review(
                 due_immediately=False,
             )
             knowledge_map[effective_lemma_id] = new_ulk
-            acquiring_lemma_ids.add(effective_lemma_id)
+            if new_ulk.knowledge_state == "acquiring":
+                acquiring_lemma_ids.add(effective_lemma_id)
+            else:
+                cap_deferred = True
+
+        if cap_deferred:
+            # No review credit while word sits in encountered. Bump total_encounters
+            # so it's tracked, then move on to the next word.
+            knowledge = knowledge_map.get(effective_lemma_id)
+            if knowledge:
+                knowledge.total_encounters = (knowledge.total_encounters or 0) + 1
+            continue
 
         # Route acquiring words through acquisition service
         if effective_lemma_id in acquiring_lemma_ids:

--- a/backend/app/services/sentence_selector.py
+++ b/backend/app/services/sentence_selector.py
@@ -184,6 +184,10 @@ class WordMeta:
     is_function_word: bool = False
     is_proper_name: bool = False
     knowledge_state: str = "new"
+    # True for acquiring words promoted today with no successful review yet.
+    # The comprehensibility gate counts these as 'unknown' so a session full
+    # of just-promoted words doesn't read as comprehensible.
+    is_fresh_today: bool = False
 
 
 @dataclass
@@ -1227,6 +1231,7 @@ def build_session(
         logger.info(f"Lapsed words due (boosted for re-exposure): {len(lapsed_lemma_ids)}")
 
     # Build candidates
+    today_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
     candidates: list[SentenceCandidate] = []
     for sent in sentences:
         sws = sw_by_sentence.get(sent.id, [])
@@ -1251,10 +1256,18 @@ def build_session(
             ) if effective_id else False
 
             k_state = "new"
+            is_fresh_today = False
             if effective_id:
                 k = knowledge_map.get(effective_id)
                 if k:
                     k_state = k.knowledge_state or "new"
+                    if k_state == "acquiring" and (k.times_correct or 0) == 0:
+                        started = k.acquisition_started_at
+                        if started:
+                            if started.tzinfo is None:
+                                started = started.replace(tzinfo=timezone.utc)
+                            if started >= today_start:
+                                is_fresh_today = True
 
             bare = strip_diacritics(sw.surface_form)
             is_func = _is_function_word(bare)
@@ -1273,6 +1286,7 @@ def build_session(
                 is_function_word=is_func,
                 is_proper_name=is_name,
                 knowledge_state=k_state,
+                is_fresh_today=is_fresh_today,
             )
             word_metas.append(wm)
 
@@ -1297,11 +1311,13 @@ def build_session(
             continue
 
         # Comprehensibility gate: skip sentences where <THRESHOLD of scaffold words are known.
+        # `is_fresh_today` words (promoted today, no successful review yet) count as unknown
+        # so a sentence stuffed with just-promoted words doesn't read as comprehensible.
         scaffold = [w for w in word_metas if not w.is_function_word and not w.is_due and not w.is_proper_name]
         total_scaffold = len(scaffold)
         known_scaffold = sum(
             1 for w in scaffold
-            if w.knowledge_state in ("known", "learning", "lapsed", "acquiring")
+            if w.knowledge_state in ("known", "learning", "lapsed", "acquiring") and not w.is_fresh_today
         )
         if total_scaffold > 0 and known_scaffold / total_scaffold < COMPREHENSIBILITY_THRESHOLD:
             continue
@@ -2026,6 +2042,12 @@ RESCUE_COOLDOWN_DAYS = 7
 
 INTRO_CARDS_BASE = 4
 INTRO_CARDS_MAX = 6
+# Ceiling on first-time intro cards in a single session. Without this, every
+# encountered word promoted to acquiring (via OCR + collateral + cold-promoter)
+# stacks an intro card up front; sessions filled with 10–15 cards before any
+# practice. The 30/day cap inside start_acquisition still controls absolute
+# volume — this just spaces it across roughly 5 sessions.
+INTRO_NEW_CARDS_PER_SESSION = 6
 TEXTBOOK_PRESERVE_INTRO_CAP = 4
 
 
@@ -2161,10 +2183,15 @@ def _build_intro_cards(
         return []
 
     cap = _dynamic_intro_cap(db)
-    # First-time intro cards are not capped: if the session will show a new
-    # word, the card must appear before its first sentence. The dynamic cap only
-    # limits rescue cards so remediation doesn't crowd out practice.
-    new_cards = _build_reintro_cards(db, new_card_ids, limit=len(new_card_ids))
+    # First-time intro cards are capped per session by INTRO_NEW_CARDS_PER_SESSION
+    # so a backlog of newly-acquiring words doesn't front-load 10+ cards. The
+    # daily 30-cap inside start_acquisition controls absolute volume; this cap
+    # smooths it across sessions. Rescue cards still use the dynamic cap below.
+    new_cards = _build_reintro_cards(
+        db,
+        new_card_ids,
+        limit=min(len(new_card_ids), INTRO_NEW_CARDS_PER_SESSION),
+    )
     textbook_cards = _build_reintro_cards(
         db,
         textbook_preserve_ids,
@@ -2316,6 +2343,7 @@ def _find_pregenerated_sentences_for_words(
     knowledge_map = {k.lemma_id: k for k in all_knowledge} if all_knowledge else {}
 
     # Build candidates with comprehensibility gate
+    today_start_fb = now.replace(hour=0, minute=0, second=0, microsecond=0)
     candidates: list[SentenceCandidate] = []
     for sent in sentences:
         sws = sw_by_sentence.get(sent.id, [])
@@ -2334,10 +2362,18 @@ def _find_pregenerated_sentences_for_words(
             )
 
             k_state = "new"
+            is_fresh_today = False
             if sw.lemma_id:
                 k = knowledge_map.get(sw.lemma_id) or knowledge_by_id.get(sw.lemma_id)
                 if k:
                     k_state = k.knowledge_state or "new"
+                    if k_state == "acquiring" and (k.times_correct or 0) == 0:
+                        started = k.acquisition_started_at
+                        if started:
+                            if started.tzinfo is None:
+                                started = started.replace(tzinfo=timezone.utc)
+                            if started >= today_start_fb:
+                                is_fresh_today = True
 
             bare = strip_diacritics(sw.surface_form)
             is_func = _is_function_word(bare)
@@ -2354,6 +2390,7 @@ def _find_pregenerated_sentences_for_words(
                 is_function_word=is_func,
                 is_proper_name=is_name,
                 knowledge_state=k_state,
+                is_fresh_today=is_fresh_today,
             )
             word_metas.append(wm)
 
@@ -2365,12 +2402,12 @@ def _find_pregenerated_sentences_for_words(
         if not due_covered:
             continue
 
-        # Comprehensibility gate (same logic as main gate).
+        # Comprehensibility gate (same logic as main gate; fresh-today acquiring counts as unknown).
         scaffold = [w for w in word_metas if not w.is_function_word and not w.is_due and not w.is_proper_name]
         total_scaffold = len(scaffold)
         known_scaffold = sum(
             1 for w in scaffold
-            if w.knowledge_state in ("known", "learning", "lapsed", "acquiring")
+            if w.knowledge_state in ("known", "learning", "lapsed", "acquiring") and not w.is_fresh_today
         )
         if total_scaffold > 0 and known_scaffold / total_scaffold < COMPREHENSIBILITY_THRESHOLD:
             continue
@@ -2566,8 +2603,15 @@ def _ensure_session_words_have_intro_state(
     if not candidate_ids:
         return False
 
+    # Per-session cap on the cold promoter so we don't mass-promote 10+
+    # encountered words at once. The 30/day cap inside start_acquisition
+    # still hard-limits absolute volume; this just shapes the curve so the
+    # session doesn't front-load 10 intro cards.
+    candidate_ids = candidate_ids[:INTRO_NEW_CARDS_PER_SESSION]
+
     from app.services.acquisition_service import start_acquisition
 
+    any_promoted = False
     for lid in candidate_ids:
         ulk = start_acquisition(
             db,
@@ -2576,7 +2620,9 @@ def _ensure_session_words_have_intro_state(
             due_immediately=False,
         )
         knowledge_by_id[lid] = ulk
-    return True
+        if ulk.knowledge_state == "acquiring":
+            any_promoted = True
+    return any_promoted
 
 
 def _drop_function_and_proper_name_lemma_ids(

--- a/backend/tests/test_acquisition.py
+++ b/backend/tests/test_acquisition.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta, timezone
 from app.models import Lemma, ReviewLog, Root, UserLemmaKnowledge
 from app.services.acquisition_service import (
     BOX_INTERVALS,
+    DAILY_INTRO_CAP,
     FAST_GRAD_INTRO_GAP,
     GRADUATION_MIN_ACCURACY,
     GRADUATION_MIN_CALENDAR_DAYS,
@@ -859,3 +860,100 @@ def test_no_root_boost_without_siblings(db_session):
     fsrs_data = json.loads(ulk.fsrs_card_json) if isinstance(ulk.fsrs_card_json, str) else ulk.fsrs_card_json
     assert fsrs_data["stability"] >= card_good.stability * 0.95
     assert fsrs_data["stability"] <= card_good.stability * 1.05
+
+
+# --- Daily intro cap ---
+
+
+def _fill_daily_cap(db_session, count):
+    """Create `count` ULKs whose acquisition_started_at is today, simulating the daily cap."""
+    today_noon = datetime.now(timezone.utc).replace(hour=12, minute=0, second=0, microsecond=0)
+    for i in range(count):
+        lem = Lemma(
+            lemma_ar=f"كلمة{i}",
+            lemma_ar_bare=f"كلمة{i}",
+            gloss_en=f"word{i}",
+            pos="noun",
+        )
+        db_session.add(lem)
+        db_session.flush()
+        ulk = UserLemmaKnowledge(
+            lemma_id=lem.lemma_id,
+            knowledge_state="acquiring",
+            acquisition_box=1,
+            acquisition_next_due=today_noon + timedelta(hours=4),
+            acquisition_started_at=today_noon,
+            entered_acquiring_at=today_noon,
+            introduced_at=today_noon,
+            source="collateral",
+        )
+        db_session.add(ulk)
+    db_session.flush()
+
+
+def test_daily_cap_blocks_new_acquisition(db_session):
+    """When the daily cap is hit, a new word stays in encountered state."""
+    _fill_daily_cap(db_session, DAILY_INTRO_CAP)
+
+    lemma = _create_lemma(db_session, arabic="جديد", english="new")
+    ulk = start_acquisition(db_session, lemma.lemma_id, source="collateral")
+
+    assert ulk.knowledge_state == "encountered"
+    assert ulk.acquisition_started_at is None
+    assert ulk.acquisition_box is None
+
+
+def test_daily_cap_blocks_encountered_promotion(db_session):
+    """When the daily cap is hit, an existing encountered ULK stays encountered."""
+    _fill_daily_cap(db_session, DAILY_INTRO_CAP)
+
+    lemma = _create_lemma(db_session, arabic="آخر", english="other")
+    enc = UserLemmaKnowledge(
+        lemma_id=lemma.lemma_id,
+        knowledge_state="encountered",
+        source="textbook_scan",
+        total_encounters=3,
+    )
+    db_session.add(enc)
+    db_session.flush()
+
+    ulk = start_acquisition(db_session, lemma.lemma_id, source="collateral")
+
+    assert ulk.knowledge_state == "encountered"
+    assert ulk.acquisition_started_at is None
+
+
+def test_daily_cap_allows_leech_reintro_bypass(db_session):
+    """leech_reintro bypasses the daily cap — re-introducing a known word."""
+    _fill_daily_cap(db_session, DAILY_INTRO_CAP)
+
+    lemma = _create_lemma(db_session, arabic="مكرر", english="repeated")
+    ulk = start_acquisition(
+        db_session, lemma.lemma_id, source="leech_reintro"
+    )
+
+    assert ulk.knowledge_state == "acquiring"
+    assert ulk.acquisition_started_at is not None
+
+
+def test_daily_cap_enforce_off(db_session):
+    """When enforce_daily_cap=False, the cap is ignored (manual user intro)."""
+    _fill_daily_cap(db_session, DAILY_INTRO_CAP)
+
+    lemma = _create_lemma(db_session, arabic="يدوي", english="manual")
+    ulk = start_acquisition(
+        db_session, lemma.lemma_id, source="study", enforce_daily_cap=False
+    )
+
+    assert ulk.knowledge_state == "acquiring"
+
+
+def test_daily_cap_allows_under_limit(db_session):
+    """When today's count is below the cap, new acquisitions proceed normally."""
+    _fill_daily_cap(db_session, DAILY_INTRO_CAP - 5)
+
+    lemma = _create_lemma(db_session, arabic="ضمن", english="within")
+    ulk = start_acquisition(db_session, lemma.lemma_id, source="collateral")
+
+    assert ulk.knowledge_state == "acquiring"
+    assert ulk.acquisition_started_at is not None

--- a/docs/scheduling-system.md
+++ b/docs/scheduling-system.md
@@ -169,7 +169,7 @@ learn, and each enters acquisition immediately.
 
 **Gating conditions**:
 - **Reserved slots**: `INTRO_RESERVE_FRACTION` (30%) of session slots reserved for introductions, even when due queue exceeds limit. With limit=10, up to 3 slots are available.
-- **Daily intro target**: Reserved auto-intro stops once `DAILY_AUTO_INTRO_TARGET` (30) words have entered acquisition that day.
+- **Daily intro cap (2026-05-15)**: All paths that call `start_acquisition()` are now gated by `DAILY_INTRO_CAP = 30` enforced inside the function itself. When today's count of new acquisitions (excluding `leech_reintro`) hits 30, further calls create or leave the ULK in `encountered` state instead of promoting to acquiring. This includes OCR/textbook_scan, sentence-review collateral promotion, Quran promotion, the cold session-build promoter, and the auto-intro path. The previous `DAILY_AUTO_INTRO_TARGET` constant in `sentence_selector.py` is now redundant but kept for accuracy throttle calculations.
 - **Pipeline backlog gate**: Reserved intro slots suppressed when acquiring pipeline exceeds a dynamic threshold keyed on recent word-level ReviewLog accuracy (last 2 days, min 10 reviews). Current values in `sentence_selector.py`: `PIPELINE_BACKLOG_THRESHOLD = 80` (accuracy < 80%), `MID_ACCURACY_INTRO_BACKLOG_CAP = 120` (80–90%), `HIGH_ACCURACY_INTRO_BACKLOG_CAP = 200` (≥ 90%). The 40/60/120 earlier values were tightened upward during the aggressive intro trial. Undersized-session fill still works (when due < limit). Resumes automatically when pipeline drains below threshold.
 - **Low-tier intro gate**: When box-1 acquiring count exceeds `LOW_TIER_BLOCK_BACKLOG` (60), candidates whose source is in `LOW_TIER_INTRO_SOURCES` (`wiktionary`, `story_import`, `manual`, `flag_autocreate`, unsourced) are filtered out of the auto-intro candidate list, even during undersized-session fill. Active book/story words and high-tier sources (`textbook_scan`, `duolingo`, `avp_a1`) are unaffected. Forces the learner to clear actively-encountered backlog before introducing words from passive frequency lists.
 - Recent accuracy ≥ `AUTO_INTRO_ACCURACY_FLOOR` (70%) over last 10+ reviews
@@ -1638,7 +1638,9 @@ remaining cards on the next card advance. See Section 8 "Sentence Pre-Warming" f
 | `MIN_ACQUISITION_EXPOSURES` | 4 | Legacy alias for `BOX1_MIN_EXPOSURES` (kept for out-of-tree callers) |
 | `MAX_ACQUISITION_EXTRA_SLOTS` | 15 | Max extra cards for acquisition repetition |
 | `MAX_AUTO_INTRO_PER_SESSION` | 5 | Per-call cap on auto-intro words |
-| `DAILY_AUTO_INTRO_TARGET` | 30 | Daily cap for automatic new-word introductions during the aggressive trial |
+| `DAILY_AUTO_INTRO_TARGET` | 30 | Daily cap for automatic new-word introductions (used by `_auto_introduce_words` accuracy throttling) |
+| `DAILY_INTRO_CAP` | 30 | Hard ceiling enforced inside `start_acquisition()` for *every* path (OCR, collateral, Quran, book, cold-promoter, auto-intro). `leech_reintro` bypasses (2026-05-15) |
+| `INTRO_NEW_CARDS_PER_SESSION` | 6 | Per-session cap on first-time intro cards in `_build_intro_cards` and on cold-promoter promotions in `_ensure_session_words_have_intro_state` (2026-05-15) |
 | `HIGH_ACCURACY_INTRO_BACKLOG_CAP` | 120 | Acquiring-pipeline cap used at ≥90% recent accuracy during the 30/day trial |
 | `INTRO_RESERVE_FRACTION` | 0.3 | Fraction of session slots reserved for new words during the aggressive trial |
 | `AUTO_INTRO_ACCURACY_FLOOR` | 0.70 | Pause auto-intro if accuracy below this |
@@ -1665,6 +1667,7 @@ remaining cards on the next card advance. See Section 8 "Sentence Pre-Warming" f
 | Unknown scaffold cap | 2 | Hard cap on unknown non-target words per sentence |
 | Acquiring box-1 excluded | stability < 0.5 | Box-1 words don't count as "known" scaffold |
 | Encountered excluded | — | Merely seen words don't count as "known" scaffold |
+| Fresh-today excluded (2026-05-15) | acquired today, times_correct == 0 | Acquiring words promoted today with no successful review yet count as unknown for the comprehensibility gate. Clears after first correct review. Prevents sentences stuffed with just-promoted words from reading as comprehensible. |
 
 ### Frontend Session Staleness (`app/index.tsx`, `lib/offline-store.ts`)
 

--- a/research/experiment-log.md
+++ b/research/experiment-log.md
@@ -4,6 +4,52 @@ Running lab notebook for Alif's learning algorithm. Each entry documents what ch
 
 ---
 
+## 2026-05-15: Enforce daily intro cap at chokepoint + smooth cards per session
+
+### What
+
+The 30/day intro cap (`DAILY_AUTO_INTRO_TARGET`) was only consulted by `_auto_introduce_words()` — the one official path. Every other path that called `start_acquisition()` bypassed it. Diagnostic on prod found 39 acquisitions started today: 28 from OCR/textbook_scan, 9 from sentence-review collateral, 1 from book, 1 from Quran, **0 from the capped path**. Sessions were stacking 10–15 intro cards because `_build_intro_cards` had `limit=len(new_card_ids)` (uncapped) and `_ensure_session_words_have_intro_state` mass-promoted every encountered word appearing in the upcoming session.
+
+Branch `sh/intro-cap-enforcement`:
+
+1. **`start_acquisition()` is now the chokepoint.** New constant `DAILY_INTRO_CAP = 30`; helper `_daily_intro_count()`. When the cap is hit, new ULKs are created in `encountered` state (so the lemma is tracked) instead of `acquiring`; existing encountered ULKs are left in place. `leech_reintro` bypasses the cap (re-introducing a known word doesn't count as net-new vocabulary). New parameter `enforce_daily_cap=True` lets manual user-initiated paths override if we need that later.
+2. **`_ensure_session_words_have_intro_state` is capped at `INTRO_NEW_CARDS_PER_SESSION = 6` per session-build.** Cold promoter no longer mass-promotes; the rest stay encountered for a future session.
+3. **`_build_intro_cards` first-time cards capped at 6.** Was previously `limit=len(new_card_ids)` with an explicit "first-time intro cards are not capped" comment.
+4. **Comprehensibility gate treats `is_fresh_today` as unknown.** A new `WordMeta.is_fresh_today` flag is `True` when `knowledge_state == "acquiring"` AND `times_correct == 0` AND `acquisition_started_at >= today_start (UTC)`. Both gate copies (`build_session` and `_find_pregenerated_sentences_for_words`) exclude these from the "known" scaffold count. The flag self-clears the moment the user successfully reviews the word once.
+5. **`sentence_review_service` handles the deferred promotion case.** When `start_acquisition` returns a ULK still in `encountered` state (cap hit), the review loop now skips the acquisition-review submission but still bumps `total_encounters`. The same `cap_deferred` flag covers both the encountered→acquiring path and the unknown→acquiring path.
+
+### Why
+
+User report (verbatim): "It has already introduced 39 new words today, and it seems to be continuing to introduce new words. By new words, I include words that are from OCR scans. They should also be limited to 30 per day. In many sessions, I got 10, 15 intro cards, and then a few sentences that had many different words that were new... I do want to learn many words per day, but we need to space it out more and have more example sentences with many words that I already know to some extent."
+
+Four product decisions, confirmed via questions before implementing:
+- Cap OCR words **at session-entry time**, not scan time — so a whole textbook page can be scanned and drained over multiple days.
+- Put the cap **inside `start_acquisition()`** as a single chokepoint, not a wrapper — harder for a future bypass to happen by accident.
+- Hard cap intro cards at **6 per session** (user pushed back on the 3-card draft: "i'd need 10 sessions to hit 30 cards per week? maybe 6?").
+- Count freshly-promoted words as unknown for the comprehensibility gate.
+
+### Expected behaviour
+
+- Daily count of net-new acquisitions never exceeds 30, regardless of OCR scans / sentence reviews / book imports.
+- Per session: at most 6 first-time intro cards. Cards for words promoted earlier today but not yet shown can appear in subsequent sessions.
+- Sentence selection: the user no longer sees sentences with 3+ words promoted-today-but-not-yet-reviewed; gate counts those as unknown so the `MAX_UNKNOWN_SCAFFOLD=2` ceiling does its job.
+- Encountered words sitting at cap (textbook-scan backlog) drain at ≤30/day over multiple days.
+
+### Risks / things to watch
+
+- **First-time cards capped at 6 but acquiring words from earlier-today can still appear in sentences without a card.** They count as `is_fresh_today` → unknown → gate limits them to ≤2 per sentence. The user may still see 1–2 unknown words per sentence without an intro card; that's the +1 learning principle.
+- **Per-session cold-promoter cap order is non-deterministic** (Python set iteration). Future polish: sort by `total_encounters DESC` so the most-seen encountered words promote first.
+- **`source != "leech_reintro"` bypass uses string equality.** If a future caller passes the wrong source, it'll count (correct fail-closed default).
+- **Activity logging not changed.** Could emit an `intro_cap_hit` event when `start_acquisition` defers a promotion.
+
+### Verify
+
+- `pytest backend/tests/test_acquisition.py -k daily_cap` — 5 new cases: blocks new acquisition, blocks encountered promotion, allows leech_reintro bypass, `enforce_daily_cap=False` override, under-limit allows.
+- Full suite: `pytest backend/` — prior tests still pass.
+- Live: after deploy, trigger OCR + a few reviews; query `SELECT source, COUNT(*) FROM user_lemma_knowledge WHERE acquisition_started_at >= date('now') GROUP BY source` — total ≤ 30. Sessions should not begin with >6 intro cards.
+
+---
+
 ## 2026-05-15: Rare-word warning + per-word suspend (PR #79)
 
 ### What


### PR DESCRIPTION
## Summary
- `start_acquisition()` is now the single chokepoint for the 30/day intro cap (`DAILY_INTRO_CAP=30`). Five other callers (OCR collateral, sentence-review collateral, Quran, cold session-build promoter, manual `introduce_word`) were bypassing the cap — today prod hit 39 acquisitions with 0 via the official capped path.
- Per-session cap on first-time intro cards: `INTRO_NEW_CARDS_PER_SESSION=6` applied to `_build_intro_cards` (was uncapped) and to `_ensure_session_words_have_intro_state` (was mass-promoting every encountered word in the session).
- New `WordMeta.is_fresh_today` flag (acquired today, `times_correct==0`) counts as unknown in the comprehensibility gate so sentences stuffed with just-promoted words don't read as comprehensible. Self-clears on first successful review.
- `sentence_review_service` handles deferred promotion via a `cap_deferred` flag: bumps `total_encounters` and skips the acquisition-review submission when cap is hit.
- 5 new tests in `test_acquisition.py::test_daily_cap_*`; 224 prior scheduling tests still pass.

## Why
User report: "39 new words today and continuing to introduce... in many sessions I got 10, 15 intro cards, and then a few sentences that had many different words that were new. I want to learn many words per day, but space it out more and have more example sentences with many words that I already know to some extent."

Diagnostic: of today's 39 intros, 28 came from textbook_scan + collateral promotion, 9 from sentence-review collateral, 1 from book, 1 from Quran, **0 from the path the cap was guarding**. Cap was decorative.

## Risks
- First-time intro cards now capped at 6/session but acquiring words from earlier-today can still appear in sentences without a card — they count as `is_fresh_today` → unknown → `MAX_UNKNOWN_SCAFFOLD=2` limits to ≤2 per sentence.
- Cold-promoter cap order is non-deterministic (set iteration); fine in steady state but could be polished to sort by `total_encounters DESC`.
- `leech_reintro` source-string bypass mirrors the existing `_introduced_today_count` filter.

See `research/experiment-log.md` 2026-05-15 entry for full design notes.