### PR TITLE
Alif: cleanup script handles all Lemma FK dependents

### DIFF
--- a/backend/scripts/cleanup_numeric_ocr_lemmas.py
+++ b/backend/scripts/cleanup_numeric_ocr_lemmas.py
@@ -13,11 +13,13 @@ created. This script cleans up the existing ones.
 
 For each numeric Lemma:
   1. Delete dependent UserLemmaKnowledge rows.
-  2. NULL out SentenceWord.lemma_id (the storage gate allows NULL for
-     book/OCR imports; the runtime reviewable-sentence gate then hides
-     the affected sentences until they're remapped, which is correct —
-     they're junk OCR sentences anyway).
-  3. NULL out StoryWord.lemma_id (same logic).
+  2. Delete dependent ReviewLog rows (lemma_id is NOT NULL).
+  3. NULL out nullable FK references: SentenceWord.lemma_id,
+     StoryWord.lemma_id, Sentence.target_lemma_id,
+     FrequencyCoreEntry.lemma_id, ContentFlag.lemma_id,
+     QuranicVerseWord.lemma_id, Lemma.canonical_lemma_id
+     (the storage / variant gates allow NULL; runtime gates hide the
+     affected sentences until remapping).
   4. Hard-delete the Lemma row.
 
 Activity log entry at the end.
@@ -38,7 +40,8 @@ sys.path.insert(0, str(BACKEND_ROOT))
 
 from app.database import SessionLocal  # noqa: E402
 from app.models import (  # noqa: E402
-    Lemma, SentenceWord, StoryWord, UserLemmaKnowledge,
+    ContentFlag, FrequencyCoreEntry, Lemma, QuranicVerseWord, ReviewLog,
+    Sentence, SentenceWord, StoryWord, UserLemmaKnowledge,
 )
 from app.services.activity_log import log_activity  # noqa: E402
 
@@ -69,37 +72,31 @@ def main() -> int:
             return 0
 
         print(f"Found {len(hits)} numeric-only lemma(s):")
-        ulk_total = 0
-        sw_total = 0
-        story_total = 0
+        counters = {
+            "ulk": 0, "review_log": 0, "sentence_word": 0, "story_word": 0,
+            "sentence_target": 0, "freq_core": 0, "content_flag": 0,
+            "quran_verse_word": 0, "variant_pointers": 0,
+        }
         for l in hits:
-            n_ulk = (
-                db.query(UserLemmaKnowledge)
-                .filter(UserLemmaKnowledge.lemma_id == l.lemma_id)
-                .count()
-            )
-            n_sw = (
-                db.query(SentenceWord)
-                .filter(SentenceWord.lemma_id == l.lemma_id)
-                .count()
-            )
-            n_story = (
-                db.query(StoryWord)
-                .filter(StoryWord.lemma_id == l.lemma_id)
-                .count()
-            )
-            ulk_total += n_ulk
-            sw_total += n_sw
-            story_total += n_story
+            row = {
+                "ulk": db.query(UserLemmaKnowledge).filter(UserLemmaKnowledge.lemma_id == l.lemma_id).count(),
+                "review_log": db.query(ReviewLog).filter(ReviewLog.lemma_id == l.lemma_id).count(),
+                "sentence_word": db.query(SentenceWord).filter(SentenceWord.lemma_id == l.lemma_id).count(),
+                "story_word": db.query(StoryWord).filter(StoryWord.lemma_id == l.lemma_id).count(),
+                "sentence_target": db.query(Sentence).filter(Sentence.target_lemma_id == l.lemma_id).count(),
+                "freq_core": db.query(FrequencyCoreEntry).filter(FrequencyCoreEntry.lemma_id == l.lemma_id).count(),
+                "content_flag": db.query(ContentFlag).filter(ContentFlag.lemma_id == l.lemma_id).count(),
+                "quran_verse_word": db.query(QuranicVerseWord).filter(QuranicVerseWord.lemma_id == l.lemma_id).count(),
+                "variant_pointers": db.query(Lemma).filter(Lemma.canonical_lemma_id == l.lemma_id).count(),
+            }
+            for k, v in row.items():
+                counters[k] += v
             print(
                 f"  #{l.lemma_id}  bare={l.lemma_ar_bare!r}  ar={l.lemma_ar!r}  "
                 f"gloss={l.gloss_en!r}  src={l.source}  "
-                f"ulk={n_ulk}  sw={n_sw}  story_word={n_story}"
+                + "  ".join(f"{k}={v}" for k, v in row.items() if v)
             )
-        print(
-            f"\nTotal dependent rows: {ulk_total} ULK, {sw_total} SentenceWord, "
-            f"{story_total} StoryWord"
-        )
+        print("\nTotal dependent rows: " + ", ".join(f"{k}={v}" for k, v in counters.items() if v))
 
         if dry_run:
             print("\nDry-run only. Re-run with --apply to delete.")
@@ -107,11 +104,19 @@ def main() -> int:
 
         ids = [l.lemma_id for l in hits]
 
+        # Delete required-FK rows first
         ulk_deleted = (
             db.query(UserLemmaKnowledge)
             .filter(UserLemmaKnowledge.lemma_id.in_(ids))
             .delete(synchronize_session=False)
         )
+        rl_deleted = (
+            db.query(ReviewLog)
+            .filter(ReviewLog.lemma_id.in_(ids))
+            .delete(synchronize_session=False)
+        )
+
+        # NULL out nullable-FK references
         sw_nulled = (
             db.query(SentenceWord)
             .filter(SentenceWord.lemma_id.in_(ids))
@@ -122,6 +127,32 @@ def main() -> int:
             .filter(StoryWord.lemma_id.in_(ids))
             .update({StoryWord.lemma_id: None}, synchronize_session=False)
         )
+        sent_nulled = (
+            db.query(Sentence)
+            .filter(Sentence.target_lemma_id.in_(ids))
+            .update({Sentence.target_lemma_id: None}, synchronize_session=False)
+        )
+        fce_nulled = (
+            db.query(FrequencyCoreEntry)
+            .filter(FrequencyCoreEntry.lemma_id.in_(ids))
+            .update({FrequencyCoreEntry.lemma_id: None}, synchronize_session=False)
+        )
+        cf_nulled = (
+            db.query(ContentFlag)
+            .filter(ContentFlag.lemma_id.in_(ids))
+            .update({ContentFlag.lemma_id: None}, synchronize_session=False)
+        )
+        qvw_nulled = (
+            db.query(QuranicVerseWord)
+            .filter(QuranicVerseWord.lemma_id.in_(ids))
+            .update({QuranicVerseWord.lemma_id: None}, synchronize_session=False)
+        )
+        canon_nulled = (
+            db.query(Lemma)
+            .filter(Lemma.canonical_lemma_id.in_(ids))
+            .update({Lemma.canonical_lemma_id: None}, synchronize_session=False)
+        )
+
         lemma_deleted = (
             db.query(Lemma)
             .filter(Lemma.lemma_id.in_(ids))
@@ -133,8 +164,14 @@ def main() -> int:
             "lemma_ids": ids,
             "lemmas_deleted": lemma_deleted,
             "ulk_deleted": ulk_deleted,
+            "review_log_deleted": rl_deleted,
             "sentence_word_nulled": sw_nulled,
             "story_word_nulled": story_nulled,
+            "sentence_target_nulled": sent_nulled,
+            "freq_core_nulled": fce_nulled,
+            "content_flag_nulled": cf_nulled,
+            "quran_verse_word_nulled": qvw_nulled,
+            "variant_pointers_nulled": canon_nulled,
         }
         log_activity(
             db,


### PR DESCRIPTION
Follow-up to #99. The cleanup script hit `FOREIGN KEY constraint failed` on the first --apply because ReviewLog (NOT NULL FK) and Sentence.target_lemma_id both pointed at the two prod numeric lemmas (4 + 3 ReviewLogs, 19 + 19 Sentence target refs). Now deletes ReviewLog rows and NULLs all other nullable FK references before deleting the Lemma.