### PR TITLE
Polyglot: revamp stats page (today activity, Leitner, FSRS, frequency)

### DIFF
--- a/frontend/app/polyglot-stats.tsx
+++ b/frontend/app/polyglot-stats.tsx
@@ -1,150 +1,671 @@
 /**
- * Polyglot stats — per-language overview of lemma states + story progress.
- * Minimal compared to Alif's stats; no FSRS retention curves yet because
- * polyglot doesn't have scheduling yet.
+ * Polyglot stats — per-language progress dashboard.
+ *
+ * Modelled on Alif's `stats.tsx` (Today / Vocabulary / Progress sections) but
+ * pared down to what polyglot actually exposes: no roots, no textbook
+ * benchmarks, no Quran, no audio. See `polyglot/CLAUDE.md` § "Ground design
+ * and code in Alif".
  */
-import { useEffect, useState } from "react";
-import { View, Text, ScrollView, StyleSheet, ActivityIndicator, Pressable } from "react-native";
-import { useRouter } from "expo-router";
-import { Ionicons } from "@expo/vector-icons";
+import { useCallback, useState } from "react";
+import {
+  View, Text, ScrollView, StyleSheet, ActivityIndicator,
+} from "react-native";
+import { useFocusEffect } from "expo-router";
 import { getLanguageStats, type LanguageStats } from "../lib/polyglot-api";
 
 const C = {
-  bg: "#0f0f1a", surface: "#1a1a2e", border: "#2a2a40",
-  text: "#e0e0f0", textDim: "#9090a8", accent: "#7aa2f7",
-  known: "#3a8a52", acquiring: "#d4a06b", encountered: "#506a8e",
-  unknown: "#c95f6f", ignored: "#3a3a3a", new: "#5a5a70",
+  bg: "#0f0f1a",
+  surface: "#1a1a2e",
+  surfaceAlt: "#22223a",
+  border: "#2a2a40",
+  text: "#e0e0f0",
+  textDim: "#9090a8",
+  textFaint: "#606078",
+  accent: "#7aa2f7",
+  known: "#5fb27a",
+  learning: "#a6c879",
+  acquiring: "#d4a06b",
+  encountered: "#506a8e",
+  lapsed: "#c95f6f",
+  unknown: "#c95f6f",
+  warn: "#e0b060",
+  good: "#5fb27a",
+};
+
+const STABILITY_COLORS: Record<string, string> = {
+  "<1d": "#e74c3c",
+  "1-3d": "#f1c40f",
+  "3-7d": "#f39c12",
+  "7-21d": "#5fb27a",
+  "21-60d": "#27ae60",
+  "60d+": "#1abc9c",
+};
+
+const LANGUAGE_NAMES: Record<string, string> = {
+  el: "Modern Greek",
+  grc: "Ancient Greek",
+  la: "Latin",
 };
 
 export default function PolyglotStats() {
-  const router = useRouter();
   const [stats, setStats] = useState<LanguageStats | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
 
-  useEffect(() => {
-    getLanguageStats("el").then(setStats).catch((e) => setError(String(e)));
-  }, []);
+  useFocusEffect(
+    useCallback(() => {
+      let cancelled = false;
+      setLoading(true);
+      setError(null);
+      getLanguageStats("el")
+        .then((s) => { if (!cancelled) { setStats(s); setLoading(false); } })
+        .catch((e) => { if (!cancelled) { setError(String(e)); setLoading(false); } });
+      return () => { cancelled = true; };
+    }, []),
+  );
 
-  if (error) {
+  if (loading && !stats) {
     return (
       <View style={s.screen}>
-        <BackHeader onBack={() => router.back()} />
-        <Text style={s.error}>Failed to load stats: {error}</Text>
+        <ActivityIndicator color={C.accent} style={{ marginTop: 80 }} />
       </View>
     );
   }
 
-  if (!stats) {
+  if (error || !stats) {
     return (
       <View style={s.screen}>
-        <BackHeader onBack={() => router.back()} />
-        <ActivityIndicator color={C.accent} style={{ marginTop: 40 }} />
+        <Text style={s.error}>Failed to load stats{error ? `: ${error}` : ""}</Text>
       </View>
     );
   }
 
-  const totalMarked =
-    stats.by_state.known + stats.by_state.acquiring + stats.by_state.encountered +
-    stats.by_state.unknown + stats.by_state.ignored;
-  const knownPct = totalMarked > 0
-    ? Math.round((stats.by_state.known / totalMarked) * 100)
+  const languageName = LANGUAGE_NAMES[stats.language_code] ?? stats.language_code;
+  const knownPct = stats.total_lemmas > 0
+    ? Math.round((stats.by_state.known / stats.total_lemmas) * 100)
     : 0;
 
   return (
     <View style={s.screen}>
-      <BackHeader onBack={() => router.back()} />
       <ScrollView contentContainerStyle={s.body}>
-        <Text style={s.h1}>Modern Greek</Text>
+        <Text style={s.h1}>{languageName}</Text>
         <Text style={s.h2}>
-          {totalMarked} marked · {knownPct}% known · {stats.total_lemmas} words in your texts
+          {stats.by_state.known.toLocaleString()} known {"·"} {stats.total_lemmas.toLocaleString()} encountered {"·"} {knownPct}%
         </Text>
 
-        <View style={s.card}>
-          <Text style={s.cardLabel}>Knowledge breakdown</Text>
-          <StateRow label="Known" value={stats.by_state.known} total={stats.total_lemmas} color={C.known} />
-          <StateRow label="Acquiring" value={stats.by_state.acquiring} total={stats.total_lemmas} color={C.acquiring} />
-          <StateRow label="Encountered" value={stats.by_state.encountered} total={stats.total_lemmas} color={C.encountered} />
-          <StateRow label="Marked unknown" value={stats.by_state.unknown} total={stats.total_lemmas} color={C.unknown} />
-          <StateRow label="Ignored" value={stats.by_state.ignored} total={stats.total_lemmas} color={C.ignored} />
-          <StateRow label="Unseen" value={stats.new} total={stats.total_lemmas} color={C.new} />
-        </View>
+        <SectionHeader label="Today" />
+        <TodayCard today={stats.today} />
 
-        <View style={s.card}>
-          <Text style={s.cardLabel}>Texts</Text>
-          {stats.stories.length === 0 ? (
-            <Text style={s.dim}>No texts yet.</Text>
-          ) : (
-            stats.stories.map((st) => (
-              <View key={st.id} style={s.storyLine}>
-                <Text style={s.storyTitle} numberOfLines={1}>{st.title || `#${st.id}`}</Text>
-                <Text style={s.storyMeta}>
-                  {st.processed_pages}/{st.page_count ?? "?"} pages processed
-                </Text>
-              </View>
-            ))
-          )}
-        </View>
+        <SectionHeader label="Vocabulary" />
+        <LifecycleCard byState={stats.by_state} total={stats.total_lemmas} unseen={stats.new} />
+
+        {stats.leitner.total_acquiring > 0 && (
+          <LeitnerCard leitner={stats.leitner} />
+        )}
+
+        {stats.fsrs.tracked > 0 && (
+          <FsrsStabilityCard fsrs={stats.fsrs} />
+        )}
+
+        {stats.frequency && stats.frequency.total_entries > 0 && (
+          <FrequencyCard freq={stats.frequency} />
+        )}
+
+        <SectionHeader label="Activity" />
+        <History14dCard history={stats.history_14d} />
+
+        {stats.stories.length > 0 && (
+          <>
+            <SectionHeader label="Texts" />
+            <StoriesCard stories={stats.stories} />
+          </>
+        )}
+
+        {stats.activity.length > 0 && (
+          <>
+            <SectionHeader label="Recent" />
+            <ActivityFeedCard activity={stats.activity} />
+          </>
+        )}
 
         <Text style={s.footer}>
-          Lemma counts are populated as you read — pages tokenize lazily on first view.
+          Counts update as you read — pages tokenize lazily on first view.
         </Text>
       </ScrollView>
     </View>
   );
 }
 
-function BackHeader({ onBack }: { onBack: () => void }) {
+// ── Section header ────────────────────────────────────────────────────────
+
+function SectionHeader({ label }: { label: string }) {
   return (
-    <View style={s.header}>
-      <Pressable onPress={onBack} style={s.backBtn}>
-        <Ionicons name="chevron-back" size={22} color={C.accent} />
-        <Text style={s.backText}>Back</Text>
-      </Pressable>
+    <View style={s.sectionHeader}>
+      <Text style={s.sectionHeaderText}>{label.toUpperCase()}</Text>
+      <View style={s.sectionHeaderLine} />
     </View>
   );
 }
 
-function StateRow({ label, value, total, color }: { label: string; value: number; total: number; color: string }) {
-  const pct = total > 0 ? (value / total) * 100 : 0;
-  return (
-    <View style={s.stateRow}>
-      <View style={s.stateRowHeader}>
-        <Text style={s.stateLabel}>{label}</Text>
-        <Text style={s.stateValue}>{value}</Text>
+// ── Today ────────────────────────────────────────────────────────────────
+
+function TodayCard({ today }: { today: LanguageStats["today"] }) {
+  const tiles: { value: number; label: string; color?: string }[] = [];
+  tiles.push({ value: today.reviews, label: "reviews" });
+  tiles.push({ value: today.sentence_reviews, label: "sentences" });
+  tiles.push({ value: today.pages_read, label: "pages read" });
+  tiles.push({ value: today.new_lemmas, label: "new lemmas", color: C.accent });
+  tiles.push({ value: today.graduated, label: "graduated", color: C.good });
+  if (today.marked_unknown > 0) {
+    tiles.push({ value: today.marked_unknown, label: "marked ?", color: C.warn });
+  }
+  tiles.push({ value: today.streak, label: "day streak" });
+
+  const allZero =
+    today.reviews === 0 && today.pages_read === 0 &&
+    today.new_lemmas === 0 && today.streak === 0;
+  if (allZero) {
+    return (
+      <View style={s.card}>
+        <Text style={s.emptyText}>
+          Nothing today yet — open a text or run a review to get started.
+        </Text>
       </View>
-      <View style={s.barTrack}>
-        <View style={[s.barFill, { width: `${pct}%`, backgroundColor: color }]} />
+    );
+  }
+
+  return (
+    <View style={s.card}>
+      <View style={s.tileGrid}>
+        {tiles.map((t, i) => (
+          <View key={i} style={s.tile}>
+            <Text style={[s.tileValue, t.color ? { color: t.color } : null]}>
+              {t.value.toLocaleString()}
+            </Text>
+            <Text style={s.tileLabel}>{t.label}</Text>
+          </View>
+        ))}
       </View>
     </View>
   );
 }
+
+// ── Vocabulary lifecycle ─────────────────────────────────────────────────
+
+function LifecycleCard({
+  byState, total, unseen,
+}: {
+  byState: LanguageStats["by_state"]; total: number; unseen: number;
+}) {
+  const stages = [
+    { label: "Seen", count: byState.encountered, color: C.encountered },
+    { label: "Acq", count: byState.acquiring_only, color: C.acquiring },
+    { label: "Learn", count: byState.learning, color: C.learning },
+    { label: "Known", count: byState.known, color: C.known },
+  ];
+  const flowTotal = Math.max(stages.reduce((sum, st) => sum + st.count, 0), 1);
+
+  const extras: { label: string; count: number; color: string }[] = [];
+  if (byState.lapsed > 0) extras.push({ label: "Lapsed", count: byState.lapsed, color: C.lapsed });
+  if (byState.unknown > 0) extras.push({ label: "Marked ?", count: byState.unknown, color: C.unknown });
+  if (byState.ignored > 0) extras.push({ label: "Ignored", count: byState.ignored, color: C.textFaint });
+  if (byState.suspended > 0) extras.push({ label: "Leech", count: byState.suspended, color: C.warn });
+
+  return (
+    <View style={s.card}>
+      <View style={s.heroRow}>
+        <Text style={s.heroNum}>{byState.known.toLocaleString()}</Text>
+        <Text style={s.heroLabel}>known words</Text>
+      </View>
+
+      <View style={s.flowStrip}>
+        {stages.map((stage, i) => (
+          <View
+            key={stage.label}
+            style={{
+              flex: Math.max(stage.count / flowTotal, 0.04),
+              backgroundColor: stage.color + "40",
+              height: 10,
+              borderTopLeftRadius: i === 0 ? 5 : 0,
+              borderBottomLeftRadius: i === 0 ? 5 : 0,
+              borderTopRightRadius: i === stages.length - 1 ? 5 : 0,
+              borderBottomRightRadius: i === stages.length - 1 ? 5 : 0,
+            }}
+          />
+        ))}
+      </View>
+      <View style={s.flowLabels}>
+        {stages.map((stage) => (
+          <View key={stage.label} style={s.flowLabelCell}>
+            <Text style={[s.flowCount, { color: stage.color }]}>{stage.count}</Text>
+            <Text style={s.flowName}>{stage.label}</Text>
+          </View>
+        ))}
+      </View>
+
+      {(extras.length > 0 || unseen > 0) && (
+        <View style={s.chipRow}>
+          {extras.map((e) => (
+            <View key={e.label} style={s.chip}>
+              <Text style={s.chipLabel}>{e.label}</Text>
+              <Text style={[s.chipValue, { color: e.color }]}>{e.count}</Text>
+            </View>
+          ))}
+          {unseen > 0 && (
+            <View style={s.chip}>
+              <Text style={s.chipLabel}>Unseen</Text>
+              <Text style={[s.chipValue, { color: C.textFaint }]}>{unseen}</Text>
+            </View>
+          )}
+          <View style={s.chip}>
+            <Text style={s.chipLabel}>Total</Text>
+            <Text style={s.chipValue}>{total}</Text>
+          </View>
+        </View>
+      )}
+    </View>
+  );
+}
+
+// ── Leitner ──────────────────────────────────────────────────────────────
+
+function LeitnerCard({ leitner }: { leitner: LanguageStats["leitner"] }) {
+  const boxes = [
+    { label: "Box 1", count: leitner.box_1, interval: "4h" },
+    { label: "Box 2", count: leitner.box_2, interval: "1d" },
+    { label: "Box 3", count: leitner.box_3, interval: "3d" },
+  ];
+  return (
+    <View style={s.card}>
+      <View style={s.cardHeaderRow}>
+        <Text style={s.cardTitle}>Acquisition (Leitner)</Text>
+        {leitner.due_now > 0 && (
+          <View style={s.duePill}>
+            <Text style={s.duePillText}>{leitner.due_now} due now</Text>
+          </View>
+        )}
+      </View>
+      <View style={s.leitnerRow}>
+        {boxes.map((b) => (
+          <View key={b.label} style={s.leitnerBox}>
+            <Text style={s.leitnerNum}>{b.count}</Text>
+            <Text style={s.leitnerLabel}>{b.label}</Text>
+            <Text style={s.leitnerInterval}>every {b.interval}</Text>
+          </View>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+// ── FSRS stability ───────────────────────────────────────────────────────
+
+function FsrsStabilityCard({ fsrs }: { fsrs: LanguageStats["fsrs"] }) {
+  const total = fsrs.stability_buckets.reduce((sum, b) => sum + b.count, 0);
+  if (total === 0) return null;
+  const fragile = fsrs.stability_buckets
+    .filter((b) => b.label === "<1d" || b.label === "1-3d")
+    .reduce((s, b) => s + b.count, 0);
+  const growing = fsrs.stability_buckets
+    .filter((b) => b.label === "3-7d" || b.label === "7-21d")
+    .reduce((s, b) => s + b.count, 0);
+  const solid = fsrs.stability_buckets
+    .filter((b) => b.label === "21-60d" || b.label === "60d+")
+    .reduce((s, b) => s + b.count, 0);
+
+  return (
+    <View style={s.card}>
+      <View style={s.cardHeaderRow}>
+        <Text style={s.cardTitle}>FSRS stability</Text>
+        <Text style={s.cardSub}>{fsrs.tracked} tracked</Text>
+      </View>
+
+      <View style={s.stackedBar}>
+        {fsrs.stability_buckets.map((b) => {
+          if (b.count === 0) return null;
+          const pct = (b.count / total) * 100;
+          return (
+            <View
+              key={b.label}
+              style={{
+                width: `${Math.max(pct, 2)}%`,
+                backgroundColor: STABILITY_COLORS[b.label] ?? C.border,
+                height: "100%",
+              }}
+            />
+          );
+        })}
+      </View>
+
+      <View style={s.summaryRow}>
+        {fragile > 0 && (
+          <Text style={[s.summaryItem, { color: STABILITY_COLORS["<1d"] }]}>{fragile} fragile</Text>
+        )}
+        {growing > 0 && (
+          <Text style={[s.summaryItem, { color: STABILITY_COLORS["3-7d"] }]}>{growing} growing</Text>
+        )}
+        {solid > 0 && (
+          <Text style={[s.summaryItem, { color: STABILITY_COLORS["60d+"] }]}>{solid} solid</Text>
+        )}
+      </View>
+
+      <View style={s.bucketGrid}>
+        {fsrs.stability_buckets.filter((b) => b.count > 0).map((b) => (
+          <View key={b.label} style={s.bucketRow}>
+            <View style={[s.bucketDot, { backgroundColor: STABILITY_COLORS[b.label] }]} />
+            <Text style={s.bucketLabel}>{b.label}</Text>
+            <Text style={s.bucketCount}>{b.count}</Text>
+          </View>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+// ── Frequency core ───────────────────────────────────────────────────────
+
+function FrequencyCard({ freq }: { freq: NonNullable<LanguageStats["frequency"]> }) {
+  return (
+    <View style={s.card}>
+      <View style={s.cardHeaderRow}>
+        <Text style={s.cardTitle}>Frequency core</Text>
+        <Text style={s.cardSub}>{freq.source}</Text>
+      </View>
+
+      {freq.bands.map((band) => {
+        const learnedPct = Math.min(band.coverage_pct, 100);
+        const acquiringPct = Math.min((band.acquiring / band.top_n) * 100, 100);
+        const encounteredPct = Math.min((band.encountered / band.top_n) * 100, 100);
+        return (
+          <View key={band.top_n} style={s.freqBand}>
+            <View style={s.freqBandTop}>
+              <Text style={s.freqBandLabel}>Top {band.top_n.toLocaleString()}</Text>
+              <Text style={s.freqBandPct}>{learnedPct.toFixed(1)}%</Text>
+            </View>
+            <View style={s.freqTrack}>
+              <View style={[s.freqLearned, { width: `${learnedPct}%` }]} />
+              <View style={[s.freqAcquiring, {
+                width: `${acquiringPct}%`,
+                left: `${learnedPct}%`,
+              }]} />
+              <View style={[s.freqEncountered, {
+                width: `${encounteredPct}%`,
+                left: `${Math.min(learnedPct + acquiringPct, 100)}%`,
+              }]} />
+            </View>
+            <Text style={s.freqDetail}>
+              {band.learned} learned {"·"} {band.acquiring} acquiring {"·"} {band.encountered} seen
+              {band.unmapped > 0 ? ` · ${band.unmapped} unmapped` : ""}
+            </Text>
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+// ── 14-day activity strip ────────────────────────────────────────────────
+
+function History14dCard({ history }: { history: LanguageStats["history_14d"] }) {
+  const maxReviews = Math.max(1, ...history.map((d) => d.reviews));
+  const maxPages = Math.max(1, ...history.map((d) => d.pages_read));
+  const hasAny = history.some((d) => d.reviews > 0 || d.pages_read > 0 || d.new_lemmas > 0);
+
+  if (!hasAny) {
+    return (
+      <View style={s.card}>
+        <Text style={s.emptyText}>No activity in the last 14 days.</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={s.card}>
+      <Text style={s.cardTitle}>Last 14 days</Text>
+      <View style={s.chartArea}>
+        {history.map((d) => {
+          const rh = d.reviews > 0 ? Math.max((d.reviews / maxReviews) * 70, 3) : 0;
+          const ph = d.pages_read > 0 ? Math.max((d.pages_read / maxPages) * 70, 3) : 0;
+          const dayNum = d.date.slice(8);
+          return (
+            <View key={d.date} style={s.barCol}>
+              <View style={s.barColInner}>
+                {d.new_lemmas > 0 && <View style={s.barNewMark} />}
+                {rh > 0 && <View style={[s.barReviews, { height: rh }]} />}
+                {ph > 0 && <View style={[s.barPages, { height: ph }]} />}
+              </View>
+              <Text style={s.barDayLabel}>{dayNum}</Text>
+            </View>
+          );
+        })}
+      </View>
+      <View style={s.legendRow}>
+        <View style={s.legendItem}>
+          <View style={[s.legendDot, { backgroundColor: C.accent }]} />
+          <Text style={s.legendText}>reviews</Text>
+        </View>
+        <View style={s.legendItem}>
+          <View style={[s.legendDot, { backgroundColor: C.known }]} />
+          <Text style={s.legendText}>pages read</Text>
+        </View>
+        <View style={s.legendItem}>
+          <View style={[s.legendDot, { backgroundColor: C.warn }]} />
+          <Text style={s.legendText}>new lemma day</Text>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+// ── Stories ──────────────────────────────────────────────────────────────
+
+function StoriesCard({ stories }: { stories: LanguageStats["stories"] }) {
+  return (
+    <View style={s.card}>
+      {stories.map((st) => {
+        const total = st.page_count ?? 0;
+        const processedPct = total > 0 ? (st.processed_pages / total) * 100 : 0;
+        const viewedPct = total > 0 ? (st.viewed_pages / total) * 100 : 0;
+        return (
+          <View key={st.id} style={s.storyRow}>
+            <View style={s.storyHead}>
+              <Text style={s.storyTitle} numberOfLines={1}>
+                {st.title || `Untitled #${st.id}`}
+              </Text>
+              <Text style={s.storyMeta}>
+                {st.viewed_pages}/{total || "?"} read
+              </Text>
+            </View>
+            <View style={s.storyTrack}>
+              <View style={[s.storyProcessed, { width: `${processedPct}%` }]} />
+              <View style={[s.storyViewed, { width: `${viewedPct}%` }]} />
+            </View>
+            {(st.known_count > 0 || st.unknown_count > 0) && (
+              <Text style={s.storyDetail}>
+                {st.known_count} known {"·"} {st.unknown_count} unknown
+                {st.total_words > 0 ? ` · ${st.total_words.toLocaleString()} words` : ""}
+              </Text>
+            )}
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+// ── Activity feed ────────────────────────────────────────────────────────
+
+function ActivityFeedCard({ activity }: { activity: LanguageStats["activity"] }) {
+  return (
+    <View style={s.card}>
+      {activity.map((a, i) => (
+        <View key={i} style={s.activityRow}>
+          <Text style={s.activityType}>{a.event_type.replace(/_/g, " ")}</Text>
+          <Text style={s.activitySummary} numberOfLines={2}>{a.summary}</Text>
+          {a.created_at && (
+            <Text style={s.activityTime}>{relativeTime(a.created_at)}</Text>
+          )}
+        </View>
+      ))}
+    </View>
+  );
+}
+
+function relativeTime(iso: string): string {
+  const then = new Date(iso).getTime();
+  if (!Number.isFinite(then)) return "";
+  const diff = Date.now() - then;
+  const min = Math.floor(diff / 60_000);
+  if (min < 1) return "just now";
+  if (min < 60) return `${min}m ago`;
+  const h = Math.floor(min / 60);
+  if (h < 24) return `${h}h ago`;
+  const d = Math.floor(h / 24);
+  if (d < 30) return `${d}d ago`;
+  return iso.slice(0, 10);
+}
+
+// ── Styles ───────────────────────────────────────────────────────────────
 
 const s = StyleSheet.create({
-  screen: { flex: 1, backgroundColor: C.bg, paddingTop: 40 },
-  header: { flexDirection: "row", paddingHorizontal: 16, marginBottom: 8 },
-  backBtn: { flexDirection: "row", alignItems: "center" },
-  backText: { color: C.accent, fontSize: 16 },
+  screen: { flex: 1, backgroundColor: C.bg },
+  body: { paddingHorizontal: 16, paddingTop: 16, paddingBottom: 80 },
 
-  body: { paddingHorizontal: 16, paddingBottom: 60 },
-  h1: { fontSize: 26, fontWeight: "700", color: C.text, marginTop: 8 },
-  h2: { fontSize: 14, color: C.textDim, marginTop: 4, marginBottom: 20 },
+  h1: { fontSize: 28, fontWeight: "700", color: C.text },
+  h2: { fontSize: 13, color: C.textDim, marginTop: 4, marginBottom: 18 },
 
-  card: { backgroundColor: C.surface, borderRadius: 10, padding: 14, marginBottom: 14,
-          borderWidth: 1, borderColor: C.border },
-  cardLabel: { color: C.textDim, fontSize: 12, textTransform: "uppercase", marginBottom: 8 },
+  sectionHeader: { flexDirection: "row", alignItems: "center", marginTop: 18, marginBottom: 8 },
+  sectionHeaderText: {
+    fontSize: 11, color: C.textDim, letterSpacing: 1.2, fontWeight: "700",
+  },
+  sectionHeaderLine: { flex: 1, height: 1, backgroundColor: C.border, marginLeft: 8 },
 
-  stateRow: { marginBottom: 10 },
-  stateRowHeader: { flexDirection: "row", justifyContent: "space-between", marginBottom: 4 },
-  stateLabel: { color: C.text, fontSize: 14 },
-  stateValue: { color: C.textDim, fontSize: 14 },
-  barTrack: { height: 6, backgroundColor: C.bg, borderRadius: 3, overflow: "hidden" },
-  barFill: { height: 6, borderRadius: 3 },
+  card: {
+    backgroundColor: C.surface, borderRadius: 12, padding: 14, marginBottom: 12,
+    borderWidth: 1, borderColor: C.border,
+  },
+  cardHeaderRow: {
+    flexDirection: "row", justifyContent: "space-between",
+    alignItems: "baseline", marginBottom: 10,
+  },
+  cardTitle: { color: C.text, fontSize: 14, fontWeight: "600" },
+  cardSub: { color: C.textDim, fontSize: 12 },
+  emptyText: { color: C.textDim, fontStyle: "italic", fontSize: 13 },
 
-  storyLine: { paddingVertical: 6 },
-  storyTitle: { color: C.text, fontSize: 15 },
-  storyMeta: { color: C.textDim, fontSize: 12, marginTop: 2 },
+  // Today tiles
+  tileGrid: { flexDirection: "row", flexWrap: "wrap", gap: 10 },
+  tile: {
+    backgroundColor: C.surfaceAlt, borderRadius: 8, paddingVertical: 10,
+    paddingHorizontal: 12, minWidth: 84, flex: 1, alignItems: "flex-start",
+  },
+  tileValue: { fontSize: 22, fontWeight: "700", color: C.text },
+  tileLabel: { fontSize: 11, color: C.textDim, marginTop: 2 },
 
-  dim: { color: C.textDim, fontStyle: "italic" },
-  error: { color: "#c95f6f", padding: 20 },
-  footer: { color: C.textDim, fontSize: 11, marginTop: 8, fontStyle: "italic" },
+  // Vocabulary hero + flow
+  heroRow: { flexDirection: "row", alignItems: "baseline", gap: 10, marginBottom: 14 },
+  heroNum: { fontSize: 38, fontWeight: "700", color: C.text },
+  heroLabel: { fontSize: 14, color: C.textDim },
+  flowStrip: { flexDirection: "row", borderRadius: 5, overflow: "hidden", marginBottom: 6 },
+  flowLabels: { flexDirection: "row", justifyContent: "space-between", marginTop: 4 },
+  flowLabelCell: { alignItems: "center", flex: 1 },
+  flowCount: { fontSize: 16, fontWeight: "700" },
+  flowName: { fontSize: 11, color: C.textDim, marginTop: 2 },
+
+  chipRow: { flexDirection: "row", flexWrap: "wrap", gap: 8, marginTop: 14 },
+  chip: {
+    backgroundColor: C.surfaceAlt, borderRadius: 6,
+    paddingHorizontal: 10, paddingVertical: 6,
+  },
+  chipLabel: { fontSize: 10, color: C.textDim, textTransform: "uppercase", letterSpacing: 0.6 },
+  chipValue: { fontSize: 14, fontWeight: "600", color: C.text },
+
+  // Leitner
+  leitnerRow: { flexDirection: "row", gap: 8 },
+  leitnerBox: {
+    flex: 1, backgroundColor: C.surfaceAlt, borderRadius: 8,
+    padding: 12, alignItems: "center",
+  },
+  leitnerNum: { fontSize: 26, fontWeight: "700", color: C.acquiring },
+  leitnerLabel: { fontSize: 12, color: C.text, marginTop: 2 },
+  leitnerInterval: { fontSize: 10, color: C.textFaint, marginTop: 2 },
+  duePill: {
+    backgroundColor: C.warn + "33", borderRadius: 12,
+    paddingHorizontal: 10, paddingVertical: 3,
+  },
+  duePillText: { color: C.warn, fontSize: 12, fontWeight: "600" },
+
+  // FSRS stability
+  stackedBar: {
+    height: 14, borderRadius: 7, backgroundColor: C.surfaceAlt,
+    overflow: "hidden", flexDirection: "row",
+  },
+  summaryRow: { flexDirection: "row", gap: 12, marginTop: 8 },
+  summaryItem: { fontSize: 12, fontWeight: "600" },
+  bucketGrid: { flexDirection: "row", flexWrap: "wrap", gap: 12, marginTop: 8 },
+  bucketRow: { flexDirection: "row", alignItems: "center", gap: 5 },
+  bucketDot: { width: 8, height: 8, borderRadius: 4 },
+  bucketLabel: { fontSize: 11, color: C.textDim },
+  bucketCount: { fontSize: 12, color: C.text, fontWeight: "600" },
+
+  // Frequency
+  freqBand: { marginBottom: 12 },
+  freqBandTop: { flexDirection: "row", justifyContent: "space-between", alignItems: "baseline" },
+  freqBandLabel: { color: C.text, fontSize: 13, fontWeight: "600" },
+  freqBandPct: { color: C.accent, fontSize: 13, fontWeight: "700" },
+  freqTrack: {
+    height: 6, borderRadius: 3, backgroundColor: C.surfaceAlt,
+    overflow: "hidden", position: "relative", marginTop: 4, marginBottom: 4,
+  },
+  freqLearned: { position: "absolute", left: 0, top: 0, height: "100%", backgroundColor: C.known },
+  freqAcquiring: { position: "absolute", top: 0, height: "100%", backgroundColor: C.acquiring + "AA" },
+  freqEncountered: { position: "absolute", top: 0, height: "100%", backgroundColor: C.encountered + "AA" },
+  freqDetail: { color: C.textDim, fontSize: 11 },
+
+  // Activity chart
+  chartArea: {
+    flexDirection: "row", alignItems: "flex-end", justifyContent: "space-between",
+    height: 90, marginTop: 4,
+  },
+  barCol: { flex: 1, alignItems: "center" },
+  barColInner: {
+    flexDirection: "row", alignItems: "flex-end", justifyContent: "center",
+    height: 75, gap: 1, position: "relative",
+  },
+  barReviews: { width: 6, backgroundColor: C.accent, borderRadius: 1 },
+  barPages: { width: 6, backgroundColor: C.known, borderRadius: 1 },
+  barNewMark: {
+    position: "absolute", top: -3, alignSelf: "center",
+    width: 5, height: 5, borderRadius: 2.5, backgroundColor: C.warn,
+  },
+  barDayLabel: { color: C.textFaint, fontSize: 9, marginTop: 4 },
+
+  legendRow: { flexDirection: "row", gap: 14, marginTop: 8, flexWrap: "wrap" },
+  legendItem: { flexDirection: "row", alignItems: "center", gap: 4 },
+  legendDot: { width: 8, height: 8, borderRadius: 4 },
+  legendText: { color: C.textDim, fontSize: 11 },
+
+  // Stories
+  storyRow: { paddingVertical: 8, borderBottomWidth: 1, borderBottomColor: C.border },
+  storyHead: { flexDirection: "row", justifyContent: "space-between", alignItems: "baseline" },
+  storyTitle: { color: C.text, fontSize: 14, flex: 1, marginRight: 8 },
+  storyMeta: { color: C.textDim, fontSize: 11 },
+  storyTrack: {
+    height: 4, borderRadius: 2, backgroundColor: C.surfaceAlt,
+    overflow: "hidden", marginTop: 6, position: "relative",
+  },
+  storyProcessed: { position: "absolute", left: 0, top: 0, height: "100%", backgroundColor: C.encountered },
+  storyViewed: { position: "absolute", left: 0, top: 0, height: "100%", backgroundColor: C.known },
+  storyDetail: { color: C.textFaint, fontSize: 11, marginTop: 4 },
+
+  // Activity feed
+  activityRow: { paddingVertical: 8, borderBottomWidth: 1, borderBottomColor: C.border },
+  activityType: {
+    color: C.accent, fontSize: 11, fontWeight: "700",
+    textTransform: "uppercase", letterSpacing: 0.5,
+  },
+  activitySummary: { color: C.text, fontSize: 13, marginTop: 2 },
+  activityTime: { color: C.textFaint, fontSize: 10, marginTop: 2 },
+
+  error: { color: C.unknown, padding: 20 },
+  footer: { color: C.textFaint, fontSize: 11, marginTop: 14, fontStyle: "italic", textAlign: "center" },
 });

--- a/frontend/lib/polyglot-api.ts
+++ b/frontend/lib/polyglot-api.ts
@@ -169,12 +169,69 @@ export type LanguageStats = {
   new: number;
   by_state: {
     known: number;
-    acquiring: number;
+    learning: number;
+    lapsed: number;
+    acquiring: number;        // legacy: acquiring + learning
+    acquiring_only: number;
     encountered: number;
     unknown: number;
     ignored: number;
+    suspended: number;
   };
-  stories: { id: number; title: string | null; page_count: number | null; processed_pages: number }[];
+  leitner: {
+    total_acquiring: number;
+    box_1: number;
+    box_2: number;
+    box_3: number;
+    due_now: number;
+  };
+  fsrs: {
+    tracked: number;
+    stability_buckets: { label: string; count: number }[];
+  };
+  today: {
+    reviews: number;
+    sentence_reviews: number;
+    pages_read: number;
+    new_lemmas: number;
+    graduated: number;
+    marked_unknown: number;
+    streak: number;
+  };
+  history_14d: {
+    date: string;
+    reviews: number;
+    pages_read: number;
+    new_lemmas: number;
+  }[];
+  frequency: {
+    source: string;
+    total_entries: number;
+    bands: {
+      top_n: number;
+      learned: number;
+      acquiring: number;
+      encountered: number;
+      unmapped: number;
+      new: number;
+      coverage_pct: number;
+    }[];
+  } | null;
+  stories: {
+    id: number;
+    title: string | null;
+    page_count: number | null;
+    processed_pages: number;
+    viewed_pages: number;
+    total_words: number;
+    known_count: number;
+    unknown_count: number;
+  }[];
+  activity: {
+    event_type: string;
+    summary: string;
+    created_at: string | null;
+  }[];
 };
 
 export async function getLanguageStats(languageCode: string): Promise<LanguageStats> {

--- a/polyglot/app/routers/stats.py
+++ b/polyglot/app/routers/stats.py
@@ -1,33 +1,71 @@
-"""Per-language stats: lemma counts by knowledge state, plus story progress.
+"""Per-language stats.
 
-Minimal compared to Alif's stats — just enough to give the user a sense of
-how much they've covered. Expands later (FSRS retention, daily streak, etc.)
-when those mechanisms exist.
+Backs the polyglot Stats screen. Returns:
+- knowledge breakdown by state (known/acquiring/learning/encountered/lapsed/...)
+- today's activity (reviews, pages read, marks, transitions)
+- Leitner box distribution + FSRS stability histogram
+- frequency-rank coverage (top-N bands) when a frequency list is present
+- last-14-days activity strip
+- story progress
+- a recent activity feed from ActivityLog
 """
+from collections import defaultdict
+from datetime import datetime, date, time, timedelta
+from typing import Any
+
 from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy import func, and_
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from app.database import get_db
-from app.models import Lemma, UserLemmaKnowledge, Story, Page, Language
+from app.models import (
+    Lemma, UserLemmaKnowledge, Story, Page, Language,
+    ReviewLog, SentenceReviewLog, FrequencyEntry, ActivityLog,
+)
 
 router = APIRouter(prefix="/api/stats", tags=["stats"])
 
 
+def _utc_start_of_today() -> datetime:
+    """SQLite stores naive UTC datetimes — return a matching naive boundary."""
+    return datetime.combine(datetime.utcnow().date(), time.min)
+
+
+def _utc_start_of_day(d: date) -> datetime:
+    return datetime.combine(d, time.min)
+
+
+_STABILITY_ORDER = ["<1d", "1-3d", "3-7d", "7-21d", "21-60d", "60d+"]
+
+
+def _bucket_stability(days: float | None) -> str:
+    if days is None:
+        return "<1d"
+    if days < 1: return "<1d"
+    if days < 3: return "1-3d"
+    if days < 7: return "3-7d"
+    if days < 21: return "7-21d"
+    if days < 60: return "21-60d"
+    return "60d+"
+
+
 @router.get("")
-def get_stats(language_code: str, db: Session = Depends(get_db)):
+def get_stats(language_code: str, db: Session = Depends(get_db)) -> dict[str, Any]:
     if not db.query(Language).filter(Language.code == language_code).first():
         raise HTTPException(status_code=400, detail=f"Unknown language: {language_code}")
 
-    # Lemma counts by state. Join Lemma → UserLemmaKnowledge (left).
-    state_counts = (
+    today_start = _utc_start_of_today()
+    now = datetime.utcnow()
+
+    # ── 1. Lemma counts by state ─────────────────────────────────────────
+    state_counts_rows = (
         db.query(UserLemmaKnowledge.knowledge_state, func.count(UserLemmaKnowledge.id))
         .join(Lemma, Lemma.lemma_id == UserLemmaKnowledge.lemma_id)
         .filter(Lemma.language_code == language_code)
         .group_by(UserLemmaKnowledge.knowledge_state)
         .all()
     )
-    by_state = {state: count for state, count in state_counts}
+    state_counts = {state: count for state, count in state_counts_rows}
 
     total_lemmas = (
         db.query(func.count(Lemma.lemma_id))
@@ -40,37 +78,363 @@ def get_stats(language_code: str, db: Session = Depends(get_db)):
         .filter(Lemma.language_code == language_code)
         .scalar() or 0
     )
-    new_count = total_lemmas - encountered_or_better
+    new_count = max(total_lemmas - encountered_or_better, 0)
 
-    # Story progress
-    stories = (
+    by_state = {
+        "known": state_counts.get("known", 0),
+        "learning": state_counts.get("learning", 0),
+        "lapsed": state_counts.get("lapsed", 0),
+        # Legacy `acquiring` aggregates acquiring + learning so the existing
+        # client doesn't regress; new clients should read `acquiring_only` +
+        # `learning` separately for the funnel view.
+        "acquiring": state_counts.get("acquiring", 0) + state_counts.get("learning", 0),
+        "acquiring_only": state_counts.get("acquiring", 0),
+        "encountered": state_counts.get("encountered", 0),
+        "unknown": state_counts.get("unknown", 0),
+        "ignored": state_counts.get("ignore", 0),
+        "suspended": state_counts.get("suspended", 0),
+    }
+
+    # ── 2. Leitner box distribution ──────────────────────────────────────
+    box_rows = (
         db.query(
-            Story.id, Story.title, Story.page_count,
+            UserLemmaKnowledge.acquisition_box,
+            func.count(UserLemmaKnowledge.id),
+        )
+        .join(Lemma, Lemma.lemma_id == UserLemmaKnowledge.lemma_id)
+        .filter(
+            Lemma.language_code == language_code,
+            UserLemmaKnowledge.knowledge_state == "acquiring",
+        )
+        .group_by(UserLemmaKnowledge.acquisition_box)
+        .all()
+    )
+    box_counts = {1: 0, 2: 0, 3: 0}
+    for box, count in box_rows:
+        if box in box_counts:
+            box_counts[box] = count
+
+    box_due_now = (
+        db.query(func.count(UserLemmaKnowledge.id))
+        .join(Lemma, Lemma.lemma_id == UserLemmaKnowledge.lemma_id)
+        .filter(
+            Lemma.language_code == language_code,
+            UserLemmaKnowledge.knowledge_state == "acquiring",
+            UserLemmaKnowledge.acquisition_next_due.isnot(None),
+            UserLemmaKnowledge.acquisition_next_due <= now,
+        )
+        .scalar() or 0
+    )
+
+    leitner = {
+        "total_acquiring": sum(box_counts.values()),
+        "box_1": box_counts[1],
+        "box_2": box_counts[2],
+        "box_3": box_counts[3],
+        "due_now": int(box_due_now),
+    }
+
+    # ── 3. FSRS stability histogram ──────────────────────────────────────
+    fsrs_rows = (
+        db.query(UserLemmaKnowledge.fsrs_card_json, UserLemmaKnowledge.knowledge_state)
+        .join(Lemma, Lemma.lemma_id == UserLemmaKnowledge.lemma_id)
+        .filter(
+            Lemma.language_code == language_code,
+            UserLemmaKnowledge.fsrs_card_json.isnot(None),
+            UserLemmaKnowledge.knowledge_state.in_(["learning", "known", "lapsed"]),
+        )
+        .all()
+    )
+    stability_counts: dict[str, int] = defaultdict(int)
+    for card_json, _state in fsrs_rows:
+        if not isinstance(card_json, dict):
+            continue
+        stability_counts[_bucket_stability(card_json.get("stability"))] += 1
+    stability_buckets = [
+        {"label": label, "count": stability_counts.get(label, 0)}
+        for label in _STABILITY_ORDER
+    ]
+
+    fsrs = {
+        "tracked": len(fsrs_rows),
+        "stability_buckets": stability_buckets,
+    }
+
+    # ── 4. Today's activity ──────────────────────────────────────────────
+    reviews_today = (
+        db.query(func.count(ReviewLog.id))
+        .join(Lemma, Lemma.lemma_id == ReviewLog.lemma_id)
+        .filter(
+            Lemma.language_code == language_code,
+            ReviewLog.reviewed_at >= today_start,
+        )
+        .scalar() or 0
+    )
+    sentence_reviews_today = (
+        db.query(func.count(SentenceReviewLog.id))
+        .filter(SentenceReviewLog.reviewed_at >= today_start)
+        .scalar() or 0
+    )
+    pages_read_today = (
+        db.query(func.count(Page.id))
+        .join(Story, Story.id == Page.story_id)
+        .filter(
+            Story.language_code == language_code,
+            Page.viewed_at >= today_start,
+        )
+        .scalar() or 0
+    )
+    new_lemmas_today = (
+        db.query(func.count(UserLemmaKnowledge.id))
+        .join(Lemma, Lemma.lemma_id == UserLemmaKnowledge.lemma_id)
+        .filter(
+            Lemma.language_code == language_code,
+            UserLemmaKnowledge.introduced_at >= today_start,
+        )
+        .scalar() or 0
+    )
+    graduated_today = (
+        db.query(func.count(UserLemmaKnowledge.id))
+        .join(Lemma, Lemma.lemma_id == UserLemmaKnowledge.lemma_id)
+        .filter(
+            Lemma.language_code == language_code,
+            UserLemmaKnowledge.graduated_at >= today_start,
+        )
+        .scalar() or 0
+    )
+    unknown_marked_today = (
+        db.query(func.count(UserLemmaKnowledge.id))
+        .join(Lemma, Lemma.lemma_id == UserLemmaKnowledge.lemma_id)
+        .filter(
+            Lemma.language_code == language_code,
+            UserLemmaKnowledge.knowledge_state == "unknown",
+            UserLemmaKnowledge.introduced_at >= today_start,
+        )
+        .scalar() or 0
+    )
+
+    # ── 5. Streak: consecutive past days with ≥1 review, anchored on today ──
+    streak = 0
+    cursor = datetime.utcnow().date()
+    # If today has no reviews yet, allow a 1-day grace and start counting from yesterday.
+    if reviews_today == 0:
+        cursor = cursor - timedelta(days=1)
+    while streak < 365:
+        day_start = _utc_start_of_day(cursor)
+        day_end = day_start + timedelta(days=1)
+        had_review = (
+            db.query(ReviewLog.id)
+            .join(Lemma, Lemma.lemma_id == ReviewLog.lemma_id)
+            .filter(
+                Lemma.language_code == language_code,
+                ReviewLog.reviewed_at >= day_start,
+                ReviewLog.reviewed_at < day_end,
+            )
+            .first()
+        )
+        if not had_review:
+            break
+        streak += 1
+        cursor = cursor - timedelta(days=1)
+
+    today = {
+        "reviews": int(reviews_today),
+        "sentence_reviews": int(sentence_reviews_today),
+        "pages_read": int(pages_read_today),
+        "new_lemmas": int(new_lemmas_today),
+        "graduated": int(graduated_today),
+        "marked_unknown": int(unknown_marked_today),
+        "streak": streak,
+    }
+
+    # ── 6. Last-14-day activity strip ────────────────────────────────────
+    history: list[dict[str, Any]] = []
+    for i in range(13, -1, -1):
+        day = (datetime.utcnow().date() - timedelta(days=i))
+        day_start = _utc_start_of_day(day)
+        day_end = day_start + timedelta(days=1)
+        r = (
+            db.query(func.count(ReviewLog.id))
+            .join(Lemma, Lemma.lemma_id == ReviewLog.lemma_id)
+            .filter(
+                Lemma.language_code == language_code,
+                ReviewLog.reviewed_at >= day_start,
+                ReviewLog.reviewed_at < day_end,
+            )
+            .scalar() or 0
+        )
+        p = (
+            db.query(func.count(Page.id))
+            .join(Story, Story.id == Page.story_id)
+            .filter(
+                Story.language_code == language_code,
+                Page.viewed_at >= day_start,
+                Page.viewed_at < day_end,
+            )
+            .scalar() or 0
+        )
+        n = (
+            db.query(func.count(UserLemmaKnowledge.id))
+            .join(Lemma, Lemma.lemma_id == UserLemmaKnowledge.lemma_id)
+            .filter(
+                Lemma.language_code == language_code,
+                UserLemmaKnowledge.introduced_at >= day_start,
+                UserLemmaKnowledge.introduced_at < day_end,
+            )
+            .scalar() or 0
+        )
+        history.append({
+            "date": day.isoformat(),
+            "reviews": int(r),
+            "pages_read": int(p),
+            "new_lemmas": int(n),
+        })
+
+    # ── 7. Frequency-rank coverage (when a frequency list is present) ────
+    frequency_block = _frequency_progress(db, language_code)
+
+    # ── 8. Story progress ────────────────────────────────────────────────
+    story_rows = (
+        db.query(
+            Story.id, Story.title, Story.page_count, Story.total_words,
+            Story.known_count, Story.unknown_count,
             func.count(Page.id).filter(Page.processed_at.isnot(None)).label("processed"),
+            func.count(Page.id).filter(Page.viewed_at.isnot(None)).label("viewed"),
         )
         .outerjoin(Page, Page.story_id == Story.id)
         .filter(Story.language_code == language_code)
         .group_by(Story.id)
+        .order_by(Story.created_at.desc())
         .all()
     )
-    story_progress = [
+    stories = [
         {
-            "id": s.id, "title": s.title, "page_count": s.page_count,
+            "id": s.id,
+            "title": s.title,
+            "page_count": s.page_count,
             "processed_pages": int(s.processed or 0),
+            "viewed_pages": int(s.viewed or 0),
+            "total_words": int(s.total_words or 0),
+            "known_count": int(s.known_count or 0),
+            "unknown_count": int(s.unknown_count or 0),
         }
-        for s in stories
+        for s in story_rows
+    ]
+
+    # ── 9. Recent activity feed (ActivityLog, last 10) ───────────────────
+    activity_rows = (
+        db.query(ActivityLog)
+        .filter(
+            (ActivityLog.language_code == language_code)
+            | (ActivityLog.language_code.is_(None))
+        )
+        .order_by(ActivityLog.created_at.desc())
+        .limit(10)
+        .all()
+    )
+    activity = [
+        {
+            "event_type": a.event_type,
+            "summary": a.summary,
+            "created_at": a.created_at.isoformat() if a.created_at else None,
+        }
+        for a in activity_rows
     ]
 
     return {
         "language_code": language_code,
         "total_lemmas": total_lemmas,
         "new": new_count,
-        "by_state": {
-            "known": by_state.get("known", 0),
-            "acquiring": by_state.get("acquiring", 0) + by_state.get("learning", 0),
-            "encountered": by_state.get("encountered", 0),
-            "unknown": by_state.get("unknown", 0),
-            "ignored": by_state.get("ignore", 0),
-        },
-        "stories": story_progress,
+        "by_state": by_state,
+        "leitner": leitner,
+        "fsrs": fsrs,
+        "today": today,
+        "history_14d": history,
+        "frequency": frequency_block,
+        "stories": stories,
+        "activity": activity,
+    }
+
+
+# ── frequency progress (top-N bands) ──────────────────────────────────────
+
+
+def _frequency_progress(db: Session, language_code: str) -> dict[str, Any] | None:
+    """Top-N coverage bands when a frequency list exists for this language.
+
+    Picks the largest available source (by entry count) and reports coverage
+    for the top 100/500/1000/2000/5000 ranks. Returns None when the table is
+    empty for this language — the frontend hides the card in that case.
+    """
+    source_row = (
+        db.query(FrequencyEntry.source, func.count(FrequencyEntry.id).label("n"))
+        .filter(FrequencyEntry.language_code == language_code)
+        .group_by(FrequencyEntry.source)
+        .order_by(func.count(FrequencyEntry.id).desc())
+        .first()
+    )
+    if not source_row:
+        return None
+
+    source = source_row.source
+    total_in_source = int(source_row.n)
+
+    rows = (
+        db.query(FrequencyEntry.rank, UserLemmaKnowledge.knowledge_state,
+                 FrequencyEntry.lemma_id)
+        .outerjoin(UserLemmaKnowledge,
+                   UserLemmaKnowledge.lemma_id == FrequencyEntry.lemma_id)
+        .filter(
+            FrequencyEntry.language_code == language_code,
+            FrequencyEntry.source == source,
+        )
+        .all()
+    )
+    rank_state: dict[int, str] = {}
+    for rank, state, lemma_id in rows:
+        if lemma_id is None:
+            rank_state[rank] = "unmapped"
+        else:
+            rank_state[rank] = state or "new"
+
+    band_candidates = [100, 500, 1000, 2000, 5000]
+    band_sizes = [b for b in band_candidates if b <= total_in_source]
+    if not band_sizes:
+        band_sizes = [total_in_source]
+    elif band_sizes[-1] < total_in_source:
+        band_sizes.append(total_in_source)
+
+    bands: list[dict[str, Any]] = []
+    for top_n in band_sizes:
+        learned = acquiring = encountered = unmapped = newer = 0
+        for rank in range(1, top_n + 1):
+            st = rank_state.get(rank)
+            if st is None:
+                newer += 1
+                continue
+            if st == "unmapped":
+                unmapped += 1
+            elif st in ("known", "learning"):
+                learned += 1
+            elif st in ("acquiring", "lapsed"):
+                acquiring += 1
+            elif st == "encountered":
+                encountered += 1
+            else:
+                newer += 1
+        coverage_pct = round((learned / top_n) * 100, 1) if top_n else 0.0
+        bands.append({
+            "top_n": top_n,
+            "learned": learned,
+            "acquiring": acquiring,
+            "encountered": encountered,
+            "unmapped": unmapped,
+            "new": newer,
+            "coverage_pct": coverage_pct,
+        })
+
+    return {
+        "source": source,
+        "total_entries": total_in_source,
+        "bands": bands,
     }

--- a/polyglot/tests/test_stats_router.py
+++ b/polyglot/tests/test_stats_router.py
@@ -1,0 +1,210 @@
+"""Smoke + shape tests for /api/stats.
+
+Verifies the expanded payload (today, leitner, fsrs, history_14d, frequency)
+renders for both an empty DB and one seeded with lemmas / reviews / pages /
+frequency entries.
+"""
+from datetime import datetime, timedelta
+
+from fastapi.testclient import TestClient
+
+from app.database import get_db
+from app.main import app
+from app.models import (
+    Lemma, UserLemmaKnowledge, ReviewLog, Story, Page,
+    FrequencyEntry,
+)
+
+
+def _client(tmp_db):
+    test_session_factory = tmp_db
+
+    def _override():
+        db = test_session_factory()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = _override
+    return TestClient(app), test_session_factory
+
+
+def _cleanup():
+    app.dependency_overrides.clear()
+
+
+def test_stats_empty_language(tmp_db):
+    client, _ = _client(tmp_db)
+    try:
+        r = client.get("/api/stats?language_code=el")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["language_code"] == "el"
+        assert body["total_lemmas"] == 0
+        assert body["new"] == 0
+        assert body["by_state"]["known"] == 0
+        assert body["leitner"]["total_acquiring"] == 0
+        assert body["fsrs"]["tracked"] == 0
+        assert body["today"]["reviews"] == 0
+        assert body["today"]["streak"] == 0
+        assert len(body["history_14d"]) == 14
+        assert body["frequency"] is None
+        assert body["stories"] == []
+    finally:
+        _cleanup()
+
+
+def test_stats_rejects_unknown_language(tmp_db):
+    client, _ = _client(tmp_db)
+    try:
+        r = client.get("/api/stats?language_code=xx")
+        assert r.status_code == 400
+    finally:
+        _cleanup()
+
+
+def test_stats_counts_lemmas_by_state(tmp_db):
+    client, factory = _client(tmp_db)
+    try:
+        with factory() as db:
+            for form, state in [
+                ("α", "known"), ("β", "known"), ("γ", "acquiring"),
+                ("δ", "learning"), ("ε", "encountered"), ("ζ", "lapsed"),
+            ]:
+                lemma = Lemma(language_code="el", lemma_form=form, lemma_bare=form,
+                              source="test")
+                db.add(lemma)
+                db.flush()
+                db.add(UserLemmaKnowledge(
+                    lemma_id=lemma.lemma_id, knowledge_state=state,
+                ))
+            # One lemma with no ULK → counts as "new" (unseen).
+            db.add(Lemma(language_code="el", lemma_form="η", lemma_bare="η", source="test"))
+            db.commit()
+
+        r = client.get("/api/stats?language_code=el")
+        body = r.json()
+        assert body["total_lemmas"] == 7
+        assert body["new"] == 1
+        assert body["by_state"]["known"] == 2
+        assert body["by_state"]["acquiring_only"] == 1
+        assert body["by_state"]["learning"] == 1
+        assert body["by_state"]["acquiring"] == 2  # legacy aggregate
+        assert body["by_state"]["encountered"] == 1
+        assert body["by_state"]["lapsed"] == 1
+    finally:
+        _cleanup()
+
+
+def test_stats_leitner_and_fsrs(tmp_db):
+    client, factory = _client(tmp_db)
+    try:
+        with factory() as db:
+            now = datetime.utcnow()
+            # Three acquiring lemmas across boxes, one of them due
+            for form, box, due_offset_h in [
+                ("a", 1, -1), ("b", 2, 5), ("c", 3, 24),
+            ]:
+                lemma = Lemma(language_code="el", lemma_form=form, lemma_bare=form,
+                              source="test")
+                db.add(lemma)
+                db.flush()
+                db.add(UserLemmaKnowledge(
+                    lemma_id=lemma.lemma_id,
+                    knowledge_state="acquiring",
+                    acquisition_box=box,
+                    acquisition_next_due=now + timedelta(hours=due_offset_h),
+                ))
+            # Two FSRS-tracked lemmas with different stabilities
+            for form, stab in [("d", 0.5), ("e", 12.0)]:
+                lemma = Lemma(language_code="el", lemma_form=form, lemma_bare=form,
+                              source="test")
+                db.add(lemma)
+                db.flush()
+                db.add(UserLemmaKnowledge(
+                    lemma_id=lemma.lemma_id,
+                    knowledge_state="known",
+                    fsrs_card_json={"stability": stab, "difficulty": 5.0, "state": 2},
+                ))
+            db.commit()
+
+        body = client.get("/api/stats?language_code=el").json()
+        assert body["leitner"]["box_1"] == 1
+        assert body["leitner"]["box_2"] == 1
+        assert body["leitner"]["box_3"] == 1
+        assert body["leitner"]["total_acquiring"] == 3
+        assert body["leitner"]["due_now"] == 1
+
+        assert body["fsrs"]["tracked"] == 2
+        buckets = {b["label"]: b["count"] for b in body["fsrs"]["stability_buckets"]}
+        assert buckets["<1d"] == 1
+        assert buckets["7-21d"] == 1
+    finally:
+        _cleanup()
+
+
+def test_stats_today_activity_and_history(tmp_db):
+    client, factory = _client(tmp_db)
+    try:
+        with factory() as db:
+            lemma = Lemma(language_code="el", lemma_form="x", lemma_bare="x",
+                          source="test")
+            db.add(lemma); db.flush()
+            now = datetime.utcnow()
+            db.add(ReviewLog(lemma_id=lemma.lemma_id, rating=3, reviewed_at=now))
+            db.add(ReviewLog(lemma_id=lemma.lemma_id, rating=3,
+                             reviewed_at=now - timedelta(days=2)))
+            # Page viewed today
+            story = Story(language_code="el", title="t", source="paste", body_src="x")
+            db.add(story); db.flush()
+            db.add(Page(story_id=story.id, page_number=1, body_src="x", viewed_at=now))
+            # ULK introduced today
+            db.add(UserLemmaKnowledge(
+                lemma_id=lemma.lemma_id, knowledge_state="acquiring",
+                introduced_at=now,
+            ))
+            db.commit()
+
+        body = client.get("/api/stats?language_code=el").json()
+        assert body["today"]["reviews"] == 1
+        assert body["today"]["pages_read"] == 1
+        assert body["today"]["new_lemmas"] == 1
+        assert body["today"]["streak"] >= 1
+        # history_14d has today and day -2 as non-zero entries
+        assert any(d["reviews"] == 1 for d in body["history_14d"])
+    finally:
+        _cleanup()
+
+
+def test_stats_frequency_block(tmp_db):
+    client, factory = _client(tmp_db)
+    try:
+        with factory() as db:
+            lemma = Lemma(language_code="el", lemma_form="ο", lemma_bare="ο",
+                          source="test")
+            db.add(lemma); db.flush()
+            db.add(UserLemmaKnowledge(lemma_id=lemma.lemma_id, knowledge_state="known"))
+            db.add(FrequencyEntry(
+                language_code="el", source="subtlex_gr", rank=1,
+                lemma_key="ο", display_form="ο", lemma_id=lemma.lemma_id,
+            ))
+            # An unlinked frequency entry
+            db.add(FrequencyEntry(
+                language_code="el", source="subtlex_gr", rank=2,
+                lemma_key="η", display_form="η", lemma_id=None,
+            ))
+            db.commit()
+
+        body = client.get("/api/stats?language_code=el").json()
+        assert body["frequency"] is not None
+        assert body["frequency"]["source"] == "subtlex_gr"
+        assert body["frequency"]["total_entries"] == 2
+        bands = body["frequency"]["bands"]
+        assert len(bands) >= 1
+        # The 100-band (or fallback band) should report 1 learned, 1 unmapped
+        first = bands[0]
+        assert first["learned"] == 1
+        assert first["unmapped"] == 1
+    finally:
+        _cleanup()


### PR DESCRIPTION
## Summary
- Polyglot's stats endpoint now exposes today's reviews / pages-read / new-lemmas / streak, Leitner box distribution, FSRS stability histogram, frequency-rank coverage bands, a 14-day activity history, and the recent ActivityLog feed.
- Polyglot stats screen rewritten on Alif's Today / Vocabulary / Activity layout. Every new section is gated on having data, so the screen degrades cleanly on an early-stage DB. In-page back button removed (the screen is reached as a tab).
- New `tests/test_stats_router.py` covers empty DB, state counts, Leitner/FSRS distributions, today + 14-day history, frequency bands, and the unknown-language reject path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)