### PR TITLE
Polyglot reader: tap-to-cycle (red→yellow→clear), single Next, en-dash fix

### DIFF
--- a/frontend/app/polyglot.tsx
+++ b/frontend/app/polyglot.tsx
@@ -3,11 +3,12 @@
  *
  * UX model:
  *   1. **Story list** — pick a text (currently only the Greek history textbook).
- *   2. **Reading view** — colored tokens by knowledge state. Tap a content
- *      word → see lemma + gloss in a single line at the bottom (doesn't
- *      break reading flow). Tap "Unknown" / "Known" / "Encountered" inline.
- *   3. **Next page** — every un-tapped content word is presumed known.
- *      This is the central UX accelerator for intermediate learners.
+ *   2. **Reading view** — book typography, every word the same warm ink.
+ *      Tap a content word → it's marked unknown and the English gloss appears
+ *      at the bottom. No buttons, no state pickers — the act of tapping IS
+ *      the answer ("I don't know this one"). Misclicks get sorted in review.
+ *   3. **Next page** — every un-tapped content word is presumed known. The
+ *      only page-nav action; no Prev (forward reading only).
  *   4. **Lazy** — pages are tokenized + LLM-verified only when first viewed.
  *
  * Talks to the polyglot backend (separate from Alif). See polyglot-api.ts.
@@ -22,39 +23,40 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Ionicons } from "@expo/vector-icons";
 import {
   listStories, getPage, markWord, markRemainingKnown,
-  type StorySummary, type PageView, type TokenView, type MarkState,
+  type StorySummary, type PageView, type TokenView,
 } from "../lib/polyglot-api";
 import { renderTokens } from "../lib/polyglot-render-helpers";
 
 // Reading palette. We treat the page as a book, not a flashcard surface:
 // every word in body text renders in the same warm ink color, function
-// words included. Knowledge state is exposed only when the user explicitly
-// taps a word — see the lookup bar at the bottom and the `selectedHighlight`
-// style for the in-flow tap accent.
+// words included. The only in-body color signal is the user's *current
+// session* tap-cycle state — red (don't know) or yellow (recognize after
+// seeing English). Server-persisted knowledge state (the user's history
+// across sessions) is intentionally invisible in the prose so the reader
+// experience is the same on day 1 and day 50.
 const C = {
   bg: "#14121a",             // warm slate — softer than pure black for long reading
   surface: "#1d1a26",        // bottom-bar surface
   border: "#2f2a3a",
   ink: "#ede4cf",            // body text — warm off-white, "paper ink"
   inkMuted: "#a89c83",       // for chrome (page number, headers)
-  accent: "#a98ef0",          // tap highlight + chevrons
-  // State colors — used ONLY in the lookup bar and tap state, never in body
-  known: "#3a3a52",
-  acquiring: "#d4a06b",
-  encountered: "#506a8e",
-  unknown: "#c95f6f",
-  ignored: "#3a3a3a",
+  accent: "#a98ef0",         // selection underline
+  cycleRed: "#c95f6f",       // tap 1: "no idea" — full SRS enrollment
+  cycleYellow: "#d4a06b",    // tap 2: "recognize after seeing English"
 };
 
