### PR TITLE
Polyglot: Haiku body-text cleaner before tokenization

### DIFF
--- a/polyglot/CLAUDE.md
+++ b/polyglot/CLAUDE.md
@@ -55,6 +55,8 @@ These should be preserved across changes:
 
 1. **Lazy page processing.** Pages are tokenized + LLM-verified only when first viewed (`GET /api/texts/{sid}/pages/{n}`). Importing a 300-page textbook must be fast — the cost is paid per-page-view, not upfront. Implemented in `app/services/reading_intake.py:process_page`.
 
+   Two LLM passes happen per page: (a) **body-clean** (Haiku, `body_clean.py`) — strips page numbers, headers, footers, bibliographies, footnote definitions; joins soft-hyphen line breaks; detaches footnote-marker digits fused to words. Cleaned prose lands in `page.body_clean` and the tokenizer reads from there. (b) **quality gate** (Sonnet, `lemma_quality.py`) — per-token lemma verification. The body-clean pass runs first because it dictates what the tokenizer sees; sending raw PyMuPDF text to the tokenizer creates phantom lemmas (`σιτηρών1`, `μη`, `χάνημα`, etc.) the user will never want to learn. Gated by `POLYGLOT_BODY_CLEAN=1` (default on); falls back to raw `body_src` on LLM failure.
+
 2. **Quality gate is the lemmatization safety net.** simplemma misclassifies homographs (χώρα → χωρώ), proper nouns (Τίγρης → τίγρη), POS confusions (adj↔noun). The LLM-in-context gate (`app/services/lemma_quality.py`) catches these. Enabled by `POLYGLOT_QUALITY_GATE=1`. **Do not skip this for "speed" — Alif spent months retroactively fixing bad mappings; we don't redo that mistake here.** Cost per page on Sonnet: ~$0.30-0.50, ~2-3 minutes (gated by Claude Max plan so it's free to the user). Model is switchable via `POLYGLOT_QG_MODEL=haiku` (~10x cheaper) once homograph quality is validated.
 
 3. **Bulk-mark presumes content lemmas only.** `bulk_mark_remaining_known()` skips lemmas where `word_category='function_word'` OR `lemma_bare` is in `FUNCTION_WORD_SETS`. This list is intentionally conservative; add to it if real-world reading surfaces false positives. Heading sentences (≥80% all-caps tokens, ≤10 words) are marked `quality_note='heading'` by the quality gate and should be excluded from review eligibility — they're meta-text, not vocabulary.
@@ -81,6 +83,7 @@ These should be preserved across changes:
 
 | Alif gate | Polyglot status | File / notes |
 |---|---|---|
+| PDF body cleanup (page numbers, headers, footnotes, bibliographies, soft-hyphens) | **Ported (polyglot-original)** | `app/services/body_clean.py` — Haiku via CLI, verbatim-audit on removed segments (soft-hyphen + footnote-digit + control-char tolerant), persisted as `Page.body_clean`. Alif doesn't have this because Alif imports from cleaned corpora rather than raw PDFs. |
 | Lemma quality verification (sentence-context LLM check) | **Ported** | `app/services/lemma_quality.py` |
 | Mapping correction pipeline (`apply_corrections`) | **Ported** | `_apply_verdict()` in lemma_quality.py |
 | Verification failure ≠ success | **Ported** | `_call_claude` returns `None` on failure |

--- a/polyglot/app/database.py
+++ b/polyglot/app/database.py
@@ -52,6 +52,7 @@ _ADDITIVE_COLUMN_DELTAS: list[tuple[str, str, str]] = [
     ("sentences", "sentence_index_in_page", "INTEGER"),
     ("user_lemma_knowledge", "experiment_intro_shown_at", "DATETIME"),
     ("pages", "viewed_at", "DATETIME"),
+    ("pages", "body_clean", "TEXT"),
 ]
 
 # Indexes that should exist once the columns above are present.

--- a/polyglot/app/models.py
+++ b/polyglot/app/models.py
@@ -266,6 +266,7 @@ class Page(Base):
     story_id = Column(Integer, ForeignKey("stories.id"), nullable=False, index=True)
     page_number = Column(Integer, nullable=False)
     body_src = Column(Text, nullable=False)
+    body_clean = Column(Text, nullable=True)               # Haiku-cleaned prose; tokenizer reads from here when set
     processed_at = Column(DateTime, nullable=True)         # tokenized + simplemma lemmatized
     mappings_verified_at = Column(DateTime, nullable=True) # quality gate (LLM-in-context) pass
     viewed_at = Column(DateTime, nullable=True)            # last time user opened the page

