### PR TITLE
Polyglot: skip front-matter + drop heading tokens from prose

### DIFF
--- a/frontend/app/polyglot.tsx
+++ b/frontend/app/polyglot.tsx
@@ -82,7 +82,15 @@ export default function Polyglot() {
     }
   }, []);
 
-  useEffect(() => { if (storyId != null) loadPage(storyId, 1); }, [storyId, loadPage]);
+  useEffect(() => {
+    if (storyId == null) return;
+    // Land on the first "real content" page (skip copyright / TOC / title
+    // pages) instead of always page 1. Falls back to 1 if the heuristic
+    // didn't surface a content page.
+    const story = stories?.find((s) => s.id === storyId);
+    const startPage = story?.first_content_page_number ?? 1;
+    loadPage(storyId, startPage);
+  }, [storyId, loadPage, stories]);
 
   const handleMark = useCallback(async (state: MarkState) => {
     if (!selected?.lemma_id || !storyId) return;
@@ -180,19 +188,26 @@ export default function Polyglot() {
         <ScrollView ref={scrollRef} contentContainerStyle={styles.pageBody}>
           <View style={styles.column}>
             <Text style={styles.greekText} selectable={false}>
-              {pageData.tokens.map((t, i) => {
-                const isSelected = selected != null && selected.position === t.position;
-                return (
-                  <Text
-                    key={i}
-                    style={isSelected ? styles.tokenSelected : styles.token}
-                    onPress={() => !t.is_punctuation && t.lemma_id && setSelected(t)}
-                  >
-                    {t.surface}
-                    {!t.is_punctuation ? " " : ""}
-                  </Text>
-                );
-              })}
+              {pageData.tokens
+                // Headings (chapter/section titles, running page headers
+                // injected by the PDF extractor) are meta-text; drop them
+                // entirely from the prose flow. Punctuation that sits
+                // inside a heading sentence is dropped too — it'd otherwise
+                // leave orphan periods or numbers floating in the body.
+                .filter((t) => !t.is_heading)
+                .map((t, i) => {
+                  const isSelected = selected != null && selected.position === t.position;
+                  return (
+                    <Text
+                      key={i}
+                      style={isSelected ? styles.tokenSelected : styles.token}
+                      onPress={() => !t.is_punctuation && t.lemma_id && setSelected(t)}
+                    >
+                      {t.surface}
+                      {!t.is_punctuation ? " " : ""}
+                    </Text>
+                  );
+                })}
             </Text>
           </View>
         </ScrollView>

--- a/frontend/lib/polyglot-api.ts
+++ b/frontend/lib/polyglot-api.ts
@@ -45,6 +45,12 @@ export type StorySummary = {
   unknown_count: number;
   status: string;
   created_at: string;
+  /**
+   * First page whose body_src passes the "looks like real reading content"
+   * heuristic — skips copyright pages, blank dividers, all-caps title pages.
+   * When the user opens a story, the reader should land here, not at page 1.
+   */
+  first_content_page_number: number;
 };
 
 export type TokenView = {
@@ -58,6 +64,10 @@ export type TokenView = {
   pos: string | null;
   gloss_en: string | null;
   is_function_word: boolean;
+  /** True iff the quality gate classified this token's sentence as a
+   *  heading (chapter/section title or running header). UI MUST NOT render
+   *  these inline with body prose. */
+  is_heading: boolean;
   is_known: boolean;
   is_acquiring: boolean;
   is_encountered: boolean;

--- a/polyglot/app/routers/texts.py
+++ b/polyglot/app/routers/texts.py
@@ -23,7 +23,7 @@ def list_stories(db: Session = Depends(get_db)):
             .filter(Page.story_id == s.id, Page.processed_at.isnot(None))
             .scalar() or 0
         )
-        out.append(_story_summary(s, processed))
+        out.append(_story_summary(s, processed, db=db))
     return out
 
 
@@ -37,7 +37,7 @@ def import_paste(req: PasteImportRequest, db: Session = Depends(get_db)):
         title=req.title,
         author=req.author,
     )
-    return _story_summary(story, 0)
+    return _story_summary(story, 0, db=db)
 
 
 @router.post("/pdf", response_model=StorySummary)
@@ -53,7 +53,7 @@ def import_pdf(req: PdfImportRequest, db: Session = Depends(get_db)):
         )
     except FileNotFoundError:
         raise HTTPException(status_code=404, detail=f"PDF not found: {req.pdf_path}")
-    return _story_summary(story, 0)
+    return _story_summary(story, 0, db=db)
 
 
 @router.get("/{story_id}", response_model=StorySummary)
@@ -66,7 +66,7 @@ def get_story(story_id: int, db: Session = Depends(get_db)):
         .filter(Page.story_id == story.id, Page.processed_at.isnot(None))
         .scalar() or 0
     )
-    return _story_summary(story, processed)
+    return _story_summary(story, processed, db=db)
 
 
 @router.get("/{story_id}/pages/{page_number}", response_model=PageView)
@@ -143,7 +143,12 @@ def _check_language(db: Session, code: str):
         raise HTTPException(status_code=400, detail=f"Unknown language: {code}")
 
 
-def _story_summary(s: Story, processed_pages: int) -> StorySummary:
+def _story_summary(s: Story, processed_pages: int, db: Session | None = None) -> StorySummary:
+    first_content = (
+        reading_intake.first_content_page_number(db, s.id)
+        if db is not None
+        else 1
+    )
     return StorySummary(
         id=s.id,
         language_code=s.language_code,
@@ -157,4 +162,5 @@ def _story_summary(s: Story, processed_pages: int) -> StorySummary:
         unknown_count=s.unknown_count or 0,
         status=s.status,
         created_at=s.created_at,
+        first_content_page_number=first_content,
     )

--- a/polyglot/app/schemas.py
+++ b/polyglot/app/schemas.py
@@ -50,6 +50,12 @@ class StorySummary(BaseModel):
     unknown_count: int
     status: str
     created_at: datetime
+    # First page that looks like actual reading content rather than
+    # bureaucratic front-matter (copyright pages, blank dividers, TOC, all-
+    # caps title pages). Detected heuristically — see
+    # reading_intake.first_content_page_number. When the user opens a story
+    # they should land on this page, not page 1.
+    first_content_page_number: int = 1
 
 
 # ─── Page view ─────────────────────────────────────────────────────────────
@@ -65,6 +71,10 @@ class TokenView(BaseModel):
     pos: str | None
     gloss_en: str | None
     is_function_word: bool
+    # True when the quality gate classified this token's sentence as a heading
+    # (all-caps + short → chapter/section title or running header). The frontend
+    # SHOULD NOT render these inline with body prose — they're meta-text.
+    is_heading: bool = False
     is_known: bool
     is_acquiring: bool
     is_encountered: bool

--- a/polyglot/app/services/reading_intake.py
+++ b/polyglot/app/services/reading_intake.py
@@ -285,6 +285,7 @@ def _build_token_view(db: Session, page: Page) -> tuple[Page, list[dict]]:
             "pos": lemma.pos if lemma else None,
             "gloss_en": lemma.gloss_en if lemma else None,
             "is_function_word": lemma is not None and lemma.word_category == "function_word",
+            "is_heading": w.quality_note == "heading",
             "is_known": state == "known",
             "is_acquiring": state in ("acquiring", "learning"),
             "is_encountered": state == "encountered",
@@ -435,6 +436,53 @@ def mark_lemma(db: Session, lemma_id: int, state: str, *, fetch_gloss: bool = Tr
         propagate_known_via_cognate(db, lemma_id)
 
     return ulk
+
+
+# ─── Front-matter detection ───────────────────────────────────────────────
+
+
+def _is_content_page(body_src: str | None) -> bool:
+    """True iff this page looks like actual reading material.
+
+    Heuristic on raw extracted text (no NLP, no LLM):
+
+    - At least 200 characters of body — skips blanks and single-line dividers.
+    - At least 100 alphabetic characters — skips number-heavy index pages.
+    - Less than 40% of letters are uppercase — skips title pages, copyright
+      boilerplate (typeset entirely in caps), and pure-heading divider pages.
+
+    The thresholds are tuned for Greek school textbooks where front-matter is
+    typically the Ministry-of-Education copyright page (all caps), a TOC
+    (digit-heavy), a preface, and a chapter title page (caps + image
+    caption). Real prose pages comfortably clear the bar.
+    """
+    if not body_src or len(body_src) < 200:
+        return False
+    letters = [c for c in body_src if c.isalpha()]
+    if len(letters) < 100:
+        return False
+    uppercase_ratio = sum(1 for c in letters if c.isupper()) / len(letters)
+    return uppercase_ratio < 0.40
+
+
+def first_content_page_number(db: Session, story_id: int) -> int:
+    """Return the lowest page_number whose body_src passes ``_is_content_page``.
+
+    Falls back to 1 when the heuristic rejects every page (e.g. a brand-new
+    story where pages still haven't been imported, or a very short text where
+    no page reaches the threshold). The frontend uses this so the user lands
+    on actual reading material instead of a copyright page on first open.
+    """
+    rows = (
+        db.query(Page.page_number, Page.body_src)
+        .filter(Page.story_id == story_id)
+        .order_by(Page.page_number.asc())
+        .all()
+    )
+    for page_number, body_src in rows:
+        if _is_content_page(body_src):
+            return page_number
+    return 1
 
 
 # ─── Page warming (cron) ───────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- New `first_content_page_number(db, story_id)` heuristic (≥200 chars, ≥100 letters, <40% uppercase). Lands the user on actual prose instead of the copyright page.
- Surfaced on `StorySummary` so the frontend uses it as the initial page when entering a story.
- `is_heading` exposed on `TokenView` (from existing `PageWord.quality_note=='heading'`).
- Frontend filters out heading tokens from the body render — chapter titles and running headers no longer pollute the prose flow.

## Test plan
- `arch -arm64 .venv/bin/python -m pytest tests/test_reading_intake.py tests/test_lemma_quality.py -q` — passing (modulo the pre-existing partial-batch test, deselected).
- After deploy, `curl alif:3000/polyglot/api/texts | jq '.[0].first_content_page_number'` should return 11 (the History of the Ancient World textbook's chapter-1 page).
- iOS: open the story → land on chapter 1 prose; tap a word → lookup bar surfaces state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)