### PR TITLE
Polyglot: page pre-warm cron (keep N pages ahead of the reader)

### DIFF
--- a/polyglot/DESIGN.md
+++ b/polyglot/DESIGN.md
@@ -440,6 +440,36 @@ client_review_id (unique). Used for undo.
 
 ## 8. Core systems
 
+### 8.0 Page pre-warming (cron — added 2026-05-20)
+
+To avoid the 2-3 min Sonnet wait when the user flips to a fresh page, a
+cron task keeps a configurable buffer (default 5) of *already-verified*
+pages ahead of the user's last-viewed position. The signal:
+
+- `Page.viewed_at` — stamped by `GET /api/texts/{sid}/pages/{n}` on each
+  user view. Cron-warmed pages do NOT stamp it; only real opens do.
+- `last_viewed = max(page_number where viewed_at IS NOT NULL)` per story.
+- `pages_ahead = count(page_number > last_viewed AND mappings_verified_at IS NOT NULL)`.
+- If `pages_ahead < buffer`, the cron processes the next pages forward
+  until the buffer fills.
+
+Mechanics live in `reading_intake.warm_pages_ahead(story_id, buffer=5)`
+and `warm_all_active_stories(language_code)`. CLI:
+`scripts/warm_pages_ahead.py`. Cron entry-point:
+`deploy/polyglot-update-material.sh` runs this phase *before* the
+sentence-cache warm — newly verified pages are the source of new
+lemmas that the sentence cache then needs to cover.
+
+**Cost shape**: bounded by reading speed. The buffer only refills as
+the user advances. Per-page Sonnet quality-gate is ~$0.30-0.50. Worst
+case per cron pass: 5 pages = ~$2.50. If you read 0 pages, the cron
+does 0 work.
+
+**Known limitation**: skipping pages (read page 100 before pages 1-99)
+leaves earlier pages lazy — next time you go back, you eat the wait.
+Acceptable for sequential reading; revisit if random-access becomes
+common.
+
 ### 8.1 Reading-as-mapping (the entry flow)
 
 The flow that defines polyglot. Inspired by Tadoku-style extensive reading
@@ -1144,6 +1174,9 @@ proof-of-shape, not proof-of-concept.
 | `POLYGLOT_BATCH_WORD_SIZE`        | `4`         | Target lemmas per generation batch                              |
 | `POLYGLOT_SENTENCES_PER_TARGET`   | `2`         | Sentences requested per lemma per batch                          |
 | `POLYGLOT_ACTIVE_TARGET`          | `3`         | Min reviewable sentences per active lemma (warm-cache threshold) |
+| `POLYGLOT_PAGES_AHEAD_BUFFER`     | `5`         | Verified pages the cron keeps ahead of the user's last view      |
+| `POLYGLOT_PAGES_AHEAD_MAX_PER_RUN`| `5`         | Cap on pages warmed per story per cron pass (safety valve)        |
+| `POLYGLOT_PAGES_AHEAD_TIMEOUT_SECONDS`| `1200`  | Cron-pass timeout for the page-warm phase                         |
 | `POLYGLOT_DETECT_COGNATES`        | `0`         | Enable external L1 cognate detection                            |
 | `POLYGLOT_AUTO_MARK_COGNATES`     | `0`         | Auto-mark high-confidence L1 cognates as `known`                |
 | `TESTING`                         | `0`         | Disable interaction logger and similar test-aware paths          |

--- a/polyglot/app/database.py
+++ b/polyglot/app/database.py
@@ -51,6 +51,7 @@ _ADDITIVE_COLUMN_DELTAS: list[tuple[str, str, str]] = [
     ("sentences", "page_id", "INTEGER REFERENCES pages(id)"),
     ("sentences", "sentence_index_in_page", "INTEGER"),
     ("user_lemma_knowledge", "experiment_intro_shown_at", "DATETIME"),
+    ("pages", "viewed_at", "DATETIME"),
 ]
 
 # Indexes that should exist once the columns above are present.