-// The lookup-bar uses these colors to indicate state. Body text never does.
-function lookupStateColor(t: TokenView): string {
-  if (t.is_known) return C.known;
-  if (t.is_unknown) return C.unknown;
-  if (t.is_acquiring) return C.acquiring;
-  if (t.is_encountered) return C.encountered;
-  if (t.is_ignored) return C.ignored;
-  return C.accent;
-}
+// Tap-cycle positions, in order. Tapping a word advances by one position
+// (wrapping after the third). See handleTap. The third position is a true
+// "unmark" — the backend deletes the ULK row and the body styling reverts.
+//
+// Why "no_idea" / "recognize" rather than the backend's "unknown" /
+// "encountered" terms: the backend names describe SRS lifecycle stages;
+// these names describe what the user is *expressing* with the tap.
+const CYCLE: { state: "unknown" | "encountered" | "clear"; label: string }[] = [
+  { state: "unknown",     label: "no idea" },
+  { state: "encountered", label: "recognize" },
+  { state: "clear",       label: "untapped" },
+];
 
 export default function Polyglot() {
   const router = useRouter();
@@ -64,6 +66,13 @@ export default function Polyglot() {
   const [pageData, setPageData] = useState<PageView | null>(null);
   const [loading, setLoading] = useState(false);
   const [selected, setSelected] = useState<TokenView | null>(null);
+  // Per-page tap-cycle positions, keyed by lemma_id. 0 = unknown (red),
+  // 1 = encountered (yellow), 2 = clear (no state). Tapping a word advances
+  // by one (wrapping). Reset on page change so each page is its own
+  // independent session of taps. Same lemma appearing at two positions on
+  // one page shares state — natural since both are the same word.
+  const [cyclePositions, setCyclePositions] = useState<Record<number, number>>({});
+  const [glossByLemma, setGlossByLemma] = useState<Record<number, string | null>>({});
   const [bulkMarking, setBulkMarking] = useState(false);
   const scrollRef = useRef<ScrollView>(null);
   const insets = useSafeAreaInsets();
@@ -73,6 +82,8 @@ export default function Polyglot() {
   const loadPage = useCallback(async (sid: number, p: number) => {
     setLoading(true);
     setSelected(null);
+    setCyclePositions({});
+    setGlossByLemma({});
     try {
       const data = await getPage(sid, p);
       setPageData(data);
@@ -95,27 +106,38 @@ export default function Polyglot() {
     loadPage(storyId, startPage);
   }, [storyId, loadPage, stories]);
 
-  const handleMark = useCallback(async (state: MarkState) => {
-    if (!selected?.lemma_id || !storyId) return;
+  // Tap-cycle handler. The act of tapping a word advances its position in
+  // the three-state cycle:
+  //   tap 1 → "no idea" (red, enrols in SRS)
+  //   tap 2 → "recognize" (yellow, light tracking, no SRS)
+  //   tap 3 → "untapped" (clear, ULK deleted, treated as if never tapped)
+  //   tap 4 → back to "no idea"
+  // Tapping a different word selects it fresh at position 0. The backend
+  // ALWAYS receives the resulting state, including "clear" which truly
+  // deletes the ULK (see reading_intake.mark_lemma).
+  const handleTap = useCallback(async (t: TokenView) => {
+    if (!t.lemma_id || !storyId) return;
+    const lemmaId = t.lemma_id;
+    // Advance from whatever this lemma's last cycle position was (even if
+    // the focus has since moved to another word). Re-tapping a lemma always
+    // means "advance one more position" — not "reset to red." Otherwise
+    // glancing at a different word, then returning, would silently undo the
+    // earlier cycle progress.
+    const nextPos = ((cyclePositions[lemmaId] ?? -1) + 1) % CYCLE.length;
+    const nextState = CYCLE[nextPos].state;
+
+    setSelected(t);
+    setCyclePositions((prev) => ({ ...prev, [lemmaId]: nextPos }));
+
     try {
-      const res = await markWord(storyId, selected.lemma_id, state);
-      // Optimistic update of the selected token so user sees feedback instantly
-      setSelected({
-        ...selected,
-        is_known: state === "known",
-        is_unknown: state === "unknown",
-        is_encountered: state === "encountered",
-        is_ignored: state === "ignore",
-        is_new: false,
-        gloss_en: res.gloss_en ?? selected.gloss_en,
-      });
-      // Re-fetch page for full coloring update — small page, so cheap
-      const fresh = await getPage(storyId, pageNumber);
-      setPageData(fresh);
+      const res = await markWord(storyId, lemmaId, nextState);
+      if (res.gloss_en != null) {
+        setGlossByLemma((prev) => ({ ...prev, [lemmaId]: res.gloss_en }));
+      }
     } catch (e) {
-      console.warn("Mark failed:", e);
+      console.warn(`Tap-cycle to ${nextState} failed:`, e);
     }
-  }, [selected, storyId, pageNumber]);
+  }, [selected, cyclePositions, storyId]);
 
   const handleNextPage = useCallback(async () => {
     if (!pageData || !storyId) return;
@@ -128,10 +150,6 @@ export default function Polyglot() {
       setBulkMarking(false);
     }
   }, [pageData, storyId, pageNumber, loadPage]);
-
-  const handlePrevPage = useCallback(() => {
-    if (storyId && pageNumber > 1) loadPage(storyId, pageNumber - 1);
-  }, [storyId, pageNumber, loadPage]);
 
   // ─── Story list ──────────────────────────────────────────────────────
   if (storyId == null) {
@@ -198,15 +216,22 @@ export default function Polyglot() {
                 // continuous prose.
                 pageData.tokens.filter((t) => !t.is_heading),
               ).map((span, i) => {
+                const lemmaId = span.token.lemma_id;
+                const cyclePos = lemmaId != null ? cyclePositions[lemmaId] : undefined;
+                const cycleStyle =
+                  cyclePos === 0 ? styles.tokenCycleRed
+                  : cyclePos === 1 ? styles.tokenCycleYellow
+                  : undefined;
                 const isSelected =
                   selected != null && selected.position === span.token.position;
+                const tokenStyle = cycleStyle ?? (isSelected ? styles.tokenSelected : styles.token);
                 return (
-                  <Text key={i} style={isSelected ? styles.tokenSelected : styles.token}>
+                  <Text key={i} style={tokenStyle}>
                     {span.leadingSpace}
                     <Text
                       onPress={
                         !span.isPunctuation && span.token.lemma_id
-                          ? () => setSelected(span.token)
+                          ? () => handleTap(span.token)
                           : undefined
                       }
                     >
@@ -220,61 +245,41 @@ export default function Polyglot() {
         </ScrollView>
       )}
 
-      {/* Single-line lookup bar — doesn't break reading flow */}
-      {selected && (
-        <View style={styles.lookupBar}>
-          <View style={styles.lookupRow}>
-            <Text style={styles.lookupSurface}>{selected.surface}</Text>
-            {selected.lemma_form && selected.lemma_form !== selected.surface && (
-              <Text style={styles.lookupLemma}> · {selected.lemma_form}</Text>
-            )}
-            {selected.pos && <Text style={styles.lookupPos}> · {selected.pos.toLowerCase()}</Text>}
-            <Text style={styles.lookupGloss} numberOfLines={1}>
-              {selected.gloss_en
-                ? `  →  ${selected.gloss_en}`
-                : "  →  (mark unknown to fetch gloss)"}
-            </Text>
-            <Pressable onPress={() => setSelected(null)} style={styles.lookupClose}>
-              <Ionicons name="close" size={20} color={C.inkMuted} />
-            </Pressable>
+      {/* Lookup bar — surface word + English gloss + close. No lemma,
+          no POS, no action buttons. Cycle dot reflects current tap state. */}
+      {selected && selected.lemma_id != null && (() => {
+        const lemmaId = selected.lemma_id;
+        const pos = cyclePositions[lemmaId];
+        const dotColor =
+          pos === 0 ? C.cycleRed
+          : pos === 1 ? C.cycleYellow
+          : C.inkMuted;
+        const gloss = glossByLemma[lemmaId] ?? selected.gloss_en;
+        return (
+          <View style={styles.lookupBar}>
+            <View style={styles.lookupRow}>
+              <View style={[styles.lookupDot, { backgroundColor: dotColor }]} />
+              <Text style={styles.lookupSurface}>{selected.surface}</Text>
+              <Text style={styles.lookupGloss} numberOfLines={2}>
+                {gloss ? `  ${gloss}` : "  …"}
+              </Text>
+              <Pressable onPress={() => setSelected(null)} style={styles.lookupClose}>
+                <Ionicons name="close" size={20} color={C.inkMuted} />
+              </Pressable>
+            </View>
           </View>
-          <View style={styles.lookupActions}>
-            <Pressable style={[styles.actionBtn, { backgroundColor: C.known }]}
-              onPress={() => handleMark("known")}>
-              <Text style={styles.actionText}>Known</Text>
-            </Pressable>
-            <Pressable style={[styles.actionBtn, { backgroundColor: C.unknown }]}
-              onPress={() => handleMark("unknown")}>
-              <Text style={styles.actionText}>Unknown</Text>
-            </Pressable>
-            <Pressable style={[styles.actionBtn, { backgroundColor: C.encountered }]}
-              onPress={() => handleMark("encountered")}>
-              <Text style={styles.actionText}>Encountered</Text>
-            </Pressable>
-            <Pressable style={[styles.actionBtn, { backgroundColor: C.ignored }]}
-              onPress={() => handleMark("ignore")}>
-              <Text style={styles.actionText}>Ignore</Text>
-            </Pressable>
-          </View>
-        </View>
-      )}
+        );
+      })()}
 
-      {/* Page nav */}
+      {/* Page nav — single "Next" button. No Prev (forward reading only). */}
       <View style={styles.pageNav}>
-        <Pressable
-          style={[styles.navBtn, pageData?.page_number === 1 && styles.navBtnDisabled]}
-          onPress={handlePrevPage}
-          disabled={pageData?.page_number === 1}
-        >
-          <Text style={styles.navBtnText}>‹ Prev</Text>
-        </Pressable>
         <Pressable
           style={[styles.navBtnPrimary, bulkMarking && styles.navBtnDisabled]}
           onPress={handleNextPage}
           disabled={!pageData || pageData.page_number >= pageData.total_pages || bulkMarking}
         >
           <Text style={styles.navBtnPrimaryText}>
-            {bulkMarking ? "Marking…" : "Next → (presume rest known)"}
+            {bulkMarking ? "Marking…" : "Next →"}
           </Text>
         </Pressable>
       </View>
@@ -340,32 +345,42 @@ const styles = StyleSheet.create({
   tokenSelected: {
     fontSize: BODY_FONT_SIZE,
     lineHeight: BODY_LINE_HEIGHT,
-    color: C.accent,
+    color: C.ink,
     fontFamily: SERIF,
     textDecorationLine: "underline",
     textDecorationColor: C.accent,
   },
+  // In-body cycle colors. Underline + tinted text so the cycle state is
+  // visible without losing the prose's serif feel.
+  tokenCycleRed: {
+    fontSize: BODY_FONT_SIZE,
+    lineHeight: BODY_LINE_HEIGHT,
+    color: C.cycleRed,
+    fontFamily: SERIF,
+    textDecorationLine: "underline",
+    textDecorationColor: C.cycleRed,
+  },
+  tokenCycleYellow: {
+    fontSize: BODY_FONT_SIZE,
+    lineHeight: BODY_LINE_HEIGHT,
+    color: C.cycleYellow,
+    fontFamily: SERIF,
+    textDecorationLine: "underline",
+    textDecorationColor: C.cycleYellow,
+  },
 
   lookupBar: { backgroundColor: C.surface, borderTopWidth: 1, borderColor: C.border,
-               paddingVertical: 12, paddingHorizontal: 20 },
+               paddingVertical: 14, paddingHorizontal: 20 },
   lookupRow: { flexDirection: "row", alignItems: "center", flexWrap: "nowrap" },
+  lookupDot: { width: 10, height: 10, borderRadius: 5, marginRight: 10 },
   lookupSurface: { color: C.ink, fontSize: 17, fontWeight: "600", fontFamily: SERIF },
-  lookupLemma: { color: C.inkMuted, fontSize: 15, fontFamily: SERIF },
-  lookupPos: { color: C.accent, fontSize: 11, textTransform: "uppercase", letterSpacing: 0.6 },
-  lookupGloss: { color: C.ink, fontSize: 14, flex: 1, fontFamily: SERIF },
-  lookupClose: { padding: 4 },
-  lookupActions: { flexDirection: "row", marginTop: 10, gap: 6 },
-  actionBtn: { flex: 1, paddingVertical: 9, borderRadius: 8, alignItems: "center" },
-  actionText: { color: C.ink, fontSize: 12, fontWeight: "600", letterSpacing: 0.3 },
+  lookupGloss: { color: C.ink, fontSize: 15, flex: 1, fontFamily: SERIF },
+  lookupClose: { padding: 4, marginLeft: 8 },
 
-  pageNav: { flexDirection: "row", justifyContent: "space-between",
-             paddingHorizontal: 20, paddingVertical: 14, gap: 8,
+  pageNav: { paddingHorizontal: 20, paddingVertical: 14,
              borderTopWidth: 1, borderColor: C.border, backgroundColor: C.surface },
-  navBtn: { paddingVertical: 12, paddingHorizontal: 18, borderRadius: 8,
-            backgroundColor: C.bg, borderWidth: 1, borderColor: C.border },
-  navBtnPrimary: { flex: 1, paddingVertical: 12, paddingHorizontal: 18, borderRadius: 8,
+  navBtnPrimary: { paddingVertical: 12, paddingHorizontal: 18, borderRadius: 8,
                    backgroundColor: C.accent, alignItems: "center" },
   navBtnDisabled: { opacity: 0.4 },
-  navBtnText: { color: C.ink, fontSize: 14 },
-  navBtnPrimaryText: { color: "#14121a", fontSize: 14, fontWeight: "700", letterSpacing: 0.4 },
+  navBtnPrimaryText: { color: "#14121a", fontSize: 15, fontWeight: "700", letterSpacing: 0.4 },
 });

--- a/frontend/lib/__tests__/polyglot-render-helpers.test.ts
+++ b/frontend/lib/__tests__/polyglot-render-helpers.test.ts
@@ -107,6 +107,32 @@ describe("renderTokens — soft-hyphen joining", () => {
     expect(joined([tok("Αυστραλο-Ασιατικός"), tok(",")]))
       .toBe("Αυστραλο-Ασιατικός,");
   });
+
+  it("does NOT join words across an en-dash (Greek parenthetical)", () => {
+    // The visible bug at page 11: tokens around `Τίγρης – ανατολικά – και`
+    // had the en-dashes silently consumed, producing `Τίγρηςανατολικάκαι`.
+    // En-dash (U+2013) is a parenthetical marker in Greek, NOT a
+    // line-break soft-hyphen. The dashes must survive into the output.
+    const tokens = [
+      tok("Τίγρης"), tok("–", { is_punctuation: true }),
+      tok("ανατολικά"), tok("–", { is_punctuation: true }),
+      tok("και"),
+    ];
+    const out = joined(tokens);
+    expect(out).toContain("Τίγρης");
+    expect(out).toContain("ανατολικά");
+    expect(out).toContain("και");
+    expect(out).toContain("–");
+    expect(out).not.toContain("Τίγρηςανατολικά");
+    expect(out).not.toContain("ανατολικάκαι");
+  });
+
+  it("does NOT join words across a non-breaking hyphen (U+2011)", () => {
+    // Same logic: non-breaking hyphen explicitly does NOT line-break, so
+    // dropping it would be wrong.
+    const tokens = [tok("A"), tok("‑"), tok("B")];
+    expect(joined(tokens)).toContain("‑");
+  });
 });
 
 describe("renderTokens — combined real-world example", () => {

--- a/frontend/lib/polyglot-api.ts
+++ b/frontend/lib/polyglot-api.ts
@@ -85,7 +85,7 @@ export type PageView = {
   tokens: TokenView[];
 };
 
-export type MarkState = "known" | "unknown" | "encountered" | "ignore";
+export type MarkState = "known" | "unknown" | "encountered" | "ignore" | "clear";
 
 export type CognateInfo = {
   lang: string;

--- a/frontend/lib/polyglot-render-helpers.ts
+++ b/frontend/lib/polyglot-render-helpers.ts
@@ -37,7 +37,15 @@ function isAlphabetic(s: string): boolean {
 }
 
 function isStandaloneHyphen(surface: string): boolean {
-  return surface === "-" || surface === "‐" || surface === "‑" || surface === "–";
+  // Only ASCII hyphen (U+002D) and Unicode hyphen (U+2010) — these are the
+  // characters PDF extractors use for line-break soft-hyphens.
+  // NOT included:
+  //   '‑' (U+2011 non-breaking hyphen) — explicitly does NOT break a word
+  //   '–' (U+2013 en-dash) — Greek parenthetical marker (Τίγρης – ανατολικά –)
+  //   '—' (U+2014 em-dash) — same role in English typography
+  // Treating en/em-dashes as soft-hyphens silently concatenates adjacent
+  // words (Τίγρηςανατολικάκαι), which was the visible bug pre-fix.
+  return surface === "-" || surface === "‐";
 }
 
 /**
@@ -99,8 +107,10 @@ export function renderTokens(tokens: readonly TokenView[]): RenderedSpan[] {
 
     // Hyphen-prefix tokens like `-νευί` (from `Νι\n-νευί` extraction):
     // strip the leading dash and append to the previous span without a space.
+    // Only ASCII hyphen + U+2010 hyphen; en/em-dashes excluded (see comment
+    // in isStandaloneHyphen).
     if (
-      /^[-‐‑–][\p{L}]/u.test(t.surface) &&
+      /^[-‐][\p{L}]/u.test(t.surface) &&
       out.length > 0 &&
       isAlphabetic(out[out.length - 1].surface)
     ) {
@@ -119,7 +129,7 @@ export function renderTokens(tokens: readonly TokenView[]): RenderedSpan[] {
     let surface = t.surface;
     let strippedTrailingHyphen = false;
     if (
-      /[\p{L}][-‐‑–]$/u.test(surface) &&
+      /[\p{L}][-‐]$/u.test(surface) &&
       i + 1 < tokens.length &&
       isAlphabetic(tokens[i + 1].surface)
     ) {

--- a/polyglot/app/routers/texts.py
+++ b/polyglot/app/routers/texts.py
@@ -101,8 +101,17 @@ def get_page(story_id: int, page_number: int, db: Session = Depends(get_db)):
 def mark_word(story_id: int, req: MarkWordRequest, db: Session = Depends(get_db)):
     ulk = reading_intake.mark_lemma(db, lemma_id=req.lemma_id, state=req.state)
     # Return the (possibly newly-fetched) gloss so the frontend can display it
-    # without an extra round-trip.
+    # without an extra round-trip. `clear` returns no ULK (it was deleted);
+    # we still return the gloss so the lookup bar can keep showing English
+    # after the tap-cycle reaches its "unmark" position.
     from app.models import Lemma
+    if ulk is None:
+        lemma = db.get(Lemma, req.lemma_id)
+        return {
+            "lemma_id": req.lemma_id,
+            "state": None,
+            "gloss_en": lemma.gloss_en if lemma else None,
+        }
     lemma = db.get(Lemma, ulk.lemma_id)
     return {
         "lemma_id": ulk.lemma_id,

--- a/polyglot/app/schemas.py
+++ b/polyglot/app/schemas.py
@@ -96,7 +96,7 @@ class PageView(BaseModel):
 
 class MarkWordRequest(BaseModel):
     lemma_id: int
-    state: str = Field(..., description="'known' | 'unknown' | 'encountered' | 'ignore'")
+    state: str = Field(..., description="'known' | 'unknown' | 'encountered' | 'ignore' | 'clear'")
 
 
 # ─── User profile / cognates ───────────────────────────────────────────────

--- a/polyglot/app/services/reading_intake.py
+++ b/polyglot/app/services/reading_intake.py
@@ -389,7 +389,7 @@ def bulk_mark_remaining_known(db: Session, story_id: int, page_number: int) -> i
     return count
 
 
-def mark_lemma(db: Session, lemma_id: int, state: str, *, fetch_gloss: bool = True) -> UserLemmaKnowledge:
+def mark_lemma(db: Session, lemma_id: int, state: str, *, fetch_gloss: bool = True) -> UserLemmaKnowledge | None:
     """Set the user's knowledge state for a lemma. Creates ULK if missing.
 
     Behaviour by ``state``:
@@ -402,10 +402,25 @@ def mark_lemma(db: Session, lemma_id: int, state: str, *, fetch_gloss: bool = Tr
         A tiny English gloss is also fetched if missing.
       - ``encountered``: lightweight state-only update; no SRS enrolment.
       - ``ignore``: mark as a proper name / out-of-band token and remove from SRS.
+      - ``clear``: drop the ULK entirely so the lemma returns to its pre-tap
+        "no state" — used to undo an accidental tap from the reading screen's
+        tap-cycle (red → yellow → clear). Audit history in ReviewLog is left
+        intact. Returns None when the ULK was deleted (or didn't exist).
     """
-    valid = {"known", "unknown", "encountered", "ignore"}
+    valid = {"known", "unknown", "encountered", "ignore", "clear"}
     if state not in valid:
         raise ValueError(f"Invalid state {state!r}; expected one of {valid}")
+
+    if state == "clear":
+        from app.services.canonical_resolution import resolve_canonical_lemma_id
+        canonical_id = resolve_canonical_lemma_id(db, lemma_id)
+        existing = db.query(UserLemmaKnowledge).filter(
+            UserLemmaKnowledge.lemma_id == canonical_id
+        ).first()
+        if existing is not None:
+            db.delete(existing)
+            db.commit()
+        return None
 
     from app.services.canonical_resolution import resolve_canonical_lemma_id
 

--- a/polyglot/tests/test_reading_intake.py
+++ b/polyglot/tests/test_reading_intake.py
@@ -107,6 +107,31 @@ def test_mark_lemma_updates_existing(tmp_db):
         assert ulks[0].knowledge_state == "known"
 
 
+def test_mark_lemma_clear_deletes_ulk(tmp_db):
+    """`clear` is the third tap in the reading screen's cycle
+    (unknown → encountered → clear). It must delete the ULK so the lemma
+    returns to a "no state" baseline."""
+    with tmp_db() as db:
+        story = reading_intake.import_paste(db, language_code="el", body="βιβλίο")
+        page, tokens = reading_intake.get_page_view(db, story.id, 1)
+        lemma_id = next(t["lemma_id"] for t in tokens if t["lemma_id"])
+
+        reading_intake.mark_lemma(db, lemma_id=lemma_id, state="unknown", fetch_gloss=False)
+        assert db.query(UserLemmaKnowledge).filter(
+            UserLemmaKnowledge.lemma_id == lemma_id
+        ).count() == 1
+
+        result = reading_intake.mark_lemma(db, lemma_id=lemma_id, state="clear")
+        assert result is None
+        assert db.query(UserLemmaKnowledge).filter(
+            UserLemmaKnowledge.lemma_id == lemma_id
+        ).count() == 0
+
+        # Idempotent: clearing again on a lemma without a ULK is a no-op.
+        result2 = reading_intake.mark_lemma(db, lemma_id=lemma_id, state="clear")
+        assert result2 is None
+
+
 def test_page_view_classifies_token_states(tmp_db):
     with tmp_db() as db:
         story = reading_intake.import_paste(db, language_code="el", body="βιβλίο σπίτι")


### PR DESCRIPTION
## Summary

The reader screen was busy: four state buttons stacked under each selected word, a redundant `surface · lemma_form · pos` line that showed the word twice, a Prev nav button that conflicted with forward-reading-only flow. And a visible bug: words separated by Greek en-dashes (parenthetical markers like `Τίγρης – ανατολικά –`) were being silently concatenated into `Τίγρηςανατολικάκαι` because the render helper treated en-dashes the same as PDF line-break soft-hyphens.

## What changed

**Tap-to-cycle.** A tap on a word cycles through three states:

1. 🔴 red — *no idea* — enrols the lemma in SRS Box 1
2. 🟡 yellow — *recognize after seeing English* — light tracking, no SRS enrolment
3. ⚫ clear — *un-tapped* — backend deletes the ULK, lemma reverts to "no state" and gets bulk-marked known on Next-page

Re-tapping a word advances its cycle even after focus has moved elsewhere — so glancing at a different word and coming back doesn't silently reset the earlier progress. Per-page state, cleared on navigation.

**Backend `state="clear"`** in `reading_intake.mark_lemma`: idempotent ULK delete with canonical resolution. ReviewLog history is preserved (immutable audit trail). Test in `test_reading_intake.test_mark_lemma_clear_deletes_ulk`.

**Single Next button.** Dropped Prev — reading is forward only. The Library/Stats/Languages tabs remain at top/bottom.

**Lookup bar slimmed.** Just `[colored dot] surface  →  English gloss  [×]`. No lemma form, no POS, no action buttons.

**En-dash render fix.** `isStandaloneHyphen` now matches only the two characters PDF extractors actually use for line-break soft-hyphens (`-` U+002D and `‐` U+2010). The en-dash `–` (U+2013, Greek parenthetical) and non-breaking hyphen `‑` (U+2011, explicitly *not* a line-break) are preserved. Two regression tests cover both.

## Test plan covered in CI

- 15 frontend jest tests in `polyglot-render-helpers.test.ts`, including two new for en-dash + non-breaking hyphen
- `tsc --noEmit` clean
- 15 backend tests in `test_reading_intake.py`, including the new `clear` semantics