### PR TITLE
Polyglot: harvest Sentence rows from textbook pages

### DIFF
--- a/polyglot/app/database.py
+++ b/polyglot/app/database.py
@@ -46,12 +46,16 @@ _ADDITIVE_COLUMN_DELTAS: list[tuple[str, str, str]] = [
     # (table, column, sqlite_type)
     ("review_log", "client_review_id", "VARCHAR(50)"),
     ("review_log", "comprehension_signal", "VARCHAR(20)"),
+    ("sentences", "page_id", "INTEGER REFERENCES pages(id)"),
+    ("sentences", "sentence_index_in_page", "INTEGER"),
 ]
 
 # Indexes that should exist once the columns above are present.
 _ADDITIVE_INDEX_DELTAS: list[tuple[str, str, str, bool]] = [
     # (index_name, table, column, unique)
     ("ix_review_log_client_review_id", "review_log", "client_review_id", True),
+    ("ix_sentences_page_id", "sentences", "page_id", False),
+    ("uq_sentences_page_sidx", "sentences", "page_id, sentence_index_in_page", True),
 ]
 
 

--- a/polyglot/app/models.py
+++ b/polyglot/app/models.py
@@ -136,9 +136,14 @@ class Sentence(Base):
     text = Column(Text, nullable=False)
     translation_en = Column(Text)
     transliteration = Column(Text, nullable=True)
-    source = Column(String(20))                        # llm/manual/import/story
+    source = Column(String(20))                        # llm/manual/import/story/textbook
     story_id = Column(Integer, ForeignKey("stories.id"), nullable=True, index=True)
     target_lemma_id = Column(Integer, ForeignKey("lemmas.lemma_id"), nullable=True, index=True)
+
+    # For sentences harvested from textbook pages: provenance + idempotency key.
+    # NULL for LLM-generated or pasted sentences.
+    page_id = Column(Integer, ForeignKey("pages.id"), nullable=True, index=True)
+    sentence_index_in_page = Column(Integer, nullable=True)
 
     difficulty_score = Column(Float, nullable=True)
     audio_url = Column(Text, nullable=True)
@@ -150,7 +155,12 @@ class Sentence(Base):
     created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
 
     story = relationship("Story", foreign_keys=[story_id])
+    page = relationship("Page", foreign_keys=[page_id])
     words = relationship("SentenceWord", back_populates="sentence", cascade="all, delete-orphan")
+
+    __table_args__ = (
+        UniqueConstraint("page_id", "sentence_index_in_page", name="uq_sentences_page_sidx"),
+    )
 
 
 class SentenceWord(Base):