--- a/polyglot/app/services/body_clean.py
+++ b/polyglot/app/services/body_clean.py
@@ -1,0 +1,257 @@
+"""LLM body-text cleaner for raw PDF page extractions.
+
+PyMuPDF gives us text that's *physically* correct (every glyph that's in the
+PDF lands in body_src) but *structurally* polluted for a reader: a page
+typically interleaves headers, footers, page numbers, section titles,
+sidebars, footnote markers (superscript digits fused into words like
+``σιτηρών1``), bibliographic citations, and end-of-line soft-hyphens that
+break a single word across two lines (``διαρ-\\nρέουν`` → two tokens, both
+junk). Tokenizing this raw text creates phantom lemmas the user will never
+want to learn.
+
+This service is the structural cleanup pass. For each Page we ask Haiku
+(via Claude CLI, free under Max plan) to return the cleaned reading prose
+plus an audit list of every segment it removed. The cleaned text is what
+``process_page`` then tokenizes.
+
+Hard constraints on the LLM:
+
+- **Verbatim preservation.** The cleaner may DROP segments and REJOIN
+  hyphen-split words. It MUST NOT paraphrase, translate, modernise spelling,
+  re-order sentences, or insert words that aren't in the source.
+- **Audit trail.** Every removed segment is returned verbatim so we can
+  ``body_src.find(seg)`` to verify it was actually in the source. If any
+  removed segment is not a substring of body_src, the cleaner hallucinated
+  and the whole result is discarded (caller falls back to body_src).
+- **Failure ≠ success.** Mirrors Hard Invariant #8: a Haiku timeout or parse
+  error returns ``None``. Callers leave ``page.body_clean`` NULL and tokenize
+  from raw ``body_src``; the next warm-cycle will retry.
+
+Cost: Haiku is ~$1/M input tokens. A typical page is ~3KB ≈ ~1k tokens in +
+~1k tokens out = ~$0.001-0.002 per page. A 300-page textbook costs <$1
+worst case; under Max plan it's free.
+
+Gated by ``POLYGLOT_BODY_CLEAN=1`` (default on once deployed). Override
+model via ``POLYGLOT_BODY_CLEAN_MODEL=haiku`` (default) or ``=sonnet``.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import subprocess
+from dataclasses import dataclass
+
+log = logging.getLogger(__name__)
+
+
+BODY_CLEAN_ENABLED = os.environ.get("POLYGLOT_BODY_CLEAN", "1") == "1"
+TIMEOUT_S = int(os.environ.get("POLYGLOT_BODY_CLEAN_TIMEOUT", "180"))
+
+_MODEL_ALIASES = {
+    "sonnet": "claude-sonnet-4-5-20250929",
+    "haiku": "claude-haiku-4-5",
+}
+
+
+def _resolve_model(raw: str) -> str:
+    return _MODEL_ALIASES.get(raw.strip().lower(), raw)
+
+
+MODEL = _resolve_model(os.environ.get("POLYGLOT_BODY_CLEAN_MODEL", "haiku"))
+
+
+_LANG_DISPLAY = {"el": "Modern Greek", "grc": "Ancient Greek", "la": "Latin"}
+
+
+@dataclass
+class CleanResult:
+    cleaned: str
+    removed: list[str]          # verbatim source segments dropped
+    hyphen_joins: list[str]     # joined-word forms (post-join), for logging
+
+
+def clean_body(body_src: str, language_code: str) -> CleanResult | None:
+    """Run the cleaner on one page's raw body_src. Returns None on LLM
+    failure or audit failure (hallucinated removals). Pure function — no DB.
+
+    Short-circuits to a trivially-cleaned result if body_src is too small to
+    contain pollution (one line, no newlines, ≤200 chars). That covers
+    blank pages and short paste imports — no LLM call worth the latency.
+    """
+    if not body_src or not body_src.strip():
+        return CleanResult(cleaned="", removed=[], hyphen_joins=[])
+    if len(body_src) < 200 and body_src.count("\n") <= 1:
+        return CleanResult(cleaned=body_src.strip(), removed=[], hyphen_joins=[])
+
+    language_name = _LANG_DISPLAY.get(language_code, language_code)
+
+    schema = {
+        "type": "object",
+        "properties": {
+            "cleaned": {"type": "string"},
+            "removed": {
+                "type": "array",
+                "items": {"type": "string"},
+            },
+            "hyphen_joins": {
+                "type": "array",
+                "items": {"type": "string"},
+            },
+        },
+        "required": ["cleaned", "removed"],
+    }
+    prompt = _build_prompt(body_src, language_name)
+    cmd = [
+        "claude", "-p",
+        "--output-format", "json",
+        "--model", MODEL,
+        "--json-schema", json.dumps(schema),
+        prompt,
+    ]
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=TIMEOUT_S)
+    except subprocess.TimeoutExpired:
+        log.error("body_clean timed out after %ds (%d chars)", TIMEOUT_S, len(body_src))
+        return None
+    if proc.returncode != 0:
+        log.error("body_clean CLI failed: %s", proc.stderr[:500])
+        return None
+
+    try:
+        wrapper = json.loads(proc.stdout)
+    except json.JSONDecodeError as e:
+        log.error("body_clean envelope parse failed: %s\n%s", e, proc.stdout[:500])
+        return None
+    if not isinstance(wrapper, dict):
+        log.error("body_clean unexpected CLI shape: %s", proc.stdout[:300])
+        return None
+
+    structured = wrapper.get("structured_output")
+    if not isinstance(structured, dict):
+        # Legacy `result` fallback, matches lemma_quality._call_claude pattern.
+        result_str = wrapper.get("result", "")
+        try:
+            structured = json.loads(result_str) if result_str else None
+        except json.JSONDecodeError:
+            structured = None
+    if not isinstance(structured, dict):
+        log.error("body_clean no structured output: %s", proc.stdout[:300])
+        return None
+
+    cleaned = structured.get("cleaned")
+    removed = structured.get("removed") or []
+    hyphen_joins = structured.get("hyphen_joins") or []
+    if not isinstance(cleaned, str) or not isinstance(removed, list):
+        log.error("body_clean wrong field types in structured output")
+        return None
+
+    if not _verify_removals(body_src, removed):
+        log.warning(
+            "body_clean discarded — at least one removed segment is not "
+            "verbatim in body_src (possible paraphrase)"
+        )
+        return None
+
+    return CleanResult(
+        cleaned=cleaned.strip(),
+        removed=[r for r in removed if isinstance(r, str)],
+        hyphen_joins=[h for h in hyphen_joins if isinstance(h, str)],
+    )
+
+
+def _verify_removals(body_src: str, removed: list) -> bool:
+    """Every removed segment must be a substring of body_src. If any isn't,
+    the LLM hallucinated content — discard the whole result.
+
+    Tolerated normalisations on both sides of the comparison:
+
+    1. **Whitespace collapse.** A citation that wraps across two lines in
+       the source ("Ηρόδοτος, Α, 193 μετ.\\nΑγγ. Βλάχου") arrives from the
+       LLM as a single line; collapsing runs of whitespace to one space on
+       both sides masks the layout drift.
+    2. **Soft-hyphen joining.** Haiku silently joins line-break hyphens
+       inside removed segments too: source ``δυναμώ-\\nνει`` shows up as
+       ``δυναμώνει`` in the returned segment. We strip ``-\\n`` from both
+       sides before comparing so that's not a false hallucination.
+    3. **Footnote-digit detach.** A word with a fused footnote marker
+       (``γεράνια1``) is returned by Haiku as the bare word (``γεράνια``)
+       inside removed segments too — same DETACH rule the prompt asks for
+       on the kept prose. We strip the trailing digit on both sides.
+
+    These are the same structural normalisations the LLM is allowed to do
+    on the *kept* prose; we extend them to the audit so we don't punish
+    consistent behaviour. We do NOT loosen further (no fuzzy-match, no
+    word-overlap thresholds) — the whole point of the audit is to catch
+    paraphrasing.
+    """
+    if not removed:
+        return True
+    src_norm = _normalize_for_audit(body_src)
+    for seg in removed:
+        if not isinstance(seg, str) or not seg.strip():
+            continue
+        if seg in body_src:
+            continue
+        if _normalize_for_audit(seg) in src_norm:
+            continue
+        log.warning("body_clean removal not found in source: %r", seg[:160])
+        return False
+    return True
+
+
+_SOFTHYPHEN_LINEBREAK = re.compile(r"[-‐‑–][ \t]*\n[ \t]*")
+# Trailing digit(s) immediately after a letter, when followed by a non-word
+# char or end-of-string — the footnote-marker pattern (γεράνια1. → γεράνια.).
+# `[^\W\d_]` is the Unicode-letter idiom in plain `re` (no `regex` dependency).
+_FOOTNOTE_DIGIT = re.compile(r"([^\W\d_])\d+(?=\W|$)", re.UNICODE)
+# C0/C1 control chars PyMuPDF leaks from PDFs (e.g. BEL=0x07 in front of
+# footnote markers). Keep \t and \n so the whitespace collapse handles them
+# uniformly.
+_CONTROL_CHARS = re.compile(r"[\x00-\x08\x0B-\x1F\x7F-\x9F]")
+
+
+def _normalize_for_audit(s: str) -> str:
+    """Apply every transformation Haiku is allowed to silently perform on
+    text it keeps OR removes: control-char strip (PyMuPDF leaks BEL etc.),
+    soft-hyphen joining, footnote-digit detach, whitespace collapse. Used
+    for the verbatim audit only — never for storage."""
+    s = _CONTROL_CHARS.sub("", s)
+    s = _SOFTHYPHEN_LINEBREAK.sub("", s)
+    s = _FOOTNOTE_DIGIT.sub(r"\1", s)
+    return " ".join(s.split())
+
+
+def _build_prompt(body_src: str, language_name: str) -> str:
+    return f"""You are a {language_name} reading-app text cleaner. The input below is one page extracted from a PDF textbook by PyMuPDF. Your job is to return ONLY the body prose a learner should read — strip pollution that was inlined by the extractor.
+
+DROP (return in `removed`, verbatim from the source):
+- Standalone page numbers, running headers, running footers
+- Section/chapter numbers and titles (e.g. "1.1 Η χώρα", "Ι. ΟΙ ΠΟΛΙΤΙΣΜΟΙ"), even when they appear mid-flow
+- Footnote definitions at the bottom of the page (e.g. "1. γεράνι ή γερανός: ανυψωτικό μηχάνημα.")
+- Bibliographic citations attached to inline quotes (e.g. "Ηρόδοτος, Α, 193 μετ. Αγγ. Βλάχου, εκδ. Δ. Παπαδήμα.")
+- Caption/figure labels, "Πηγή:", "Εικόνα N", "Πίνακας N"
+- Sidebar headers that duplicate the section title
+
+JOIN (silently, but list each joined form in `hyphen_joins`):
+- End-of-line soft-hyphens that split a single word: `διαρ-\\nρέουν` → `διαρρέουν`, `ανατολι-\\nκά` → `ανατολικά`. The hyphen must be at the end of a line AND followed by an alphabetic letter on the next line.
+- DO NOT join real compound-word hyphens that appear mid-line (e.g. proper-noun ranges, "Bizans-Kayseri" style).
+
+DETACH (silently):
+- Footnote markers fused into words. PyMuPDF extracts superscript digits as plain digits stuck to the preceding word: `σιτηρών1` → `σιτηρών`, `γεράνια1` → `γεράνια`, `θεός2` → `θεός`. Drop the trailing digit(s) when the rest of the token is a real {language_name} word.
+
+PRESERVE EXACTLY:
+- Every other character of the body prose. Do not paraphrase, modernise spelling, translate, re-order sentences, or "fix" punctuation. Whitespace may be normalised (collapse runs of spaces/newlines into single spaces or paragraph breaks), but no actual letters may change.
+- If a section title is the ONLY content on the page (a chapter divider), return it as the cleaned text and put nothing in `removed`. Don't return an empty page just because there's no prose.
+
+OUTPUT:
+- `cleaned`: the prose, ready to read. Paragraphs separated by single blank lines.
+- `removed`: each dropped segment verbatim from the source. One entry per removed run; don't merge unrelated removals into one string.
+- `hyphen_joins`: each post-join word form (e.g. "διαρρέουν"). Optional; helps with debugging.
+
+SOURCE TEXT:
+\"\"\"
+{body_src}
+\"\"\"
+"""

--- a/polyglot/app/services/reading_intake.py
+++ b/polyglot/app/services/reading_intake.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from sqlalchemy.orm import Session
 
 from app.models import Lemma, Story, Page, PageWord, UserLemmaKnowledge
+from app.services import body_clean as body_clean_svc
 from app.services import pdf_extract
 from app.services.cognate_detector import link_intra_greek_cognates, propagate_known_via_cognate
 from app.services import lemma_quality
@@ -126,8 +127,26 @@ def process_page(db: Session, page: Page, *, force: bool = False) -> Page:
     provider: NLPProvider = get_provider(page.story.language_code)
     language_code = page.story.language_code
 
+    # Phase 0: structural cleanup (LLM). Strips page numbers, headers, footers,
+    # bibliographies, footnote definitions; joins soft-hyphen line breaks;
+    # detaches footnote-marker digits fused into words. Persisted on the Page
+    # so re-tokenization doesn't pay the LLM cost twice. Falls back to
+    # body_src on LLM failure — tokenizer still works, just on noisier input.
+    if body_clean_svc.BODY_CLEAN_ENABLED and (page.body_clean is None or force):
+        result = body_clean_svc.clean_body(page.body_src, language_code)
+        if result is not None:
+            page.body_clean = result.cleaned
+            db.commit()
+            log.info(
+                "Cleaned page %d: %d→%d chars, %d removed segments, %d hyphen-joins",
+                page.id, len(page.body_src), len(result.cleaned),
+                len(result.removed), len(result.hyphen_joins),
+            )
+
+    source_text = page.body_clean if page.body_clean else page.body_src
+
     # Phase 1: pure compute
-    sentences = _split_into_sentences(page.body_src)
+    sentences = _split_into_sentences(source_text)
     tokens_with_meta: list[tuple[int, Token, int]] = []  # (sentence_idx, token, global_pos)
     global_pos = 0
     for s_idx, sentence in enumerate(sentences):

--- a/polyglot/scripts/backfill_body_clean.py
+++ b/polyglot/scripts/backfill_body_clean.py
@@ -1,0 +1,191 @@
+"""Backfill body_clean on existing Pages and re-tokenize them.
+
+The Haiku body-cleaner is new (2026-05-20). Pages imported before it
+existed have NULL body_clean and their PageWord / Sentence rows reflect
+the raw polluted text (page numbers, footnote markers, soft-hyphens
+breaking words, bibliographic citations, etc.). This script re-cleans
+every Page, then resets the tokenization so the lazy pipeline re-runs
+from the cleaned text on the next page view.
+
+Per page, the script:
+
+1. Calls ``body_clean.clean_body(page.body_src, language_code)`` and
+   stores the result in ``page.body_clean``. Skips pages where
+   body_clean is already set unless ``--force``.
+2. Deletes harvested ``Sentence`` rows attached to the page (and their
+   ``SentenceWord`` children via cascade). Without this, harvested
+   sentences would point at PageWords that no longer exist.
+3. Deletes ``PageWord`` rows for the page.
+4. Nulls ``processed_at``, ``mappings_verified_at``, ``quality_gate_failures``.
+   The next ``GET /api/texts/{sid}/pages/{n}`` triggers re-tokenization
+   from ``body_clean`` and the quality gate from scratch.
+
+The currently-unreferenced Lemmas (junk like ``σιτηρών1``) are left in
+place — a separate cleanup script can prune them once the dust settles.
+They're inert: nothing in the new pipeline will create a PageWord pointing
+at them.
+
+Usage::
+
+    .venv/bin/python scripts/backfill_body_clean.py --language el --dry-run
+    .venv/bin/python scripts/backfill_body_clean.py --language el --story-id 1
+    .venv/bin/python scripts/backfill_body_clean.py --language el --max-pages 5
+
+Cost: one Haiku call per page (~$0.001-0.002 raw, free under Max plan).
+Latency: ~3-5s per page including subprocess startup, so a 300-page
+textbook takes ~15-25 minutes. Run as a background job (nohup) when
+processing a full book on the server.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+from datetime import datetime, timezone
+
+from app.database import SessionLocal
+from app.models import Page, PageWord, Sentence, Story
+from app.services import body_clean
+
+
+def _reset_page_processing(db, page: Page) -> int:
+    """Delete PageWord + harvested Sentence rows for the page. Returns the
+    number of PageWord rows deleted (useful for progress logging)."""
+    sentence_ids = [
+        s.id for s in db.query(Sentence).filter(Sentence.page_id == page.id).all()
+    ]
+    if sentence_ids:
+        # SentenceWord cascade via FK is set on the relationship; explicit
+        # delete here keeps it independent of ORM-cascade configuration.
+        from app.models import SentenceWord
+        db.query(SentenceWord).filter(
+            SentenceWord.sentence_id.in_(sentence_ids)
+        ).delete(synchronize_session=False)
+        db.query(Sentence).filter(Sentence.id.in_(sentence_ids)).delete(
+            synchronize_session=False
+        )
+    pw_count = (
+        db.query(PageWord).filter(PageWord.page_id == page.id).delete(
+            synchronize_session=False
+        )
+    )
+    page.processed_at = None
+    page.mappings_verified_at = None
+    page.quality_gate_failures = 0
+    page.total_words = 0
+    return pw_count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Backfill body_clean on existing Pages.")
+    parser.add_argument("--language", default="el", help="Language code. Default: el")
+    parser.add_argument("--story-id", type=int, default=None,
+                        help="Only process this story_id. Default: all active stories.")
+    parser.add_argument("--max-pages", type=int, default=None,
+                        help="Stop after this many pages cleaned (across all stories).")
+    parser.add_argument("--force", action="store_true",
+                        help="Re-clean pages whose body_clean is already set.")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Report what would change without calling the LLM or writing.")
+    parser.add_argument("--verbose", "-v", action="store_true")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    log = logging.getLogger("backfill_body_clean")
+
+    if not body_clean.BODY_CLEAN_ENABLED and not args.dry_run:
+        log.error(
+            "POLYGLOT_BODY_CLEAN is not enabled — the cleaner is gated off. "
+            "Set POLYGLOT_BODY_CLEAN=1 to actually call the LLM.",
+        )
+        return 2
+
+    db = SessionLocal()
+    summary = {
+        "language_code": args.language,
+        "pages_examined": 0,
+        "pages_cleaned": 0,
+        "pages_skipped_already_clean": 0,
+        "pages_failed": 0,
+        "pagewords_deleted": 0,
+        "errors": [],
+    }
+
+    try:
+        story_q = db.query(Story).filter(Story.language_code == args.language)
+        if args.story_id is not None:
+            story_q = story_q.filter(Story.id == args.story_id)
+        else:
+            story_q = story_q.filter(Story.status == "active")
+        stories = story_q.order_by(Story.created_at.asc()).all()
+
+        for story in stories:
+            log.info("Story %d (%s): %d pages total",
+                     story.id, story.title, story.page_count)
+            pages = (
+                db.query(Page)
+                .filter(Page.story_id == story.id)
+                .order_by(Page.page_number.asc())
+                .all()
+            )
+            for page in pages:
+                if args.max_pages is not None and summary["pages_cleaned"] >= args.max_pages:
+                    log.info("Hit --max-pages cap of %d, stopping.", args.max_pages)
+                    break
+                summary["pages_examined"] += 1
+                if page.body_clean is not None and not args.force:
+                    summary["pages_skipped_already_clean"] += 1
+                    continue
+
+                if args.dry_run:
+                    log.info("[dry-run] would clean page %d of story %d (%d chars)",
+                             page.page_number, story.id, len(page.body_src or ""))
+                    summary["pages_cleaned"] += 1
+                    continue
+
+                try:
+                    result = body_clean.clean_body(page.body_src, args.language)
+                except Exception as e:
+                    log.exception("body_clean threw for page %d of story %d", page.page_number, story.id)
+                    summary["pages_failed"] += 1
+                    summary["errors"].append((story.id, page.page_number, repr(e)))
+                    continue
+
+                if result is None:
+                    log.warning("body_clean returned None for page %d of story %d",
+                                page.page_number, story.id)
+                    summary["pages_failed"] += 1
+                    summary["errors"].append(
+                        (story.id, page.page_number, "clean_body returned None")
+                    )
+                    continue
+
+                page.body_clean = result.cleaned
+                pw_deleted = _reset_page_processing(db, page)
+                summary["pagewords_deleted"] += pw_deleted
+                summary["pages_cleaned"] += 1
+                db.commit()
+                log.info(
+                    "Cleaned story=%d page=%d: %d→%d chars, %d removed, "
+                    "%d hyphen-joins, %d PageWords purged",
+                    story.id, page.page_number,
+                    len(page.body_src or ""), len(result.cleaned),
+                    len(result.removed), len(result.hyphen_joins), pw_deleted,
+                )
+            if args.max_pages is not None and summary["pages_cleaned"] >= args.max_pages:
+                break
+    finally:
+        db.close()
+
+    summary["finished_at"] = datetime.now(timezone.utc).isoformat()
+    print(json.dumps(summary, ensure_ascii=False, indent=2, default=str))
+    return 0 if summary["pages_failed"] == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/polyglot/tests/test_body_clean.py
+++ b/polyglot/tests/test_body_clean.py
@@ -1,0 +1,280 @@
+"""Tests for the LLM body-text cleaner.
+
+CLI subprocess is mocked everywhere except the explicit `slow` test which
+hits a real Claude CLI. The shape of the mock matches what
+`lemma_quality._call_claude` expects from `claude -p --output-format json
+--json-schema`: a `structured_output` dict at the top level (or a JSON-string
+`result` field as the legacy fallback).
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from app.services import body_clean
+
+
+def _fake_proc(structured: dict, returncode: int = 0, stderr: str = ""):
+    class FakeProc:
+        pass
+
+    FakeProc.returncode = returncode
+    FakeProc.stderr = stderr
+    FakeProc.stdout = json.dumps({"structured_output": structured, "result": ""})
+    return FakeProc
+
+
+def test_short_text_short_circuits_no_llm_call(monkeypatch):
+    """Tiny pasted snippets shouldn't pay the LLM tax — they almost never
+    carry the pollution we built this for."""
+    called = {"n": 0}
+
+    def fake_run(*args, **kwargs):
+        called["n"] += 1
+        raise AssertionError("subprocess should not be called for short input")
+
+    monkeypatch.setattr(body_clean.subprocess, "run", fake_run)
+    out = body_clean.clean_body("Καλημέρα κόσμε", "el")
+    assert out is not None
+    assert out.cleaned == "Καλημέρα κόσμε"
+    assert out.removed == []
+    assert called["n"] == 0
+
+
+def test_empty_input_returns_empty_cleaned(monkeypatch):
+    monkeypatch.setattr(body_clean.subprocess, "run",
+                        lambda *a, **k: pytest.fail("no LLM for empty input"))
+    out = body_clean.clean_body("   \n  ", "el")
+    assert out is not None
+    assert out.cleaned == ""
+
+
+def test_happy_path_removes_and_joins(monkeypatch):
+    src = (
+        "10\n"
+        "1.1 Η χώρα\n"
+        "Μεσοποταμία ονομάστηκε για πρώτη φορά από \n"
+        "τους αρχαίους Έλληνες. Ο Τίγρης διαρ-\n"
+        "ρέουν στα ανατολι-\n"
+        "κά μέρη. σιτηρών1.\n"
+        "1. γεράνι ή γερανός: ανυψωτικό μηχάνημα.\n"
+    )
+    structured = {
+        "cleaned": (
+            "Μεσοποταμία ονομάστηκε για πρώτη φορά από "
+            "τους αρχαίους Έλληνες. Ο Τίγρης διαρρέουν στα ανατολικά μέρη. σιτηρών."
+        ),
+        "removed": [
+            "10",
+            "1.1 Η χώρα",
+            "1. γεράνι ή γερανός: ανυψωτικό μηχάνημα.",
+        ],
+        "hyphen_joins": ["διαρρέουν", "ανατολικά"],
+    }
+    monkeypatch.setattr(body_clean.subprocess, "run",
+                        lambda *a, **k: _fake_proc(structured))
+    out = body_clean.clean_body(src, "el")
+    assert out is not None
+    assert "διαρρέουν" in out.cleaned
+    assert "ανατολικά" in out.cleaned
+    assert "10" not in out.cleaned
+    assert "γεράνι ή γερανός" not in out.cleaned
+    assert len(out.removed) == 3
+    assert out.hyphen_joins == ["διαρρέουν", "ανατολικά"]
+
+
+def test_hallucinated_removal_discards_result(monkeypatch):
+    """If the LLM claims to have removed text that wasn't in the source,
+    discard the whole result — it likely paraphrased."""
+    src = "Μεσοποταμία ονομάστηκε για πρώτη φορά."
+    structured = {
+        "cleaned": "Mesopotamia was first named.",
+        "removed": ["This string never existed in the source"],
+        "hyphen_joins": [],
+    }
+    monkeypatch.setattr(body_clean.subprocess, "run",
+                        lambda *a, **k: _fake_proc(structured))
+    out = body_clean.clean_body(src + "\n\nfiller to clear the short-input bypass " * 10, "el")
+    assert out is None
+
+
+def test_whitespace_collapsed_removals_still_match(monkeypatch):
+    """A bibliographic citation that spans a line break in the source should
+    still match when the LLM returns it as a single normalised line."""
+    src = (
+        "Real prose here that's long enough to skip the bypass. "
+        "Lorem ipsum dolor sit amet, consectetur adipiscing elit.\n"
+        "Ηρόδοτος, Α, 193 μετ. Αγγ. Βλάχου,\n"
+        "εκδ. Δ. Παπαδήμα.\n"
+    )
+    structured = {
+        "cleaned": "Real prose here that's long enough to skip the bypass. Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+        "removed": ["Ηρόδοτος, Α, 193 μετ. Αγγ. Βλάχου, εκδ. Δ. Παπαδήμα."],
+        "hyphen_joins": [],
+    }
+    monkeypatch.setattr(body_clean.subprocess, "run",
+                        lambda *a, **k: _fake_proc(structured))
+    out = body_clean.clean_body(src, "el")
+    assert out is not None
+    assert "Ηρόδοτος" not in out.cleaned
+
+
+def test_softhyphen_inside_removed_segment_passes_audit(monkeypatch):
+    """Haiku silently joins line-break hyphens inside removed segments too:
+    a sidebar quote containing ``δυναμώ-\\nνει`` arrives back as
+    ``δυναμώνει``. The audit must tolerate that, otherwise every page
+    with a removed sidebar containing a hyphen-broken word is discarded."""
+    src = (
+        "Real chapter prose here that's long enough to clear the bypass. "
+        "Lorem ipsum dolor sit amet consectetur adipiscing elit.\n"
+        "Στην Ασσυρία βρέχει λίγο κι\n"
+        "αυτό το νερό τρέφει τη ρίζα του\n"
+        "σιταριού. Ποτίζεται όμως με το\n"
+        "νερό του ποταμού που δυναμώ-\n"
+        "νει τα σπαρτά κι έτσι ωριμάζει\n"
+        "το σιτάρι.\n"
+    )
+    structured = {
+        "cleaned": "Real chapter prose here that's long enough to clear the bypass. Lorem ipsum dolor sit amet consectetur adipiscing elit.",
+        # The returned segment has the soft-hyphen already joined (δυναμώνει
+        # instead of δυναμώ-\nνει) and whitespace collapsed.
+        "removed": [
+            "Στην Ασσυρία βρέχει λίγο κι αυτό το νερό τρέφει τη ρίζα του σιταριού. Ποτίζεται όμως με το νερό του ποταμού που δυναμώνει τα σπαρτά κι έτσι ωριμάζει το σιτάρι.",
+        ],
+        "hyphen_joins": [],
+    }
+    monkeypatch.setattr(body_clean.subprocess, "run",
+                        lambda *a, **k: _fake_proc(structured))
+    out = body_clean.clean_body(src, "el")
+    assert out is not None, "audit should accept hyphen-joined removed segments"
+    assert "δυναμώνει" not in out.cleaned
+    assert "Ασσυρία" not in out.cleaned
+
+
+def test_footnote_digit_detach_inside_removed_segment_passes_audit(monkeypatch):
+    """Same idea as soft-hyphen: Haiku detaches footnote-marker digits
+    (``γεράνια1`` → ``γεράνια``) inside removed segments. The audit must
+    tolerate that or every sidebar with a marker gets discarded."""
+    src = (
+        "Real chapter prose here that's long enough to clear the bypass. "
+        "Lorem ipsum dolor sit amet consectetur adipiscing elit.\n"
+        "βγάζουν με το χέρι ή με γεράνια1. Ολόκληρη η Βαβυλωνία.\n"
+    )
+    structured = {
+        "cleaned": "Real chapter prose here that's long enough to clear the bypass. Lorem ipsum dolor sit amet consectetur adipiscing elit.",
+        "removed": ["βγάζουν με το χέρι ή με γεράνια. Ολόκληρη η Βαβυλωνία."],
+        "hyphen_joins": [],
+    }
+    monkeypatch.setattr(body_clean.subprocess, "run",
+                        lambda *a, **k: _fake_proc(structured))
+    out = body_clean.clean_body(src, "el")
+    assert out is not None, "audit should accept footnote-digit-stripped removed segments"
+    assert "γεράνια" not in out.cleaned
+    assert "Βαβυλωνία" not in out.cleaned
+
+
+def test_control_char_in_source_passes_audit(monkeypatch):
+    """PyMuPDF leaks C0 control chars (BEL=0x07 in front of footnote markers,
+    among others). Haiku correctly drops them; audit shouldn't punish that."""
+    src = (
+        "Real chapter prose here that's long enough to clear the bypass. "
+        "Lorem ipsum dolor sit amet consectetur adipiscing elit.\n"
+        "Παπαδήμα. 1. \x07γεράνι ή γερανός: ανυψωτικό μηχάνημα.\n"
+    )
+    structured = {
+        "cleaned": "Real chapter prose here that's long enough to clear the bypass. Lorem ipsum dolor sit amet consectetur adipiscing elit.",
+        "removed": [
+            "Παπαδήμα.",
+            "1. γεράνι ή γερανός: ανυψωτικό μηχάνημα.",
+        ],
+        "hyphen_joins": [],
+    }
+    monkeypatch.setattr(body_clean.subprocess, "run",
+                        lambda *a, **k: _fake_proc(structured))
+    out = body_clean.clean_body(src, "el")
+    assert out is not None, "audit should accept BEL-stripped removed segments"
+    assert "γεράνι" not in out.cleaned
+
+
+def test_cli_nonzero_returncode_returns_none(monkeypatch):
+    class FakeProc:
+        returncode = 1
+        stderr = "boom"
+        stdout = ""
+
+    monkeypatch.setattr(body_clean.subprocess, "run",
+                        lambda *a, **k: FakeProc())
+    out = body_clean.clean_body("a" * 500 + "\n" * 5, "el")
+    assert out is None
+
+
+def test_cli_timeout_returns_none(monkeypatch):
+    import subprocess as _sp
+
+    def fake_run(*a, **k):
+        raise _sp.TimeoutExpired(cmd="claude", timeout=180)
+
+    monkeypatch.setattr(body_clean.subprocess, "run", fake_run)
+    out = body_clean.clean_body("a" * 500 + "\n" * 5, "el")
+    assert out is None
+
+
+def test_unparseable_envelope_returns_none(monkeypatch):
+    class FakeProc:
+        returncode = 0
+        stderr = ""
+        stdout = "not json at all"
+
+    monkeypatch.setattr(body_clean.subprocess, "run",
+                        lambda *a, **k: FakeProc())
+    out = body_clean.clean_body("a" * 500 + "\n" * 5, "el")
+    assert out is None
+
+
+def test_legacy_result_field_fallback(monkeypatch):
+    """Older CLI versions put the JSON in `result` as a string instead of
+    `structured_output`. The cleaner accepts both."""
+    structured = {"cleaned": "ok", "removed": [], "hyphen_joins": []}
+    payload = json.dumps({"structured_output": None, "result": json.dumps(structured)})
+
+    class FakeProc:
+        returncode = 0
+        stderr = ""
+        stdout = payload
+
+    monkeypatch.setattr(body_clean.subprocess, "run",
+                        lambda *a, **k: FakeProc())
+    out = body_clean.clean_body("a" * 500 + "\n" * 5, "el")
+    assert out is not None
+    assert out.cleaned == "ok"
+
+
+# ─── Integration: real Claude CLI (slow, marked) ─────────────────────────
+
+@pytest.mark.slow
+def test_real_haiku_cleans_greek_textbook_page():
+    """Actually call the Claude CLI on the screenshot's page-11 prose. Skipped
+    in the fast suite; runs in the slow lane to catch real-world regressions
+    in prompt design."""
+    src = (
+        "10\n"
+        "Ι. ΟΙ ΠΟΛΙΤΙΣΜΟΙ ΤΗΣ ΕΓΓΥΣ ΑΝΑΤΟΛΗΣ\n"
+        "1.1 Η χώρα\n"
+        "Μεσοποταμία ονομάστηκε για πρώτη φορά από τους αρχαίους Έλληνες "
+        "η χώρα την οποία διαρρέουν δύο μεγάλοι ποταμοί, ο Τίγρης και ο Ευφράτης. "
+        "Ωστόσο, η άρδευση της γης από τα νερά των ποταμών μετέβαλε τις άγονες "
+        "εκτάσεις σε εύφορες για την παραγωγή σιτηρών1.\n"
+        "Ηρόδοτος, Α, 193 μετ. Αγγ. Βλάχου, εκδ. Δ. Παπαδήμα.\n"
+        "1. γεράνι ή γερανός: ανυψωτικό μηχάνημα.\n"
+    )
+    out = body_clean.clean_body(src, "el")
+    assert out is not None
+    assert "10" not in out.cleaned.split("\n")[0]
+    assert "ΠΟΛΙΤΙΣΜΟΙ" not in out.cleaned
+    assert "Ηρόδοτος" not in out.cleaned
+    assert "γεράνι ή γερανός" not in out.cleaned
+    assert "Μεσοποταμία" in out.cleaned
+    assert "σιτηρών" in out.cleaned
+    # Footnote digit detached:
+    assert "σιτηρών1" not in out.cleaned


