### PR TITLE
Polyglot: batch-gloss every lemma on first page view

### DIFF
--- a/polyglot/app/services/lemma_gloss.py
+++ b/polyglot/app/services/lemma_gloss.py
@@ -25,6 +25,9 @@ log = logging.getLogger(__name__)
 
 GLOSS_MODEL = os.environ.get("POLYGLOT_GLOSS_MODEL", "claude-haiku-4-5-20251001")
 TIMEOUT_S = int(os.environ.get("POLYGLOT_GLOSS_TIMEOUT", "60"))
+# Haiku reliably handles ~50 lemma definitions in one structured-output call;
+# larger batches start dropping entries. Configurable for tuning.
+BATCH_CHUNK_SIZE = int(os.environ.get("POLYGLOT_GLOSS_CHUNK", "50"))
 LANG_DISPLAY = {"el": "Modern Greek", "grc": "Ancient Greek", "la": "Latin"}
 
 
@@ -49,11 +52,24 @@ def ensure_gloss(db: Session, lemma_id: int, *, context: str | None = None, forc
 
 
 def ensure_glosses_batch(db: Session, lemma_ids: list[int]) -> int:
-    """Gloss multiple lemmas in one CLI call. Returns the count that were
-    successfully glossed. Useful for batching when user marks many at once."""
+    """Gloss multiple lemmas in chunked Haiku calls. Returns the count that
+    were successfully glossed.
+
+    Filters performed before LLM call (free to skip — they don't need gloss):
+      - already-glossed lemmas (idempotent)
+      - function words (e.g. articles, particles — gloss is uninteresting)
+      - proper names (lemma_form is the gloss)
+
+    Chunked at ``BATCH_CHUNK_SIZE`` lemmas per call because Haiku starts
+    dropping entries when asked for too many at once. Each chunk commits
+    independently so a later-chunk failure doesn't lose earlier work and
+    doesn't hold the SQLite write lock across multiple LLM calls
+    (CLAUDE.md rule #10).
+    """
     targets = [
         l for l in db.query(Lemma).filter(Lemma.lemma_id.in_(lemma_ids)).all()
         if not l.gloss_en
+        and l.word_category not in ("function_word", "proper_name")
     ]
     if not targets:
         return 0
@@ -62,12 +78,14 @@ def ensure_glosses_batch(db: Session, lemma_ids: list[int]) -> int:
         by_lang.setdefault(l.language_code, []).append(l)
     glossed = 0
     for lang, lemmas in by_lang.items():
-        results = _call_claude_for_gloss_batch(lemmas, lang)
-        for lemma, gloss in zip(lemmas, results):
-            if gloss:
-                lemma.gloss_en = gloss
-                glossed += 1
-        db.commit()
+        for i in range(0, len(lemmas), BATCH_CHUNK_SIZE):
+            chunk = lemmas[i:i + BATCH_CHUNK_SIZE]
+            results = _call_claude_for_gloss_batch(chunk, lang)
+            for lemma, gloss in zip(chunk, results):
+                if gloss:
+                    lemma.gloss_en = gloss
+                    glossed += 1
+            db.commit()
     return glossed
 
 

--- a/polyglot/app/services/reading_intake.py
+++ b/polyglot/app/services/reading_intake.py
@@ -24,6 +24,7 @@ from sqlalchemy.orm import Session
 
 from app.models import Lemma, Story, Page, PageWord, UserLemmaKnowledge
 from app.services import body_clean as body_clean_svc
+from app.services import lemma_gloss
 from app.services import pdf_extract
 from app.services.cognate_detector import link_intra_greek_cognates, propagate_known_via_cognate
 from app.services import lemma_quality
@@ -32,6 +33,13 @@ from app.services.languages import (
 )
 
 log = logging.getLogger(__name__)
+
+import os as _os
+# Batch-gloss every new lemma on the page right after tokenization, so the
+# reader sees English meanings the instant a tap surfaces a lookup. Default
+# on — Haiku is cheap (~$0.001 per 50 lemmas, free under Max). Disable for
+# tests / cost-sensitive environments.
+BATCH_GLOSS_ENABLED = _os.environ.get("POLYGLOT_BATCH_GLOSS", "1") == "1"
 
 
 def _split_into_sentences(text: str) -> list[str]:
@@ -221,6 +229,21 @@ def process_page(db: Session, page: Page, *, force: bool = False) -> Page:
     db.refresh(page)
     log.info("Processed page %d of story %d: %d tokens, %d unique lemmas",
              page.page_number, page.story_id, word_rows, len(bare_to_lemma_id))
+
+    # Phase 2b: batch-fetch English glosses for every lemma on the page that
+    # doesn't have one yet. This is what makes the tap-to-lookup feel instant
+    # — when the user taps a word, the gloss is already cached. Skips
+    # function words + proper names internally. Lock-safe: ensure_glosses_batch
+    # commits between chunks so the SQLite write lock is released between
+    # Haiku calls (CLAUDE.md rule #10).
+    if BATCH_GLOSS_ENABLED:
+        try:
+            page_lemma_ids = list(bare_to_lemma_id.values())
+            n_glossed = lemma_gloss.ensure_glosses_batch(db, page_lemma_ids)
+            if n_glossed > 0:
+                log.info("Glossed %d new lemmas on page %d", n_glossed, page.id)
+        except Exception as e:
+            log.warning("Batch gloss failed for page %d: %s", page.id, e)
 
     # Quality gate: LLM-in-context verification of lemma assignments. Gated
     # by POLYGLOT_QUALITY_GATE=1 — for the MVP we want users to opt in once

--- a/polyglot/tests/test_lemma_gloss.py
+++ b/polyglot/tests/test_lemma_gloss.py
@@ -40,7 +40,12 @@ def test_ensure_gloss_handles_cli_failure(tmp_db, monkeypatch):
 
 def test_mark_unknown_triggers_gloss(tmp_db, monkeypatch):
     """End-to-end: mark a lemma 'unknown' → its gloss gets populated via the
-    integration in reading_intake.mark_lemma."""
+    integration in reading_intake.mark_lemma.
+
+    Disable BATCH_GLOSS so the upfront process_page gloss call doesn't preempt
+    this test's mock of the single-form code path.
+    """
+    monkeypatch.setattr(reading_intake, "BATCH_GLOSS_ENABLED", False)
     with tmp_db() as db:
         story = reading_intake.import_paste(db, language_code="el", body="ταξίδι")
         _, tokens = reading_intake.get_page_view(db, story.id, 1)
@@ -71,3 +76,54 @@ def test_batch_gloss(tmp_db, monkeypatch):
         assert l1.gloss_en == "book"
         assert l2.gloss_en == "house"
         assert l3.gloss_en == "family"  # unchanged
+
+
+def test_batch_gloss_skips_function_words_and_proper_names(tmp_db, monkeypatch):
+    """Function words and proper names don't get LLM calls — the gloss is
+    either uninteresting (articles, particles) or self-evident (a name)."""
+    with tmp_db() as db:
+        article = Lemma(language_code="el", lemma_form="ο", lemma_bare="ο",
+                        word_category="function_word", source="m")
+        name = Lemma(language_code="el", lemma_form="Τίγρης", lemma_bare="τιγρης",
+                     word_category="proper_name", source="m")
+        content = Lemma(language_code="el", lemma_form="βιβλίο", lemma_bare="βιβλιο", source="m")
+        db.add_all([article, name, content]); db.commit()
+
+        sent_to_llm = {"lemmas": None}
+
+        def fake_call(lemmas, language_code):
+            sent_to_llm["lemmas"] = [l.lemma_form for l in lemmas]
+            return ["book"]
+
+        monkeypatch.setattr(lemma_gloss, "_call_claude_for_gloss_batch", fake_call)
+
+        count = lemma_gloss.ensure_glosses_batch(
+            db, [article.lemma_id, name.lemma_id, content.lemma_id]
+        )
+        assert count == 1
+        # The LLM never saw the article or the proper name.
+        assert sent_to_llm["lemmas"] == ["βιβλίο"]
+
+
+def test_batch_gloss_chunks_large_input(tmp_db, monkeypatch):
+    """A batch of 120 lemmas with chunk_size=50 should produce 3 CLI calls
+    (50 + 50 + 20), each chunk committing independently."""
+    monkeypatch.setattr(lemma_gloss, "BATCH_CHUNK_SIZE", 50)
+    with tmp_db() as db:
+        lemmas = []
+        for i in range(120):
+            l = Lemma(language_code="el", lemma_form=f"λ{i}", lemma_bare=f"λ{i}", source="m")
+            lemmas.append(l)
+        db.add_all(lemmas); db.commit()
+
+        chunk_sizes: list[int] = []
+
+        def fake_call(chunk, language_code):
+            chunk_sizes.append(len(chunk))
+            return [f"gloss-{l.lemma_form}" for l in chunk]
+
+        monkeypatch.setattr(lemma_gloss, "_call_claude_for_gloss_batch", fake_call)
+
+        count = lemma_gloss.ensure_glosses_batch(db, [l.lemma_id for l in lemmas])
+        assert count == 120
+        assert chunk_sizes == [50, 50, 20]

--- a/polyglot/tests/test_reading_intake.py
+++ b/polyglot/tests/test_reading_intake.py
@@ -107,6 +107,52 @@ def test_mark_lemma_updates_existing(tmp_db):
         assert ulks[0].knowledge_state == "known"
 
 
+def test_process_page_batch_glosses_new_lemmas(tmp_db, monkeypatch):
+    """process_page should call ensure_glosses_batch for every lemma on the
+    page right after Phase 2 commit, so the user sees English meanings the
+    instant a tap lands."""
+    monkeypatch.setattr(reading_intake, "BATCH_GLOSS_ENABLED", True)
+    called_with: list[list[int]] = []
+
+    def fake_batch(db, lemma_ids):
+        called_with.append(list(lemma_ids))
+        return 0
+
+    from app.services import lemma_gloss
+    monkeypatch.setattr(lemma_gloss, "ensure_glosses_batch", fake_batch)
+    monkeypatch.setattr(reading_intake.lemma_quality, "QUALITY_GATE_ENABLED", False)
+    monkeypatch.setattr(reading_intake.body_clean_svc, "BODY_CLEAN_ENABLED", False)
+
+    with tmp_db() as db:
+        story = reading_intake.import_paste(db, language_code="el", body="βιβλίο σπίτι")
+        page, _ = reading_intake.get_page_view(db, story.id, 1)
+        assert page.processed_at is not None
+        assert len(called_with) == 1
+        # Both content lemmas (βιβλίο, σπίτι) should have been queued.
+        assert len(called_with[0]) == 2
+
+
+def test_process_page_skips_batch_gloss_when_disabled(tmp_db, monkeypatch):
+    """POLYGLOT_BATCH_GLOSS=0 disables the upfront gloss call so cost-sensitive
+    deployments can opt out."""
+    monkeypatch.setattr(reading_intake, "BATCH_GLOSS_ENABLED", False)
+    called = {"n": 0}
+
+    def fake_batch(db, lemma_ids):
+        called["n"] += 1
+        return 0
+
+    from app.services import lemma_gloss
+    monkeypatch.setattr(lemma_gloss, "ensure_glosses_batch", fake_batch)
+    monkeypatch.setattr(reading_intake.lemma_quality, "QUALITY_GATE_ENABLED", False)
+    monkeypatch.setattr(reading_intake.body_clean_svc, "BODY_CLEAN_ENABLED", False)
+
+    with tmp_db() as db:
+        story = reading_intake.import_paste(db, language_code="el", body="βιβλίο")
+        reading_intake.get_page_view(db, story.id, 1)
+        assert called["n"] == 0
+
+
 def test_mark_lemma_clear_deletes_ulk(tmp_db):
     """`clear` is the third tap in the reading screen's cycle
     (unknown → encountered → clear). It must delete the ULK so the lemma


### PR DESCRIPTION
## Summary

The new tap-to-cycle UI surfaces English meanings on the first tap, but glosses were only fetched lazily when the user explicitly marked a word unknown. Every other tap showed \"…\" until ensure_gloss returned. This wires \`ensure_glosses_batch\` into \`process_page\` so every lemma created during tokenization gets a cached gloss before the user can tap.

## What changed

\`reading_intake.process_page\` now calls \`ensure_glosses_batch\` right after the Phase 2 commit (lemmas + page-words written), before the existing quality-gate pass. New env var \`POLYGLOT_BATCH_GLOSS\` (default on) for opt-out.

\`lemma_gloss.ensure_glosses_batch\` gained:

- **Chunking** at \`POLYGLOT_GLOSS_CHUNK=50\` lemmas per Haiku call. Larger batches start dropping entries in structured output.
- **Filter**: skips lemmas whose \`word_category\` is \`function_word\` or \`proper_name\`. Their glosses are uninteresting (το = \"the\") or self-evident (Τίγρης = Tigris).
- **Per-chunk commit**: SQLite write lock released between LLM calls (CLAUDE.md rule #10).

The single-lemma \`ensure_gloss\` path that \`mark_lemma\` still calls becomes a cache hit for most words. Tests assert wiring, opt-out, chunking, and the function-word/proper-name filter.

## Cost / latency

Haiku batch: ~\$0.001 per 50 lemmas. Page 11 of the Greek textbook has 266 unique lemmas → ~6 chunks → ~20-30s on first view. Subsequent pages cost only for genuinely new lemmas (~50-100/page typical). Free under Max plan.