### PR TITLE
Alif: transparent reverse proxy to polyglot at /polyglot/*

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,7 +7,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.database import engine, Base
-from app.routers import words, review, analyze, stats, import_data, sentences, tts, learn, grammar, stories, chat, ocr, flags, activity, settings, books, patterns, roots, podcast
+from app.routers import words, review, analyze, stats, import_data, sentences, tts, learn, grammar, stories, chat, ocr, flags, activity, settings, books, patterns, roots, podcast, polyglot_proxy
 
 
 @asynccontextmanager
@@ -107,6 +107,11 @@ app.include_router(books.router)
 app.include_router(patterns.router)
 app.include_router(roots.router)
 app.include_router(podcast.router)
+# Reverse proxy to the polyglot backend on localhost:3002, so the client
+# only needs to talk to ONE host:port. See routers/polyglot_proxy.py for
+# the deliberate constraints — this module is pure HTTP passthrough, no
+# code coupling to polyglot.
+app.include_router(polyglot_proxy.router)
 
 # Serve voice samples for comparison testing
 from pathlib import Path as _Path

--- a/backend/app/routers/polyglot_proxy.py
+++ b/backend/app/routers/polyglot_proxy.py
@@ -1,0 +1,111 @@
+"""Transparent reverse proxy for the polyglot backend.
+
+**Why this exists**: lets the iOS / web client talk to ONE host:port
+(``alif:3000``) instead of two, so EAS dev-client binaries, ATS exceptions,
+and firewall whitelists don't need to know about polyglot's port. The
+client calls ``alif:3000/polyglot/api/...`` and this module forwards
+byte-for-byte to ``127.0.0.1:3002/api/...``.
+
+**What this module MUST NOT do**:
+
+- Import from polyglot. Anything.
+- Introspect request or response payloads.
+- Apply business logic, validation, auth, or schema awareness.
+- Cache, retry, or transform anything beyond hop-by-hop headers.
+
+The whole point is that polyglot stays independently testable + deployable
+while sharing alif's externally-visible port. If you find yourself reaching
+for any of the above, you're either (a) building a feature that belongs in
+polyglot itself, or (b) it's time to swap this module for real nginx /
+Caddy.
+
+When real nginx arrives, delete this file. It will not be missed.
+"""
+from __future__ import annotations
+
+import os
+
+import httpx
+from fastapi import APIRouter, Request, Response
+
+router = APIRouter(prefix="/polyglot", tags=["polyglot-proxy"])
+
+POLYGLOT_UPSTREAM = os.environ.get("POLYGLOT_UPSTREAM_URL", "http://127.0.0.1:3002")
+
+# Long timeout because polyglot's page-view endpoint can spend 2-3 minutes
+# inside the LLM quality gate on first view of an unwarmed page. Anything
+# shorter and we'd surface spurious 504s during normal reading.
+_PROXY_TIMEOUT_S = float(os.environ.get("POLYGLOT_PROXY_TIMEOUT_S", "300"))
+
+# Hop-by-hop headers per RFC 7230 §6.1 — must not be forwarded.
+_HOP_BY_HOP = {
+    "connection", "keep-alive", "proxy-authenticate", "proxy-authorization",
+    "te", "trailers", "transfer-encoding", "upgrade",
+    # `host` would point at the alif domain — let httpx set the right one.
+    "host",
+    # `content-length` is recomputed by the upstream client; passing it
+    # through can mismatch and break streaming.
+    "content-length",
+}
+
+# Single shared async client. FastAPI's lifespan would be the strict place
+# to manage this, but a module-level client is simpler and httpx handles
+# pooling internally. The connect timeout is short (5s) because polyglot
+# is on localhost — if it's not up, fail fast.
+#
+# trust_env=False because polyglot lives on 127.0.0.1; any HTTP_PROXY /
+# HTTPS_PROXY / ALL_PROXY env var in the shell that started uvicorn would
+# otherwise route loopback traffic through the proxy and break it (also
+# triggers a `socksio not installed` ImportError under tests).
+_client = httpx.AsyncClient(
+    timeout=httpx.Timeout(_PROXY_TIMEOUT_S, connect=5.0),
+    trust_env=False,
+)
+
+
+@router.api_route(
+    "/{path:path}",
+    methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD"],
+)
+async def proxy(request: Request, path: str) -> Response:
+    upstream_url = f"{POLYGLOT_UPSTREAM}/{path}"
+    forwarded_headers = {
+        k: v for k, v in request.headers.items()
+        if k.lower() not in _HOP_BY_HOP
+    }
+    body = await request.body()
+
+    try:
+        upstream = await _client.request(
+            request.method,
+            upstream_url,
+            params=request.query_params,
+            headers=forwarded_headers,
+            content=body,
+        )
+    except httpx.ConnectError:
+        return Response(
+            status_code=502,
+            content=b'{"detail":"polyglot upstream unavailable"}',
+            media_type="application/json",
+        )
+    except httpx.ReadTimeout:
+        return Response(
+            status_code=504,
+            content=b'{"detail":"polyglot upstream timed out"}',
+            media_type="application/json",
+        )
+
+    response_headers = {
+        k: v for k, v in upstream.headers.items()
+        if k.lower() not in _HOP_BY_HOP
+        # Drop content-encoding because httpx already decoded the body —
+        # passing the header through would make the client try to decode
+        # plain bytes as gzip.
+        and k.lower() != "content-encoding"
+    }
+    return Response(
+        content=upstream.content,
+        status_code=upstream.status_code,
+        headers=response_headers,
+    )

--- a/backend/tests/test_polyglot_proxy.py
+++ b/backend/tests/test_polyglot_proxy.py
@@ -1,0 +1,128 @@
+"""Tests for the transparent polyglot proxy.
+
+Uses httpx.MockTransport to stand in for the real polyglot backend so we
+never hit the network. Each test verifies one passthrough property
+(method, status, headers, query params, body, error handling).
+"""
+from __future__ import annotations
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.routers import polyglot_proxy
+
+
+@pytest.fixture
+def mock_upstream(monkeypatch):
+    """Replace polyglot_proxy's shared httpx.AsyncClient with one that
+    talks to a MockTransport. Returns a list that captures each upstream
+    request the proxy makes.
+    """
+    captured: list[httpx.Request] = []
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        # Echo back enough metadata to verify the passthrough properties.
+        if request.url.path == "/api/_proxy_test/echo":
+            return httpx.Response(
+                200,
+                json={
+                    "method": request.method,
+                    "path": request.url.path,
+                    "query": dict(request.url.params),
+                    "headers": {k.lower(): v for k, v in request.headers.items()
+                                if k.lower() in {"x-trace-id", "content-type",
+                                                 "authorization"}},
+                    "body": request.content.decode("utf-8") if request.content else "",
+                },
+            )
+        if request.url.path == "/api/_proxy_test/bad":
+            return httpx.Response(418, json={"detail": "I'm a teapot"})
+        if request.url.path == "/api/_proxy_test/connect-error":
+            raise httpx.ConnectError("simulated upstream down")
+        if request.url.path == "/api/_proxy_test/timeout":
+            raise httpx.ReadTimeout("simulated upstream timeout")
+        return httpx.Response(404, json={"detail": "unknown test route"})
+
+    mock_client = httpx.AsyncClient(transport=httpx.MockTransport(_handler))
+    monkeypatch.setattr(polyglot_proxy, "_client", mock_client)
+    yield captured
+
+
+def test_proxy_forwards_get_path_and_status(mock_upstream):
+    """GET /polyglot/api/foo → upstream sees /api/foo. Status code mirrors."""
+    with TestClient(app) as client:
+        resp = client.get("/polyglot/api/_proxy_test/echo")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["method"] == "GET"
+    assert body["path"] == "/api/_proxy_test/echo"
+    assert len(mock_upstream) == 1
+
+
+def test_proxy_forwards_query_params(mock_upstream):
+    """Query params are preserved as-is."""
+    with TestClient(app) as client:
+        resp = client.get("/polyglot/api/_proxy_test/echo?language_code=el&limit=5")
+    assert resp.status_code == 200
+    assert resp.json()["query"] == {"language_code": "el", "limit": "5"}
+
+
+def test_proxy_forwards_post_body_and_content_type(mock_upstream):
+    """POST body forwarded byte-for-byte; content-type header preserved."""
+    with TestClient(app) as client:
+        resp = client.post(
+            "/polyglot/api/_proxy_test/echo",
+            json={"hello": "world"},
+            headers={"X-Trace-Id": "abc123"},
+        )
+    import json
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["method"] == "POST"
+    # Whitespace-tolerant: TestClient and httpx may emit slightly different
+    # JSON serializations; what matters is the parsed payload round-trips.
+    assert json.loads(body["body"]) == {"hello": "world"}
+    assert body["headers"]["content-type"] == "application/json"
+    # Custom header passed through (not in the hop-by-hop blocklist)
+    assert body["headers"]["x-trace-id"] == "abc123"
+
+
+def test_proxy_mirrors_non_2xx_status(mock_upstream):
+    """A 418 from upstream surfaces as 418 to the client — proxy doesn't
+    interpret status codes as success/failure."""
+    with TestClient(app) as client:
+        resp = client.get("/polyglot/api/_proxy_test/bad")
+    assert resp.status_code == 418
+    assert resp.json() == {"detail": "I'm a teapot"}
+
+
+def test_proxy_returns_502_when_upstream_unavailable(mock_upstream):
+    """If polyglot is down (connect refused), the proxy must surface 502
+    rather than crash or hang."""
+    with TestClient(app) as client:
+        resp = client.get("/polyglot/api/_proxy_test/connect-error")
+    assert resp.status_code == 502
+    assert "unavailable" in resp.json()["detail"]
+
+
+def test_proxy_returns_504_on_upstream_timeout(mock_upstream):
+    """If polyglot takes too long (LLM hang), the proxy returns 504, not 500."""
+    with TestClient(app) as client:
+        resp = client.get("/polyglot/api/_proxy_test/timeout")
+    assert resp.status_code == 504
+    assert "timed out" in resp.json()["detail"]
+
+
+def test_proxy_strips_host_header(mock_upstream):
+    """The Host header must be rewritten by httpx — the upstream should see
+    its own loopback host, not the client's host. (Verified by checking
+    that the captured request's host equals the upstream URL host.)"""
+    with TestClient(app) as client:
+        resp = client.get("/polyglot/api/_proxy_test/echo",
+                          headers={"Host": "example.com"})
+    assert resp.status_code == 200
+    upstream_req = mock_upstream[0]
+    assert upstream_req.url.host == "127.0.0.1"

--- a/frontend/app.json
+++ b/frontend/app.json
@@ -50,7 +50,6 @@
     ],
     "extra": {
       "apiUrl": "http://46.225.75.29:3000",
-      "polyglotApiUrl": "http://46.225.75.29:3002",
       "router": {},
       "eas": {
         "projectId": "20b68974-631b-4074-83df-64d741f72325"

--- a/frontend/lib/polyglot-api.ts
+++ b/frontend/lib/polyglot-api.ts
@@ -1,13 +1,24 @@
 /**
- * Polyglot API client — separate backend from Alif (different port + DB).
+ * Polyglot API client — separate backend from Alif (different DB + process).
  *
- * Modern Greek, Ancient Greek, and Latin reading-as-mapping. Polyglot runs at
- * `polyglotApiUrl` from expoConfig.extra (defaults to localhost:3001).
+ * Modern Greek, Ancient Greek, and Latin reading-as-mapping. The polyglot
+ * service lives on its own port (3002 in prod) but is fronted by a
+ * transparent reverse proxy mounted at `/polyglot` on the alif backend
+ * — see `backend/app/routers/polyglot_proxy.py`. The client therefore
+ * uses `apiUrl + /polyglot` so iOS / web only needs to know ONE host:port.
+ *
+ * `polyglotApiUrl` in expoConfig.extra remains as an explicit override for
+ * dev setups where alif isn't running (e.g. talking directly to a local
+ * polyglot uvicorn on :3001).
  */
 import Constants from "expo-constants";
 