### PR DESCRIPTION
## Summary

PyMuPDF extracts raw page text correctly per-glyph but structurally polluted: page numbers, section headers, footnote markers fused to words (`σιτηρών1`), end-of-line soft-hyphens splitting one word across two tokens, bibliographic citations inlined as prose, footnote definitions trailing the page. Tokenizing that junk creates phantom Lemma rows the user will never want to learn — and the recent render-layer fixes (fd473bc) couldn't help because the damage was already done in the DB.

New `app/services/body_clean.py` calls **Haiku via Claude CLI with `--json-schema`** before tokenization. The LLM is constrained to drop pollution, join soft-hyphens, detach footnote-marker digits, and preserve every other letter verbatim. Cleaned prose lands in a new `Page.body_clean` column and the tokenizer reads from there.

## Audit safety net

Hallucination/paraphrasing is the obvious failure mode. The LLM also returns every removed segment verbatim from the source; the cleaner checks each is actually a substring of `body_src` (modulo four explicit normalisations the LLM is allowed to silently perform: control-char strip, soft-hyphen join, footnote-digit detach, whitespace collapse). If any segment fails the audit, the whole result is discarded and the caller falls back to raw `body_src` — page is still readable, just noisier. Mirrors the project's "verification failure ≠ success" invariant.