--- a/polyglot/app/models.py
+++ b/polyglot/app/models.py
@@ -268,6 +268,7 @@ class Page(Base):
     body_src = Column(Text, nullable=False)
     processed_at = Column(DateTime, nullable=True)         # tokenized + simplemma lemmatized
     mappings_verified_at = Column(DateTime, nullable=True) # quality gate (LLM-in-context) pass
+    viewed_at = Column(DateTime, nullable=True)            # last time user opened the page
     quality_gate_failures = Column(Integer, default=0)     # tokens the gate left as 'unclear'
     total_words = Column(Integer, default=0)
     known_count = Column(Integer, default=0)

--- a/polyglot/app/routers/texts.py
+++ b/polyglot/app/routers/texts.py
@@ -71,11 +71,20 @@ def get_story(story_id: int, db: Session = Depends(get_db)):
 
 @router.get("/{story_id}/pages/{page_number}", response_model=PageView)
 def get_page(story_id: int, page_number: int, db: Session = Depends(get_db)):
-    """Lazy: tokenizes + lemmatizes on first request."""
+    """Lazy: tokenizes + lemmatizes on first request.
+
+    Stamps ``page.viewed_at`` after the (possibly slow) processing returns —
+    this is the signal `warm_pages_ahead` uses to decide which pages need
+    pre-warming. Cron-warmed pages don't stamp this; only actual user views do.
+    """
+    from datetime import datetime, timezone
+
     result = reading_intake.get_page_view(db, story_id, page_number)
     if result is None:
         raise HTTPException(status_code=404, detail="Page not found")
     page, tokens = result
+    page.viewed_at = datetime.now(timezone.utc)
+    db.commit()
     total_pages = (
         db.query(func.count(Page.id)).filter(Page.story_id == story_id).scalar() or 0
     )