--- a/polyglot/app/routers/texts.py
+++ b/polyglot/app/routers/texts.py
@@ -111,6 +111,22 @@ def mark_remaining_known(story_id: int, page_number: int, db: Session = Depends(
     return {"page_number": page_number, "newly_known": count}
 
 
+@router.post("/{story_id}/extract-sentences")
+def extract_sentences(story_id: int, force: bool = False, db: Session = Depends(get_db)):
+    """Harvest reviewable Sentence rows from every verified page in a story.
+
+    Normally runs implicitly as part of page-view processing. Use this endpoint
+    to backfill sentences for pages that were imported before the harvest service
+    existed, or to re-harvest after a quality-gate sweep (`force=True` deletes
+    and rebuilds).
+    """
+    if not db.query(Story).filter(Story.id == story_id).first():
+        raise HTTPException(status_code=404, detail="Story not found")
+    from app.services.sentence_harvest import harvest_story_sentences
+    created = harvest_story_sentences(db, story_id, force=force)
+    return {"story_id": story_id, "sentences_created": created}
+
+
 # ─── helpers ───────────────────────────────────────────────────────────────
 
 def _check_language(db: Session, code: str):

--- a/polyglot/app/services/reading_intake.py
+++ b/polyglot/app/services/reading_intake.py
@@ -212,6 +212,17 @@ def process_page(db: Session, page: Page, *, force: bool = False) -> Page:
         except Exception as e:
             log.warning("Quality gate failed for page %d: %s", page.id, e)
 
+    # Harvest reviewable Sentence rows from PageWord. Only fires when the
+    # quality gate stamped `mappings_verified_at`; the harvest itself short-
+    # circuits otherwise. Cheap (DB-only) so safe to inline in the page-view
+    # critical path.
+    if page.mappings_verified_at is not None:
+        try:
+            from app.services.sentence_harvest import harvest_page_sentences
+            harvest_page_sentences(db, page)
+        except Exception as e:
+            log.warning("Sentence harvest failed for page %d: %s", page.id, e)
+
     return page
 
 

--- a/polyglot/app/services/sentence_harvest.py
+++ b/polyglot/app/services/sentence_harvest.py
@@ -1,0 +1,195 @@
+"""Harvest reviewable sentences from textbook pages.
+
+The Sentence/SentenceWord tables sit ready to feed the sentence-review pipeline,
+but reading-intake only populates Page + PageWord — sentences had no source until
+this service. This is the cheap path: leverage authentic imported text plus the
+already-verified PageWord → Lemma mappings, instead of asking an LLM to generate
+sentences for words the user encountered in real reading.
+
+Hard invariants honoured:
+
+- **Reviewability gate**: a page must have `mappings_verified_at` set (i.e. the
+  quality gate passed) before its sentences become reviewable. We stamp the
+  harvested Sentence's `mappings_verified_at` from the Page's, so a sentence
+  with unverified words is never produced.
+- **Canonical scheduling**: every SentenceWord stores the canonical lemma_id,
+  not the variant. The resolver redirect happens at SentenceWord creation so
+  the review-credit pipeline sees only canonicals (mirrors Hard Invariant #9
+  applied at storage rather than read time — cheap because pages are small).
+- **Heading exclusion**: caps-heading sentences detected by the quality gate
+  carry no vocabulary value and should not surface as review material. We
+  reuse `_detect_heading_sentence_indices` from `lemma_quality`.
+- **Idempotency**: re-running for the same page is a no-op. The
+  `(page_id, sentence_index_in_page)` unique constraint enforces it at the DB
+  level; the service short-circuits earlier via a count check to avoid the
+  IntegrityError path entirely.
+
+When sentences are LLM-generated later (PR #4 — material_generator port),
+their `page_id` will be NULL — the unique constraint still works because
+SQLite treats NULL as distinct in unique indexes.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+
+from sqlalchemy.orm import Session
+
+from app.models import Lemma, Page, PageWord, Sentence, SentenceWord
+from app.services.canonical_resolution import resolve_canonical_via_map
+from app.services.lemma_quality import _detect_heading_sentence_indices
+
+log = logging.getLogger(__name__)
+
+
+def _reconstruct_sentence_text(words: list[PageWord]) -> str:
+    """Join surface forms in position order. Punctuation tokens attach to the
+    preceding word without a leading space; other tokens get a separating
+    space. Greek punctuation set covers `. , ; ! ? · " — ( ) [ ] : -`. The
+    output is good for display and for the eventual translation LLM call;
+    perfect whitespace fidelity to the source PDF is not a goal.
+    """
+    if not words:
+        return ""
+    sorted_words = sorted(words, key=lambda w: w.position)
+    parts: list[str] = [sorted_words[0].surface_form]
+    for w in sorted_words[1:]:
+        s = w.surface_form
+        is_punct = bool(s) and not any(c.isalpha() or c.isdigit() for c in s)
+        if is_punct:
+            parts.append(s)
+        else:
+            parts.append(" " + s)
+    return "".join(parts).strip()
+
+
+def _canonical_map_for(db: Session, lemma_ids: set[int]) -> dict[int, int | None]:
+    """Pre-load canonical_lemma_id for a set of lemma_ids. Used so the harvest
+    loop resolves canonical without N queries per page."""
+    if not lemma_ids:
+        return {}
+    rows = (
+        db.query(Lemma.lemma_id, Lemma.canonical_lemma_id)
+        .filter(Lemma.lemma_id.in_(lemma_ids))
+        .all()
+    )
+    return {lid: canonical for lid, canonical in rows}
+
+
+def harvest_page_sentences(db: Session, page: Page, *, force: bool = False) -> int:
+    """Create Sentence + SentenceWord rows from a page's PageWord rows.
+
+    Returns the number of Sentence rows created (0 if already harvested or
+    page not verified). Idempotent unless `force=True`, in which case existing
+    rows for the page are deleted first and the harvest replayed.
+
+    Pre-conditions:
+        - Page must have `mappings_verified_at` set (quality gate passed).
+          Without verification, sentence-word lemma assignments may be wrong
+          and the sentence would violate the reviewability gate. Returns 0
+          and logs at INFO if missing.
+
+    The function holds no LLM/network calls — pure DB compute. Per CLAUDE.md
+    Rule #10 (SQLite write lock discipline), no slow work happens between
+    read and commit.
+    """
+    if page.mappings_verified_at is None:
+        log.info(
+            "harvest_page_sentences skipping page %d (mappings_verified_at is NULL)",
+            page.id,
+        )
+        return 0
+
+    if force:
+        db.query(Sentence).filter(Sentence.page_id == page.id).delete()
+        db.commit()
+    else:
+        existing = (
+            db.query(Sentence).filter(Sentence.page_id == page.id).count()
+        )
+        if existing > 0:
+            return 0
+
+    page_words = (
+        db.query(PageWord)
+        .filter(PageWord.page_id == page.id)
+        .order_by(PageWord.position)
+        .all()
+    )
+    if not page_words:
+        return 0
+
+    heading_indices = _detect_heading_sentence_indices(page_words)
+
+    by_idx: dict[int, list[PageWord]] = {}
+    for w in page_words:
+        by_idx.setdefault(w.sentence_index, []).append(w)
+
+    lemma_ids = {w.lemma_id for w in page_words if w.lemma_id is not None}
+    canonical_map = _canonical_map_for(db, lemma_ids)
+
+    now = datetime.now(timezone.utc)
+    language_code = page.story.language_code
+    created = 0
+
+    for s_idx in sorted(by_idx):
+        if s_idx in heading_indices:
+            continue
+        words = by_idx[s_idx]
+        # Sentences with no content lemmas are pure-punctuation artefacts from
+        # the tokenizer (e.g. a line break treated as its own sentence).
+        if not any(w.lemma_id is not None for w in words):
+            continue
+
+        text = _reconstruct_sentence_text(words)
+        if not text:
+            continue
+
+        sentence = Sentence(
+            language_code=language_code,
+            text=text,
+            source="textbook",
+            story_id=page.story_id,
+            page_id=page.id,
+            sentence_index_in_page=s_idx,
+            is_active=True,
+            mappings_verified_at=page.mappings_verified_at,
+        )
+        db.add(sentence)
+        db.flush()
+
+        for w in sorted(words, key=lambda x: x.position):
+            lemma_id = w.lemma_id
+            if lemma_id is not None:
+                lemma_id = resolve_canonical_via_map(lemma_id, canonical_map)
+            db.add(SentenceWord(
+                sentence_id=sentence.id,
+                position=w.position,
+                surface_form=w.surface_form,
+                lemma_id=lemma_id,
+                is_target_word=False,
+            ))
+        created += 1
+
+    db.commit()
+    log.info(
+        "Harvested %d sentences from page %d (story %d)",
+        created, page.id, page.story_id,
+    )
+    return created
+
+
+def harvest_story_sentences(db: Session, story_id: int, *, force: bool = False) -> int:
+    """Harvest sentences from every verified page in a story. Returns the
+    total count of new Sentence rows across the story."""
+    pages = (
+        db.query(Page)
+        .filter(Page.story_id == story_id)
+        .filter(Page.mappings_verified_at.isnot(None))
+        .order_by(Page.page_number)
+        .all()
+    )
+    total = 0
+    for page in pages:
+        total += harvest_page_sentences(db, page, force=force)
+    return total

--- a/polyglot/tests/test_sentence_harvest.py
+++ b/polyglot/tests/test_sentence_harvest.py
@@ -1,0 +1,246 @@
+"""Sentence-harvest tests.
+
+The harvest service is pure DB compute — no LLM, no network — so these can run
+in the fast test tier. We construct Page + PageWord rows directly to avoid
+depending on the NLP provider stack.
+"""
+from datetime import datetime, timezone
+
+from app.models import (
+    Lemma, Story, Page, PageWord, Sentence, SentenceWord, UserLemmaKnowledge,
+)
+from app.services.sentence_harvest import (
+    harvest_page_sentences,
+    harvest_story_sentences,
+    _reconstruct_sentence_text,
+)
+
+
+def _seed_story(db, body="Είμαι εδώ. Φιλοσοφία είναι ωραία."):
+    story = Story(language_code="el", title="t", source="paste", body_src=body, page_count=1)
+    db.add(story)
+    db.flush()
+    page = Page(
+        story_id=story.id, page_number=1, body_src=body,
+        processed_at=datetime.now(timezone.utc),
+        mappings_verified_at=datetime.now(timezone.utc),
+    )
+    db.add(page)
+    db.flush()
+    return story, page
+
+
+def _add_lemma(db, form, bare, **kw):
+    l = Lemma(language_code="el", lemma_form=form, lemma_bare=bare, source="test", **kw)
+    db.add(l)
+    db.flush()
+    return l
+
+
+def _add_word(db, page, position, surface, sentence_index, lemma=None):
+    pw = PageWord(
+        page_id=page.id,
+        position=position,
+        surface_form=surface,
+        sentence_index=sentence_index,
+        lemma_id=lemma.lemma_id if lemma else None,
+    )
+    db.add(pw)
+    return pw
+
+
+def test_reconstruct_text_attaches_punctuation_to_preceding_word(tmp_db):
+    with tmp_db() as db:
+        # Build PageWord rows without committing — pure list ordering test
+        story, page = _seed_story(db)
+        words = [
+            _add_word(db, page, 0, "Καλημέρα", 0),
+            _add_word(db, page, 1, ",", 0),
+            _add_word(db, page, 2, "κόσμε", 0),
+            _add_word(db, page, 3, "!", 0),
+        ]
+        text = _reconstruct_sentence_text(words)
+        assert text == "Καλημέρα, κόσμε!"
+
+
+def test_harvest_skips_page_without_verified_mappings(tmp_db):
+    with tmp_db() as db:
+        story, page = _seed_story(db)
+        page.mappings_verified_at = None
+        db.commit()
+        lemma = _add_lemma(db, "βιβλίο", "βιβλιο")
+        _add_word(db, page, 0, "Βιβλίο", 0, lemma)
+        db.commit()
+
+        created = harvest_page_sentences(db, page)
+
+        assert created == 0
+        assert db.query(Sentence).count() == 0
+
+
+def test_harvest_creates_one_sentence_per_sentence_index(tmp_db):
+    with tmp_db() as db:
+        story, page = _seed_story(db)
+        l_be = _add_lemma(db, "είμαι", "ειμαι")
+        l_here = _add_lemma(db, "εδώ", "εδω")
+        l_phil = _add_lemma(db, "φιλοσοφία", "φιλοσοφια")
+        l_is = _add_lemma(db, "είναι", "ειναι")
+        l_nice = _add_lemma(db, "ωραίος", "ωραιος")
+
+        _add_word(db, page, 0, "Είμαι", 0, l_be)
+        _add_word(db, page, 1, "εδώ", 0, l_here)
+        _add_word(db, page, 2, ".", 0)
+        _add_word(db, page, 3, "Φιλοσοφία", 1, l_phil)
+        _add_word(db, page, 4, "είναι", 1, l_is)
+        _add_word(db, page, 5, "ωραία", 1, l_nice)
+        _add_word(db, page, 6, ".", 1)
+        db.commit()
+
+        created = harvest_page_sentences(db, page)
+
+        assert created == 2
+        sentences = db.query(Sentence).filter(Sentence.page_id == page.id).order_by(
+            Sentence.sentence_index_in_page
+        ).all()
+        assert [s.sentence_index_in_page for s in sentences] == [0, 1]
+        assert sentences[0].text == "Είμαι εδώ."
+        assert sentences[1].text == "Φιλοσοφία είναι ωραία."
+        assert sentences[0].source == "textbook"
+        assert sentences[0].mappings_verified_at == page.mappings_verified_at
+
+        # SentenceWord rows mirror the PageWord rows
+        sw0 = db.query(SentenceWord).filter(SentenceWord.sentence_id == sentences[0].id).all()
+        assert len(sw0) == 3  # Είμαι, εδώ, .
+
+
+def test_harvest_is_idempotent(tmp_db):
+    with tmp_db() as db:
+        story, page = _seed_story(db)
+        lemma = _add_lemma(db, "βιβλίο", "βιβλιο")
+        _add_word(db, page, 0, "Βιβλίο", 0, lemma)
+        _add_word(db, page, 1, ".", 0)
+        db.commit()
+
+        first = harvest_page_sentences(db, page)
+        second = harvest_page_sentences(db, page)
+
+        assert first == 1
+        assert second == 0
+        assert db.query(Sentence).filter(Sentence.page_id == page.id).count() == 1
+
+
+def test_harvest_force_replays(tmp_db):
+    with tmp_db() as db:
+        story, page = _seed_story(db)
+        lemma = _add_lemma(db, "βιβλίο", "βιβλιο")
+        _add_word(db, page, 0, "Βιβλίο", 0, lemma)
+        _add_word(db, page, 1, ".", 0)
+        db.commit()
+
+        # First harvest creates 1 sentence; second (no force) is a no-op.
+        assert harvest_page_sentences(db, page) == 1
+        assert harvest_page_sentences(db, page) == 0
+        # Force replays — same end state, but the create returns 1 again.
+        assert harvest_page_sentences(db, page, force=True) == 1
+        assert db.query(Sentence).filter(Sentence.page_id == page.id).count() == 1
+
+
+def test_harvest_skips_caps_headings(tmp_db):
+    """A sentence with ≥80% all-caps tokens and ≤10 words is a heading and
+    must not become reviewable material — Greek PDFs typeset chapter titles
+    in caps without accents, which is meta-text, not vocabulary."""
+    with tmp_db() as db:
+        story, page = _seed_story(db)
+        l_heading = _add_lemma(db, "ΠΟΛΙΤΙΣΜΟΣ", "πολιτισμοσ")
+        l_body = _add_lemma(db, "γράφω", "γραφω")
+
+        # Sentence 0: heading — three all-caps tokens
+        _add_word(db, page, 0, "ΑΡΧΑΙΟΙ", 0, l_heading)
+        _add_word(db, page, 1, "ΕΛΛΗΝΙΚΟΙ", 0, l_heading)
+        _add_word(db, page, 2, "ΠΟΛΙΤΙΣΜΟΙ", 0, l_heading)
+
+        # Sentence 1: body — content sentence
+        _add_word(db, page, 3, "Γράφω", 1, l_body)
+        _add_word(db, page, 4, ".", 1)
+        db.commit()
+
+        created = harvest_page_sentences(db, page)
+        assert created == 1
+        sids = [s.sentence_index_in_page for s in
+                db.query(Sentence).filter(Sentence.page_id == page.id).all()]
+        assert sids == [1]
+
+
+def test_harvest_resolves_variant_lemmas_to_canonical(tmp_db):
+    """SentenceWord rows must carry the canonical lemma_id — never the variant.
+    Defense-in-depth for Hard Invariant #9 applied at storage time."""
+    with tmp_db() as db:
+        story, page = _seed_story(db)
+        canonical = _add_lemma(db, "βιβλίο", "βιβλιο")
+        variant = _add_lemma(
+            db, "βιβλίον", "βιβλιον",
+            canonical_lemma_id=canonical.lemma_id,
+        )
+        _add_word(db, page, 0, "Βιβλίον", 0, variant)
+        _add_word(db, page, 1, ".", 0)
+        db.commit()
+
+        harvest_page_sentences(db, page)
+
+        sw = db.query(SentenceWord).filter(SentenceWord.lemma_id.isnot(None)).first()
+        assert sw.lemma_id == canonical.lemma_id
+
+
+def test_harvest_skips_punctuation_only_sentences(tmp_db):
+    """Tokenizer artefacts (e.g. a stray line break giving a sentence with
+    only `\\n` or `--`) carry no content and must not produce Sentence rows."""
+    with tmp_db() as db:
+        story, page = _seed_story(db)
+        lemma = _add_lemma(db, "λέξη", "λεξη")
+
+        # Sentence 0: punctuation only
+        _add_word(db, page, 0, "—", 0)
+        _add_word(db, page, 1, "—", 0)
+
+        # Sentence 1: real content
+        _add_word(db, page, 2, "Λέξη", 1, lemma)
+        _add_word(db, page, 3, ".", 1)
+        db.commit()
+
+        created = harvest_page_sentences(db, page)
+        assert created == 1
+
+
+def test_harvest_story_walks_verified_pages(tmp_db):
+    with tmp_db() as db:
+        story, p1 = _seed_story(db)
+        # Add second page, also verified
+        p2 = Page(
+            story_id=story.id, page_number=2, body_src="x",
+            processed_at=datetime.now(timezone.utc),
+            mappings_verified_at=datetime.now(timezone.utc),
+        )
+        db.add(p2)
+        db.flush()
+        # Add a third page that's NOT verified — must be skipped
+        p3 = Page(
+            story_id=story.id, page_number=3, body_src="y",
+            processed_at=datetime.now(timezone.utc),
+            mappings_verified_at=None,
+        )
+        db.add(p3)
+        db.flush()
+
+        l1 = _add_lemma(db, "α", "α")
+        l2 = _add_lemma(db, "β", "β")
+        _add_word(db, p1, 0, "α", 0, l1)
+        _add_word(db, p1, 1, ".", 0)
+        _add_word(db, p2, 0, "β", 0, l2)
+        _add_word(db, p2, 1, ".", 0)
+        # p3 has a word but won't be harvested
+        _add_word(db, p3, 0, "γ", 0, l1)
+        db.commit()
+
+        total = harvest_story_sentences(db, story.id)
+        assert total == 2
+        assert db.query(Sentence).filter(Sentence.page_id == p3.id).count() == 0


### PR DESCRIPTION
## Summary

The `Sentence` and `SentenceWord` tables existed since the initial polyglot schema but nothing wrote to them — so the sentence-review pipeline had zero source material. This is PR #1 of the 5-PR sentence-review port and lays the foundation: harvest sentences from textbook pages the user has already read, leveraging the lemmatized + verified PageWord rows as input.

- New service `app/services/sentence_harvest.py` walks PageWord rows grouped by `sentence_index`, reconstructs sentence text (with Greek-aware punctuation attachment), and emits Sentence + SentenceWord rows.
- New columns on `Sentence`: `page_id`, `sentence_index_in_page` (nullable for LLM-generated sentences in PR #4). Unique constraint enforces no duplicates per page. Schema delta applied idempotently via `ensure_schema()`.
- Auto-triggered at the end of `process_page` after the quality gate stamps `mappings_verified_at`. Bulk re-harvest endpoint `POST /api/texts/{story_id}/extract-sentences` for backfilling pre-existing imports.

## Hard invariants honoured

- **Reviewability gate**: only verified pages (`mappings_verified_at IS NOT NULL`) produce Sentence rows. The harvested Sentence's own `mappings_verified_at` carries forward from the Page, so the selector in PR #3 sees verified material.
- **Canonical scheduling**: SentenceWord stores the canonical lemma_id, not the variant — defense-in-depth for Hard Invariant #9 at storage rather than read time.
- **Heading exclusion**: caps-heading sentences (reused detector from `lemma_quality`) and pure-punctuation tokenizer artefacts are skipped.
- **No LLM/network in DB transaction**: harvest is pure DB compute, so CLAUDE.md Rule #10 (SQLite write lock discipline) is trivially satisfied.

## Tests

Polyglot backend: **92 passing** (was 83 + 9 new harvest tests). Covers: punctuation attachment, verified-page gating, sentence-per-index grouping, idempotency + force replay, caps-heading skipping, canonical resolution, pure-punctuation skipping, whole-story walk.