## End-to-end result

Story 1 page 11 (Greek "Ιστορία του Αρχαίου Κόσμου"): 3110 → 2010 chars, page number / chapter title / subsection title / sidebar header / Herodotus quote / `Ηρόδοτος, Α, 193 μετ. Αγγ. Βλάχου, εκδ. Δ. Παπαδήμα.` citation / `1. γεράνι ή γερανός: ανυψωτικό μηχάνημα.` footnote all gone. Two clean paragraphs of prose remain; `διαρρέουν`, `ανατολικά`, `σπουδαιότερο` and others correctly rejoined; `σιτηρών1` → `σιτηρών`.

## Backfill

`scripts/backfill_body_clean.py` re-cleans every existing Page and resets its tokenization (deletes PageWord + harvested Sentence rows, nulls `processed_at` + `mappings_verified_at`) so the lazy pipeline re-runs from the cleaned text on next view. `--dry-run`, `--story-id`, `--max-pages`, `--force` flags. Orphaned junk lemmas (`σιτηρών1` etc.) left for a follow-up prune.

## Cost / latency

~\$0.001-0.002/page on Haiku (free under Max plan), ~3-5s/page including CLI startup. 298-page Greek textbook ≈ 15-25 min as a background job.

## Tests

12 unit tests covering short-circuit, audit hallucination detection, the three audit-normalisation cases (soft-hyphen / footnote-digit / BEL control char), CLI envelope parsing, timeout & error paths, and legacy `result` field fallback. One `@pytest.mark.slow` integration test hits real Haiku on the page-11 fixture.