-export const POLYGLOT_BASE_URL =
-  Constants.expoConfig?.extra?.polyglotApiUrl ?? "http://localhost:3001";
+const ALIF_API_URL: string =
+  Constants.expoConfig?.extra?.apiUrl ?? "http://localhost:3000";
+const POLYGLOT_OVERRIDE: string | undefined =
+  Constants.expoConfig?.extra?.polyglotApiUrl;
+
+export const POLYGLOT_BASE_URL = POLYGLOT_OVERRIDE ?? `${ALIF_API_URL}/polyglot`;
 
 // ─── Types ─────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- New self-contained `backend/app/routers/polyglot_proxy.py` (~110 LOC): pure HTTP passthrough at `/polyglot/*` → `localhost:3002`. No imports from polyglot, no payload introspection, no business logic. Strips hop-by-hop + content-encoding/length headers; surfaces 502 on connect-error and 504 on read-timeout.
- Mounted in `main.py` so `alif:3000/polyglot/api/...` reaches polyglot's `api/...`. iOS / web only needs ONE host:port — sidesteps the EAS dev-client port-allowlist issue.
- Frontend `POLYGLOT_BASE_URL` defaults to `apiUrl + /polyglot`; `polyglotApiUrl` override remains for dev. `polyglotApiUrl` removed from `app.json` (was hard-coded to :3002).

## Test plan
- `cd backend && arch -arm64 .venv/bin/python -m pytest tests/test_polyglot_proxy.py` — 7/7 passing (GET/POST/query/body/status passthrough, 502, 504, Host rewrite).
- `cd backend && arch -arm64 .venv/bin/python -m pytest -q -x` — all 1171 prior alif tests still pass; mount didn't regress anything.
- `cd frontend && npx tsc --noEmit && npx jest --watchman=false` — clean typecheck + 101/101 jest passing.
- After deploy, verify `curl http://46.225.75.29:3000/polyglot/api/languages` returns the 3 polyglot language rows (same JSON as direct `:3002`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)