--- a/polyglot/app/services/reading_intake.py
+++ b/polyglot/app/services/reading_intake.py
@@ -435,3 +435,149 @@ def mark_lemma(db: Session, lemma_id: int, state: str, *, fetch_gloss: bool = Tr
         propagate_known_via_cognate(db, lemma_id)
 
     return ulk
+
+
+# ─── Page warming (cron) ───────────────────────────────────────────────────
+
+
+DEFAULT_PAGES_AHEAD_BUFFER = 5
+
+
+def _last_viewed_page_number(db: Session, story_id: int) -> int:
+    """Highest page_number the user has actually opened, or 0 if none yet.
+
+    `Page.viewed_at` is stamped only by the GET /pages/{n} endpoint — cron-
+    warmed pages do NOT stamp it, so this returns "how far the user has
+    read," not "how far the cron has warmed."
+    """
+    from sqlalchemy import func as _func
+    result = (
+        db.query(_func.max(Page.page_number))
+        .filter(Page.story_id == story_id, Page.viewed_at.isnot(None))
+        .scalar()
+    )
+    return int(result or 0)
+
+
+def _verified_pages_ahead(db: Session, story_id: int, last_viewed: int) -> int:
+    """Count pages already through the quality gate beyond the last-viewed
+    page. This is the buffer the cron tries to keep ≥ ``buffer`` deep.
+    """
+    return (
+        db.query(Page)
+        .filter(
+            Page.story_id == story_id,
+            Page.page_number > last_viewed,
+            Page.mappings_verified_at.isnot(None),
+        )
+        .count()
+    )
+
+
+def warm_pages_ahead(
+    db: Session,
+    story_id: int,
+    *,
+    buffer: int = DEFAULT_PAGES_AHEAD_BUFFER,
+    max_to_warm: int | None = None,
+) -> dict:
+    """Ensure ``buffer`` verified pages exist beyond the last-viewed page.
+
+    Reads the last-viewed page number (highest ``page_number`` with non-null
+    ``viewed_at``), counts how many later pages have already passed the
+    quality gate, and processes additional pages forward until the buffer is
+    full. Each page processed costs one Sonnet call (~$0.30-0.50, ~2-3 min)
+    so a buffer of 5 has bounded daily cost: it only refills as the user
+    reads, never further.
+
+    Returns a summary dict for cron logging.
+    Skipped silently if the story has no unverified pages remaining beyond
+    the user's current position (whole book gated through, or buffer is
+    already past the end).
+    """
+    from app.models import Story as _Story
+
+    story = db.get(_Story, story_id)
+    if story is None:
+        return {"story_id": story_id, "error": "story not found"}
+
+    last_viewed = _last_viewed_page_number(db, story_id)
+    ahead_before = _verified_pages_ahead(db, story_id, last_viewed)
+
+    summary: dict = {
+        "story_id": story_id,
+        "story_title": story.title,
+        "last_viewed": last_viewed,
+        "ahead_before": ahead_before,
+        "pages_warmed": [],
+        "errors": [],
+    }
+
+    if ahead_before >= buffer:
+        summary["ahead_after"] = ahead_before
+        return summary
+
+    needed = buffer - ahead_before
+    if max_to_warm is not None:
+        needed = min(needed, max_to_warm)
+
+    candidates: list[Page] = (
+        db.query(Page)
+        .filter(
+            Page.story_id == story_id,
+            Page.page_number > last_viewed,
+            Page.mappings_verified_at.is_(None),
+        )
+        .order_by(Page.page_number.asc())
+        .limit(needed)
+        .all()
+    )
+
+    for page in candidates:
+        try:
+            process_page(db, page)
+        except Exception as e:
+            log.warning("warm_pages_ahead: page %d of story %d failed: %s",
+                        page.page_number, story_id, e)
+            summary["errors"].append((page.page_number, str(e)))
+            continue
+        # Only count it as warmed if the quality gate actually finished.
+        db.refresh(page)
+        if page.mappings_verified_at is not None:
+            summary["pages_warmed"].append(page.page_number)
+
+    summary["ahead_after"] = _verified_pages_ahead(db, story_id, last_viewed)
+    return summary
+
+
+def warm_all_active_stories(
+    db: Session,
+    language_code: str,
+    *,
+    buffer: int = DEFAULT_PAGES_AHEAD_BUFFER,
+    max_to_warm_per_story: int | None = None,
+) -> list[dict]:
+    """Run warm_pages_ahead for every active story in ``language_code``.
+
+    Used by the cron wrapper. Iterates stories oldest-first so newly-imported
+    books don't starve out the one the user is actively reading.
+    """
+    from app.models import Story as _Story
+
+    stories = (
+        db.query(_Story)
+        .filter(_Story.language_code == language_code, _Story.status == "active")
+        .order_by(_Story.created_at.asc())
+        .all()
+    )
+    summaries: list[dict] = []
+    for story in stories:
+        s = warm_pages_ahead(
+            db,
+            story_id=story.id,
+            buffer=buffer,
+            max_to_warm=max_to_warm_per_story,
+        )
+        summaries.append(s)
+    return summaries
+

--- a/polyglot/deploy/polyglot-update-material.sh
+++ b/polyglot/deploy/polyglot-update-material.sh
@@ -8,7 +8,12 @@
 #     45 */3 * * * /opt/polyglot-update-material.sh >> /var/log/polyglot-update-material.log 2>&1
 #
 # One pass per run, in order:
-#   1. warm_sentence_cache for Modern Greek (primary)
+#   1. warm_pages_ahead for Modern Greek (primary)
+#      — keeps the next N (default 5) unread pages of every active story
+#        already through the quality gate, so the user never waits when
+#        flipping pages. Runs first because freshly verified pages are the
+#        source of new lemmas that the sentence cache then needs to cover.
+#   2. warm_sentence_cache for Modern Greek
 #      — finds acquiring/learning/known lemmas below ACTIVE_TARGET sentence
 #        coverage and generates more via Claude CLI (Sonnet) + Haiku verify.
 #
@@ -33,6 +38,9 @@ LANGUAGE="${POLYGLOT_WARM_LANGUAGE:-el}"
 MAX_LEMMAS="${POLYGLOT_WARM_MAX_LEMMAS:-16}"
 SENTENCES_PER_TARGET="${POLYGLOT_WARM_SENTENCES_PER_TARGET:-2}"
 TIMEOUT_SECONDS="${POLYGLOT_WARM_TIMEOUT_SECONDS:-1200}"
+PAGES_BUFFER="${POLYGLOT_PAGES_AHEAD_BUFFER:-5}"
+PAGES_MAX_PER_RUN="${POLYGLOT_PAGES_AHEAD_MAX_PER_RUN:-5}"
+PAGES_TIMEOUT_SECONDS="${POLYGLOT_PAGES_AHEAD_TIMEOUT_SECONDS:-1200}"
 
 export PYTHONUNBUFFERED=1
 
@@ -52,6 +60,12 @@ run_phase() {
 }
 
 echo "[$TIMESTAMP] Polyglot material cron start" >> "$LOG"
+
+run_phase "warm_pages_ahead" timeout "$PAGES_TIMEOUT_SECONDS" \
+  "$VENV" scripts/warm_pages_ahead.py \
+  --language "$LANGUAGE" \
+  --buffer "$PAGES_BUFFER" \
+  --max-per-story "$PAGES_MAX_PER_RUN"
 
 run_phase "warm_sentence_cache" timeout "$TIMEOUT_SECONDS" \
   "$VENV" scripts/warm_sentence_cache.py \

--- a/polyglot/scripts/warm_pages_ahead.py
+++ b/polyglot/scripts/warm_pages_ahead.py
@@ -1,0 +1,106 @@
+"""Pre-warm the next few unread pages of active stories.
+
+Iterates every active Story in the configured language and runs the lazy
+page pipeline (tokenize + simplemma + LLM quality gate) on the next
+``--buffer`` pages beyond the user's last-viewed position. By the time the
+user opens those pages, no waiting is required.
+
+Bounded by design:
+- A page is only warmed if it sits between the last-viewed page and the
+  buffer ceiling. Once the buffer is full, the script exits without work.
+- ``--max-per-story`` caps a single run, so a very long book can't burn
+  the whole 20-minute cron timeout on one story.
+
+Cost shape: one Sonnet quality-gate call per warmed page (~$0.30-0.50,
+~2-3 min). With ``--buffer 5``, worst case per cron pass is 5 pages per
+active story.
+
+Usage::
+
+    .venv/bin/python scripts/warm_pages_ahead.py --language el --buffer 5
+
+Env vars (alternative to CLI flags)::
+
+    POLYGLOT_PAGES_AHEAD_BUFFER       default buffer size
+    POLYGLOT_PAGES_AHEAD_MAX_PER_RUN  cap per story per run (None = no cap)
+    POLYGLOT_QUALITY_GATE             must be "1" for the gate to actually run
+
+Exits 0 on success (including "no work needed"), 1 on hard failure.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+
+from app.database import SessionLocal
+from app.services.reading_intake import warm_all_active_stories
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Pre-warm pages for active stories.")
+    parser.add_argument("--language", default="el",
+                        help="Language code (el/grc/la). Default: el")
+    parser.add_argument("--buffer", type=int,
+                        default=int(os.environ.get("POLYGLOT_PAGES_AHEAD_BUFFER", "5")),
+                        help="Verified pages to keep ahead of the user. Default: 5")
+    parser.add_argument("--max-per-story", type=int, default=None,
+                        help="Cap on pages warmed per story per run. Default: no cap.")
+    parser.add_argument("--verbose", "-v", action="store_true")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    log = logging.getLogger("warm_pages_ahead")
+
+    if os.environ.get("POLYGLOT_QUALITY_GATE", "0") != "1":
+        log.warning(
+            "POLYGLOT_QUALITY_GATE is not set to 1 — page processing will skip "
+            "the LLM verification step. Set POLYGLOT_QUALITY_GATE=1 for a "
+            "real warm pass.",
+        )
+
+    max_per_run_env = os.environ.get("POLYGLOT_PAGES_AHEAD_MAX_PER_RUN")
+    max_per_story = args.max_per_story
+    if max_per_story is None and max_per_run_env:
+        max_per_story = int(max_per_run_env)
+
+    db = SessionLocal()
+    try:
+        summaries = warm_all_active_stories(
+            db,
+            language_code=args.language,
+            buffer=args.buffer,
+            max_to_warm_per_story=max_per_story,
+        )
+    finally:
+        db.close()
+
+    total_warmed = sum(len(s.get("pages_warmed", [])) for s in summaries)
+    total_errors = sum(len(s.get("errors", [])) for s in summaries)
+    log.info(
+        "warm_pages_ahead %s: %d stories processed, %d pages warmed, %d errors",
+        args.language, len(summaries), total_warmed, total_errors,
+    )
+    print(json.dumps(
+        {
+            "language_code": args.language,
+            "buffer": args.buffer,
+            "stories_processed": len(summaries),
+            "pages_warmed": total_warmed,
+            "errors": total_errors,
+            "summaries": summaries,
+        },
+        ensure_ascii=False,
+        indent=2,
+        default=str,
+    ))
+    return 0 if total_errors == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/polyglot/tests/test_reading_intake.py
+++ b/polyglot/tests/test_reading_intake.py
@@ -119,3 +119,209 @@ def test_page_view_classifies_token_states(tmp_db):
         word_tokens = [t for t in tokens if not t["is_punctuation"]]
         assert any(t["is_known"] for t in word_tokens)
         assert any(t["is_new"] for t in word_tokens)
+
+
+# ─── warm_pages_ahead ─────────────────────────────────────────────────────
+
+
+def _seed_multi_page_story(db, n_pages: int, body_per_page: str = "βιβλίο σπίτι") -> Story:
+    """Create a Story with `n_pages` raw, unprocessed pages."""
+    story = Story(
+        language_code="el",
+        title="multi-page test",
+        source="paste",
+        page_count=n_pages,
+        status="active",
+    )
+    db.add(story)
+    db.flush()
+    for i in range(1, n_pages + 1):
+        db.add(Page(story_id=story.id, page_number=i, body_src=f"{body_per_page} (page {i})"))
+    db.commit()
+    return story
+
+
+def _stub_quality_gate(monkeypatch):
+    """Make process_page's quality gate auto-succeed without LLM calls."""
+    from app.services import sentence_harvest
+
+    def fake_verify(db, page):
+        page.mappings_verified_at = datetime.now(timezone.utc)
+        db.commit()
+        return 0
+
+    monkeypatch.setattr(reading_intake.lemma_quality, "QUALITY_GATE_ENABLED", True)
+    monkeypatch.setattr(reading_intake.lemma_quality, "verify_page_mappings", fake_verify)
+    monkeypatch.setattr(sentence_harvest, "harvest_page_sentences", lambda db, page: 0)
+
+
+def test_warm_pages_ahead_empty_story_warms_first_buffer(tmp_db, monkeypatch):
+    """A story the user has never opened: buffer pages should be processed
+    starting from page 1."""
+    _stub_quality_gate(monkeypatch)
+    with tmp_db() as db:
+        story = _seed_multi_page_story(db, n_pages=20)
+
+        summary = reading_intake.warm_pages_ahead(db, story.id, buffer=5)
+
+        assert summary["last_viewed"] == 0
+        assert summary["ahead_before"] == 0
+        assert summary["ahead_after"] == 5
+        assert summary["pages_warmed"] == [1, 2, 3, 4, 5]
+        assert summary["errors"] == []
+
+        verified = (
+            db.query(Page)
+            .filter(Page.story_id == story.id, Page.mappings_verified_at.isnot(None))
+            .order_by(Page.page_number)
+            .all()
+        )
+        assert [p.page_number for p in verified] == [1, 2, 3, 4, 5]
+
+
+def test_warm_pages_ahead_resumes_after_last_viewed(tmp_db, monkeypatch):
+    """User has opened page 10. Cron should warm 11-15, not earlier."""
+    _stub_quality_gate(monkeypatch)
+    with tmp_db() as db:
+        story = _seed_multi_page_story(db, n_pages=30)
+        # Mark page 10 as viewed
+        page10 = db.query(Page).filter_by(story_id=story.id, page_number=10).one()
+        page10.viewed_at = datetime.now(timezone.utc)
+        db.commit()
+
+        summary = reading_intake.warm_pages_ahead(db, story.id, buffer=5)
+
+        assert summary["last_viewed"] == 10
+        assert summary["pages_warmed"] == [11, 12, 13, 14, 15]
+        # Page 1-9 still untouched
+        assert db.query(Page).filter(
+            Page.story_id == story.id,
+            Page.page_number < 10,
+            Page.mappings_verified_at.isnot(None),
+        ).count() == 0
+
+
+def test_warm_pages_ahead_noop_when_buffer_already_full(tmp_db, monkeypatch):
+    """If 5 pages ahead are already verified, the cron makes 0 calls."""
+    _stub_quality_gate(monkeypatch)
+    with tmp_db() as db:
+        story = _seed_multi_page_story(db, n_pages=20)
+        # Manually mark pages 1-5 as verified (simulate prior cron pass)
+        now = datetime.now(timezone.utc)
+        for n in range(1, 6):
+            p = db.query(Page).filter_by(story_id=story.id, page_number=n).one()
+            p.processed_at = now
+            p.mappings_verified_at = now
+        db.commit()
+
+        # Spy on process_page so we can assert it isn't called
+        process_calls = {"n": 0}
+        orig_process = reading_intake.process_page
+
+        def spy_process(db, page, *, force=False):
+            process_calls["n"] += 1
+            return orig_process(db, page, force=force)
+
+        monkeypatch.setattr(reading_intake, "process_page", spy_process)
+
+        summary = reading_intake.warm_pages_ahead(db, story.id, buffer=5)
+
+        assert summary["ahead_before"] == 5
+        assert summary["ahead_after"] == 5
+        assert summary["pages_warmed"] == []
+        assert process_calls["n"] == 0
+
+
+def test_warm_pages_ahead_partial_buffer_fills_gap(tmp_db, monkeypatch):
+    """If only 2 ahead pages are verified, fill the remaining 3 to reach buffer=5."""
+    _stub_quality_gate(monkeypatch)
+    with tmp_db() as db:
+        story = _seed_multi_page_story(db, n_pages=20)
+        now = datetime.now(timezone.utc)
+        for n in [1, 2]:
+            p = db.query(Page).filter_by(story_id=story.id, page_number=n).one()
+            p.processed_at = now
+            p.mappings_verified_at = now
+        db.commit()
+
+        summary = reading_intake.warm_pages_ahead(db, story.id, buffer=5)
+
+        assert summary["ahead_before"] == 2
+        assert summary["ahead_after"] == 5
+        assert summary["pages_warmed"] == [3, 4, 5]
+
+
+def test_warm_pages_ahead_handles_end_of_book(tmp_db, monkeypatch):
+    """If user is near the end and fewer than buffer pages remain, process
+    only what's left without error."""
+    _stub_quality_gate(monkeypatch)
+    with tmp_db() as db:
+        story = _seed_multi_page_story(db, n_pages=10)
+        # User has read up to page 8 → only 9, 10 remain
+        page8 = db.query(Page).filter_by(story_id=story.id, page_number=8).one()
+        page8.viewed_at = datetime.now(timezone.utc)
+        db.commit()
+
+        summary = reading_intake.warm_pages_ahead(db, story.id, buffer=5)
+
+        assert summary["last_viewed"] == 8
+        assert summary["pages_warmed"] == [9, 10]
+        assert summary["ahead_after"] == 2
+
+
+def test_warm_pages_ahead_max_to_warm_caps_per_run(tmp_db, monkeypatch):
+    """``max_to_warm`` lets the cron bound a single pass even when more pages
+    would be needed to reach the buffer — useful as a safety valve."""
+    _stub_quality_gate(monkeypatch)
+    with tmp_db() as db:
+        story = _seed_multi_page_story(db, n_pages=20)
+
+        summary = reading_intake.warm_pages_ahead(
+            db, story.id, buffer=10, max_to_warm=3,
+        )
+
+        assert summary["pages_warmed"] == [1, 2, 3]
+        assert summary["ahead_after"] == 3
+
+
+def test_warm_pages_ahead_skips_pages_when_gate_fails(tmp_db, monkeypatch):
+    """If the quality gate returns None (LLM failure), the page is reported
+    in `errors` and not counted as warmed. Buffer stays partially filled."""
+    from app.services import sentence_harvest
+
+    monkeypatch.setattr(reading_intake.lemma_quality, "QUALITY_GATE_ENABLED", True)
+    # Gate is silent — leaves mappings_verified_at NULL
+    monkeypatch.setattr(reading_intake.lemma_quality, "verify_page_mappings",
+                        lambda db, page: 0)
+    monkeypatch.setattr(sentence_harvest, "harvest_page_sentences", lambda db, page: 0)
+
+    with tmp_db() as db:
+        story = _seed_multi_page_story(db, n_pages=10)
+
+        summary = reading_intake.warm_pages_ahead(db, story.id, buffer=3)
+
+        # process_page runs and stamps processed_at, but mappings_verified_at
+        # stays NULL since the gate didn't set it.
+        assert summary["pages_warmed"] == []
+        assert summary["ahead_after"] == 0
+
+
+def test_warm_all_active_stories_iterates_oldest_first(tmp_db, monkeypatch):
+    """Multiple active stories: cron walks them in created_at order, so the
+    earliest-imported (typically the actively-read one) is topped up first."""
+    _stub_quality_gate(monkeypatch)
+    with tmp_db() as db:
+        s1 = _seed_multi_page_story(db, n_pages=5)
+        s2 = _seed_multi_page_story(db, n_pages=5)
+        # Ensure created_at ordering is deterministic
+        s1.created_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
+        s2.created_at = datetime(2026, 5, 5, tzinfo=timezone.utc)
+        db.commit()
+
+        summaries = reading_intake.warm_all_active_stories(
+            db, language_code="el", buffer=3,
+        )
+
+        assert [s["story_id"] for s in summaries] == [s1.id, s2.id]
+        assert summaries[0]["pages_warmed"] == [1, 2, 3]
+        assert summaries[1]["pages_warmed"] == [1, 2, 3]


### PR DESCRIPTION
## Summary
- Adds a cron-driven loop that keeps a buffer (default 5) of quality-gated pages ahead of the user's last-viewed position in each active story, so flipping forward never blocks on a 2-3 min Sonnet pass.
- `Page.viewed_at` (nullable DATETIME) is stamped only by `GET /pages/{n}` — cron-warmed pages don't set it, so we can distinguish "user has read this far" from "cron has warmed this far."
- `reading_intake.warm_pages_ahead` + `warm_all_active_stories` + `scripts/warm_pages_ahead.py` + new phase in `deploy/polyglot-update-material.sh` (runs before the sentence-cache warm so freshly verified pages feed the lemma pipeline).
- Cost is self-rate-limited: the buffer only refills as the user advances. 0 reads ⇒ 0 work. Worst case per cron pass = buffer × ~$0.30-0.50 Sonnet/page.

## Test plan
- Backend: `cd polyglot && arch -arm64 .venv/bin/python -m pytest tests/test_reading_intake.py` — 14/14 passing (8 new `warm_pages_ahead` tests). One pre-existing failure in `test_lemma_quality::test_partial_batch_failure_leaves_page_unverified` is unrelated to this branch (Hard Invariant #8 regression on main — tracked separately).
- Server-side smoke: after deploy, run `ssh alif "cd /opt/alif/polyglot && POLYGLOT_QUALITY_GATE=1 .venv/bin/python scripts/warm_pages_ahead.py --language el --buffer 5"` against the imported textbook and confirm pages 1-5 get `mappings_verified_at` set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)