### PR TITLE
Alif: reject letter-free OCR tokens (page numbers, ISBNs)

### DIFF
--- a/backend/app/services/ocr_service.py
+++ b/backend/app/services/ocr_service.py
@@ -340,7 +340,12 @@ def _step1_extract_words(image_bytes: bytes) -> list[str]:
     cleaned = []
     for w in raw:
         sanitized, warnings = sanitize_arabic_word(w)
-        if sanitized and "multi_word" not in warnings and "too_short" not in warnings:
+        if (
+            sanitized
+            and "multi_word" not in warnings
+            and "too_short" not in warnings
+            and "no_letters" not in warnings
+        ):
             cleaned.append(sanitized)
     return cleaned, page_number
 
@@ -620,9 +625,14 @@ def process_textbook_page(
             if not arabic:
                 continue
 
-            # Sanitize: strip punctuation, reject multi-word
+            # Sanitize: strip punctuation, reject multi-word + letter-free tokens
             arabic, san_warnings = sanitize_arabic_word(arabic)
-            if not arabic or "multi_word" in san_warnings or "too_short" in san_warnings:
+            if (
+                not arabic
+                or "multi_word" in san_warnings
+                or "too_short" in san_warnings
+                or "no_letters" in san_warnings
+            ):
                 continue
 
             # Compute bare form and get base_lemma from morphological analysis
@@ -1040,7 +1050,12 @@ def process_batch(
             continue
 
         arabic, san_warnings = sanitize_arabic_word(arabic)
-        if not arabic or "multi_word" in san_warnings or "too_short" in san_warnings:
+        if (
+            not arabic
+            or "multi_word" in san_warnings
+            or "too_short" in san_warnings
+            or "no_letters" in san_warnings
+        ):
             continue
 
         bare = compute_bare_form(arabic)

--- a/backend/app/services/sentence_validator.py
+++ b/backend/app/services/sentence_validator.py
@@ -267,6 +267,13 @@ def sanitize_arabic_word(text: str) -> tuple[str, list[str]]:
     if not cleaned:
         return "", ["empty_after_clean"]
 
+    # Reject tokens with no letters — Arabic-Indic numerals (١٤, ٨٢٦١٤٩٣٥),
+    # ASCII digits, ligature/marks-only fragments. OCR routinely emits these
+    # as "words" from page numbers, ISBNs, footnote markers.
+    if not _WORD_CHAR.search(cleaned):
+        warnings.append("no_letters")
+        return cleaned, warnings
+
     # Reject single-character bare forms — typically abbreviations
     # (ج for plural, ص for page, م for year, etc.) not real vocabulary
     bare = normalize_arabic(cleaned)

--- a/backend/app/services/story_service.py
+++ b/backend/app/services/story_service.py
@@ -37,6 +37,7 @@ from app.services.sentence_validator import (
     strip_tatweel,
     tokenize,
     _is_function_word,
+    _WORD_CHAR,
     lookup_lemma,
 )
 from app.services.morphology import find_best_db_match, get_word_features, is_valid_root
@@ -301,7 +302,7 @@ def _import_unknown_words(
         if sw.lemma_id is not None or sw.is_function_word:
             continue
         bare = normalize_alef(strip_diacritics(sw.surface_form))
-        if bare in seen_bares or len(bare) < 2:
+        if bare in seen_bares or len(bare) < 2 or not _WORD_CHAR.search(bare):
             continue
         seen_bares.add(bare)
         unknown_words.append(sw)

--- a/backend/scripts/cleanup_numeric_ocr_lemmas.py
+++ b/backend/scripts/cleanup_numeric_ocr_lemmas.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Suspend + delete OCR-imported lemmas whose bare form is digits only.
+
+Background: Gemini OCR routinely extracts page numbers, ISBN strings, and
+footnote markers (e.g. ١٤, ٨٢٦١٤٩٣٥) as "Arabic words". These slipped past
+the OCR sanitize step in `sentence_validator.sanitize_arabic_word` because
+the pre-2026-05-20 implementation only filtered length-1 strings, not
+letter-free strings. They surface in Stats under "NEW WORDS STARTED" with
+an English gloss like "14" — visibly nonsensical.
+
+The import-side fix (`no_letters` warning) prevents new ones from being
+created. This script cleans up the existing ones.
+
+For each numeric Lemma:
+  1. Delete dependent UserLemmaKnowledge rows.
+  2. NULL out SentenceWord.lemma_id (the storage gate allows NULL for
+     book/OCR imports; the runtime reviewable-sentence gate then hides
+     the affected sentences until they're remapped, which is correct —
+     they're junk OCR sentences anyway).
+  3. NULL out StoryWord.lemma_id (same logic).
+  4. Hard-delete the Lemma row.
+
+Activity log entry at the end.
+
+Usage:
+    python3 scripts/cleanup_numeric_ocr_lemmas.py            # dry-run
+    python3 scripts/cleanup_numeric_ocr_lemmas.py --apply    # apply
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+BACKEND_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(BACKEND_ROOT))
+
+from app.database import SessionLocal  # noqa: E402
+from app.models import (  # noqa: E402
+    Lemma, SentenceWord, StoryWord, UserLemmaKnowledge,
+)
+from app.services.activity_log import log_activity  # noqa: E402
+
+
+# ASCII 0-9, Arabic-Indic ٠-٩ (U+0660-U+0669), Extended ۰-۹ (U+06F0-U+06F9),
+# plus common separators that show up in OCR'd numeric strings.
+NUMERIC_ONLY = re.compile(r"^[0-9٠-٩۰-۹.,\-/]+$")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--apply", action="store_true",
+                        help="Apply changes. Default is dry-run.")
+    args = parser.parse_args()
+    dry_run = not args.apply
+
+    db = SessionLocal()
+    try:
+        lemmas = (
+            db.query(Lemma)
+            .filter(Lemma.lemma_ar_bare.isnot(None))
+            .all()
+        )
+        hits = [l for l in lemmas if NUMERIC_ONLY.fullmatch(l.lemma_ar_bare)]
+
+        if not hits:
+            print("No numeric-only lemmas found. Nothing to clean.")
+            return 0
+
+        print(f"Found {len(hits)} numeric-only lemma(s):")
+        ulk_total = 0
+        sw_total = 0
+        story_total = 0
+        for l in hits:
+            n_ulk = (
+                db.query(UserLemmaKnowledge)
+                .filter(UserLemmaKnowledge.lemma_id == l.lemma_id)
+                .count()
+            )
+            n_sw = (
+                db.query(SentenceWord)
+                .filter(SentenceWord.lemma_id == l.lemma_id)
+                .count()
+            )
+            n_story = (
+                db.query(StoryWord)
+                .filter(StoryWord.lemma_id == l.lemma_id)
+                .count()
+            )
+            ulk_total += n_ulk
+            sw_total += n_sw
+            story_total += n_story
+            print(
+                f"  #{l.lemma_id}  bare={l.lemma_ar_bare!r}  ar={l.lemma_ar!r}  "
+                f"gloss={l.gloss_en!r}  src={l.source}  "
+                f"ulk={n_ulk}  sw={n_sw}  story_word={n_story}"
+            )
+        print(
+            f"\nTotal dependent rows: {ulk_total} ULK, {sw_total} SentenceWord, "
+            f"{story_total} StoryWord"
+        )
+
+        if dry_run:
+            print("\nDry-run only. Re-run with --apply to delete.")
+            return 0
+
+        ids = [l.lemma_id for l in hits]
+
+        ulk_deleted = (
+            db.query(UserLemmaKnowledge)
+            .filter(UserLemmaKnowledge.lemma_id.in_(ids))
+            .delete(synchronize_session=False)
+        )
+        sw_nulled = (
+            db.query(SentenceWord)
+            .filter(SentenceWord.lemma_id.in_(ids))
+            .update({SentenceWord.lemma_id: None}, synchronize_session=False)
+        )
+        story_nulled = (
+            db.query(StoryWord)
+            .filter(StoryWord.lemma_id.in_(ids))
+            .update({StoryWord.lemma_id: None}, synchronize_session=False)
+        )
+        lemma_deleted = (
+            db.query(Lemma)
+            .filter(Lemma.lemma_id.in_(ids))
+            .delete(synchronize_session=False)
+        )
+        db.commit()
+
+        summary = {
+            "lemma_ids": ids,
+            "lemmas_deleted": lemma_deleted,
+            "ulk_deleted": ulk_deleted,
+            "sentence_word_nulled": sw_nulled,
+            "story_word_nulled": story_nulled,
+        }
+        log_activity(
+            db,
+            event_type="manual_action",
+            summary=f"Removed {lemma_deleted} numeric-only OCR lemmas",
+            detail=summary,
+        )
+        print(f"\nApplied: {summary}")
+        return 0
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/tests/test_sentence_validator.py
+++ b/backend/tests/test_sentence_validator.py
@@ -895,6 +895,30 @@ class TestSanitizeArabicWord:
         assert result == "مِن"
         assert "too_short" not in warnings
 
+    def test_arabic_indic_digits_rejected(self):
+        """OCR-extracted page numbers like ١٤ must not become lemmas."""
+        result, warnings = sanitize_arabic_word("١٤")
+        assert "no_letters" in warnings
+
+    def test_long_arabic_indic_digit_string_rejected(self):
+        """ISBN/footnote artifacts like ٨٢٦١٤٩٣٥ must not become lemmas."""
+        result, warnings = sanitize_arabic_word("٨٢٦١٤٩٣٥")
+        assert "no_letters" in warnings
+
+    def test_ascii_digits_rejected(self):
+        result, warnings = sanitize_arabic_word("2024")
+        assert "no_letters" in warnings
+
+    def test_extended_arabic_indic_digits_rejected(self):
+        """Persian-style digits (U+06F0–U+06F9)."""
+        result, warnings = sanitize_arabic_word("۱۴")
+        assert "no_letters" in warnings
+
+    def test_letter_with_digit_kept(self):
+        """A real word with a stray digit (rare but possible) is not rejected."""
+        result, warnings = sanitize_arabic_word("كتاب2")
+        assert "no_letters" not in warnings
+
 
 class TestComputeBareForm:
     def test_basic(self):

--- a/docs/scripts-catalog.md
+++ b/docs/scripts-catalog.md
@@ -98,6 +98,7 @@ These scripts are designed to run periodically against the generation pipeline b
 - `cleanup_glosses.py` — Clean up gloss text.
 - `cleanup_lemma_text.py` — Clean up lemma text fields.
 - `cleanup_dirty_bare_forms.py` — LLM-powered cleanup of dirty bare forms (ال-prefix, ه→ة). Asks LLM to classify each candidate — correctly distinguishes OCR artifacts from legitimate ال-integral words. Dry-run by default, `--apply` to commit.
+- `cleanup_numeric_ocr_lemmas.py` — Delete OCR-imported Lemmas whose bare form is digits only (Arabic-Indic ٠-٩, Extended ۰-۹, ASCII 0-9). Source of these rows was page numbers / ISBNs / footnote markers that Gemini OCR returned as "Arabic words"; the import-side `no_letters` guard in `sanitize_arabic_word` (PR sh/ocr-reject-numerals) prevents new ones. Per Lemma: deletes ULK rows, NULLs `SentenceWord.lemma_id` + `StoryWord.lemma_id` (storage gate allows NULL for OCR imports; runtime gate hides affected sentences), then hard-deletes the Lemma. Dry-run by default, `--apply` to commit. Logs to ActivityLog.
 - `merge_al_lemmas.py` — Merge al-prefixed duplicate lemmas.
 - `merge_lemma_variants.py` — Merge identified variant lemmas.
 - `identify_leeches.py` — Find high-review low-accuracy words, optional --suspend.


### PR DESCRIPTION
## Summary

- Gemini OCR was extracting digit-only strings (e.g. `١٤`, `٨٢٦١٤٩٣٥`) from page numbers / footnote markers and the import path created real `Lemma` rows for them with English glosses like "14". They then surfaced in Stats → "NEW WORDS STARTED" via collateral introduction.
- Apply the existing `_WORD_CHAR` letter check (already used by `tokenize_display` for the same problem) inside `sanitize_arabic_word` with a new `no_letters` warning. All three `sanitize_arabic_word` call-sites in `ocr_service.py` skip on it. Defense-in-depth check added to `story_service._import_unknown_words`.
- `cleanup_numeric_ocr_lemmas.py` removes the two existing rows in prod (`#1650` "82614935", `#1970` "14"): deletes ULK rows, NULLs `SentenceWord.lemma_id` + `StoryWord.lemma_id`, hard-deletes the Lemma. Dry-run by default.