### PR TITLE
Polyglot: Modern Editorial design + lemma philology enrichment

### DIFF
--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -251,6 +251,7 @@ function LayoutInner({ online }: { online: boolean }) {
         <Tabs.Screen name="root/[id]" options={{ href: null, title: "Root Detail" }} />
         <Tabs.Screen name="pattern/[id]" options={{ href: null, title: "Pattern Detail" }} />
         <Tabs.Screen name="words" options={{ href: null, title: "Words" }} />
+        <Tabs.Screen name="polyglot-lemma/[id]" options={{ href: null, title: "Lemma Detail" }} />
       </Tabs>
     </>
   );

--- a/frontend/app/polyglot-lemma/[id].tsx
+++ b/frontend/app/polyglot-lemma/[id].tsx
@@ -1,0 +1,692 @@
+/**
+ * Polyglot lemma detail screen — Modern Editorial.
+ *
+ * The full philological deep-dive: etymology + morphology callout, vertical
+ * diachrony timeline (3-5 stages, color-coded by era), cognates table with
+ * language pills, literary quotes with purple left-rule, and a register
+ * section with collocations + false-friend warning. iPhone-first column
+ * (page H padding = POLYGLOT_SPACING.pageH so the layout breathes at 390px
+ * width but stretches gracefully on larger screens).
+ *
+ * Locked design from 2026-05-21 design-explorer round 2 — see
+ * `~/.claude/design-explorer/mockups/alif/mockup-detail-iphone-editorial.html`
+ * and the λόγος stress-test variant. Most styling choices map 1:1 from those
+ * mockups to React Native; comments only mark places where RN forced a
+ * divergence.
+ *
+ * Empty states: the screen still renders the header (lemma + gloss + chips)
+ * even when enrichment is null. Each enrichment section unmounts when its
+ * slice is empty rather than rendering a skeleton — a missing diachrony list
+ * usually means the cron just hasn't enriched this lemma yet.
+ */
+import React, { useEffect, useState } from "react";
+import {
+  ActivityIndicator,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
+import { Stack, useLocalSearchParams, useRouter } from "expo-router";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { getLemmaDetail, LemmaDetail } from "../../lib/polyglot-api";
+import {
+  POLYGLOT_COLORS,
+  POLYGLOT_RADIUS,
+  POLYGLOT_SPACING,
+  POLYGLOT_TYPE,
+  eraColor,
+} from "../../lib/polyglot-design-colors";
+import { POLYGLOT_FONTS } from "../../lib/polyglot-design-tokens";
+
+export default function PolyglotLemmaDetailScreen() {
+  const params = useLocalSearchParams<{ id: string }>();
+  const router = useRouter();
+  const lemmaId = Number(params.id);
+
+  const [detail, setDetail] = useState<LemmaDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    setLoading(true);
+    setError(null);
+    getLemmaDetail(lemmaId)
+      .then((d) => {
+        if (alive) setDetail(d);
+      })
+      .catch((e) => {
+        if (alive) setError(String(e?.message ?? e));
+      })
+      .finally(() => {
+        if (alive) setLoading(false);
+      });
+    return () => {
+      alive = false;
+    };
+  }, [lemmaId]);
+
+  if (loading) {
+    return (
+      <SafeAreaView style={styles.loadingWrap} edges={["top"]}>
+        <Stack.Screen options={{ headerShown: false }} />
+        <ActivityIndicator size="small" color={POLYGLOT_COLORS.accent} />
+      </SafeAreaView>
+    );
+  }
+
+  if (error || !detail) {
+    return (
+      <SafeAreaView style={styles.loadingWrap} edges={["top"]}>
+        <Stack.Screen options={{ headerShown: false }} />
+        <View style={styles.topbar}>
+          <Pressable onPress={() => router.back()} hitSlop={10}>
+            <Text style={styles.backLink}>‹ Back</Text>
+          </Pressable>
+        </View>
+        <View style={{ padding: 24, alignItems: "center", gap: 8 }}>
+          <Text style={{ color: POLYGLOT_COLORS.text, fontSize: 16 }}>
+            Couldn't load lemma {lemmaId}.
+          </Text>
+          {error ? (
+            <Text style={{ color: POLYGLOT_COLORS.textSecondary, fontSize: 12 }}>
+              {error}
+            </Text>
+          ) : null}
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  const enrichment = detail.enrichment;
+  const etymology = enrichment?.etymology;
+  const diachrony = enrichment?.diachrony ?? [];
+  const cognates = enrichment?.cognates ?? [];
+  const quotes = enrichment?.quotes ?? [];
+  const register = enrichment?.register;
+
+  // Ancient form: prefer the cognate Lemma's form (cognate_lemma_form), fall
+  // back to etymology.ancient_form. Both can be present; cognate is more
+  // authoritative because it's a DB link, not LLM output.
+  const ancientForm = detail.cognate_lemma_form ?? etymology?.ancient_form ?? null;
+
+  return (
+    <SafeAreaView style={styles.root} edges={["top"]}>
+      <Stack.Screen options={{ headerShown: false }} />
+      <View style={styles.topbar}>
+        <Pressable onPress={() => router.back()} hitSlop={10}>
+          <Text style={styles.backLink}>‹ Reader</Text>
+        </Pressable>
+        <Text style={styles.breadcrumb}>
+          {detail.language_code === "el" ? "Modern Greek" : detail.language_code} · lemma · #{detail.lemma_id}
+        </Text>
+      </View>
+
+      <ScrollView contentContainerStyle={styles.scrollBody} showsVerticalScrollIndicator={false}>
+        {/* Header — always renders, even when enrichment is null */}
+        <View style={styles.head}>
+          <View style={styles.wordRow}>
+            <Text style={styles.greekForm}>{detail.lemma_form}</Text>
+          </View>
+          {detail.gloss_en ? (
+            <Text style={styles.gloss}>{detail.gloss_en}</Text>
+          ) : null}
+          <View style={styles.chips}>
+            {detail.pos ? <Chip kind="pos" label={detail.pos} /> : null}
+            {ancientForm ? <Chip kind="cog" label="Ancient" greek={ancientForm} /> : null}
+            {etymology?.pie_root ? <Chip kind="pie" label={etymology.pie_root} /> : null}
+            {detail.frequency_rank != null ? (
+              <Chip kind="freq" label={`freq #${detail.frequency_rank}`} />
+            ) : null}
+          </View>
+        </View>
+
+        {/* Etymology */}
+        {etymology ? (
+          <Section accent={POLYGLOT_COLORS.etymology} title="Etymology">
+            <Text style={styles.etyProse}>{etymology.origin_note}</Text>
+            {etymology.morphology ? (
+              <View style={styles.morph}>
+                <Text style={styles.morphText}>{etymology.morphology}</Text>
+              </View>
+            ) : null}
+          </Section>
+        ) : null}
+
+        {/* Diachrony — vertical timeline */}
+        {diachrony.length > 0 ? (
+          <Section
+            accent={POLYGLOT_COLORS.etymology}
+            title="Across time"
+            count={`${diachrony.length} stages`}
+          >
+            <View style={styles.timeline}>
+              {/* Vertical rail — extends from first to last dot. */}
+              <View style={styles.timelineRail} />
+              {diachrony.map((stage, idx) => (
+                <View key={`stage-${idx}`} style={styles.stage}>
+                  <View
+                    style={[
+                      styles.stageDot,
+                      { backgroundColor: eraColor(stage.era), borderColor: POLYGLOT_COLORS.bg },
+                    ]}
+                  />
+                  <View style={styles.stageBody}>
+                    <Text style={[styles.stageEra, { color: eraColor(stage.era) }]}>
+                      {stage.era}
+                    </Text>
+                    <Text style={styles.stageForm}>{stage.form}</Text>
+                    <Text style={styles.stageMeaning}>{stage.meaning}</Text>
+                    {stage.note ? <Text style={styles.stageNote}>{stage.note}</Text> : null}
+                  </View>
+                </View>
+              ))}
+            </View>
+          </Section>
+        ) : null}
+
+        {/* Cognates */}
+        {cognates.length > 0 ? (
+          <Section
+            accent={POLYGLOT_COLORS.cognate}
+            title="Cognates"
+            count={`${cognates.length} across ${countLanguages(cognates)} language${countLanguages(cognates) === 1 ? "" : "s"}`}
+          >
+            {cognates.map((cog, idx) => (
+              <View key={`cog-${idx}`} style={[styles.cogRow, idx === cognates.length - 1 && { borderBottomWidth: 0 }]}>
+                <View style={styles.cogLeft}>
+                  <Text
+                    style={[
+                      styles.cogForm,
+                      isGreekLatin(cog.language) && {
+                        fontFamily: POLYGLOT_FONTS.greekDisplay,
+                        fontSize: POLYGLOT_TYPE.cogGreek,
+                      },
+                    ]}
+                  >
+                    {cog.form}
+                  </Text>
+                  {cog.note ? <Text style={styles.cogNote}>{cog.note}</Text> : null}
+                </View>
+                <View style={styles.cogTag}>
+                  <View style={styles.cogLangPill}>
+                    <Text style={styles.cogLangText}>{shortLang(cog.language)}</Text>
+                  </View>
+                  <Text style={styles.cogRel}>{shortRel(cog.relation)}</Text>
+                </View>
+              </View>
+            ))}
+          </Section>
+        ) : null}
+
+        {/* Quotes */}
+        {quotes.length > 0 ? (
+          <Section
+            accent={POLYGLOT_COLORS.quote}
+            title="In the literature"
+            count={`${quotes.length} attestation${quotes.length === 1 ? "" : "s"}`}
+          >
+            {quotes.map((q, idx) => (
+              <View key={`q-${idx}`} style={styles.quoteCard}>
+                <Text style={styles.qtext}>{q.text}</Text>
+                <Text style={styles.qtrans}>"{q.translation_en}"</Text>
+                <View style={styles.qsourceRow}>
+                  <View
+                    style={[
+                      styles.eraPill,
+                      { backgroundColor: eraColor(q.era) + "22", borderColor: eraColor(q.era) },
+                    ]}
+                  >
+                    <Text style={[styles.eraPillText, { color: eraColor(q.era) }]}>
+                      {q.era}
+                    </Text>
+                  </View>
+                  <Text style={styles.qsource}>{q.source}</Text>
+                </View>
+              </View>
+            ))}
+          </Section>
+        ) : null}
+
+        {/* Register / modern usage */}
+        {register ? (
+          <Section
+            accent={POLYGLOT_COLORS.accent}
+            title="Modern usage"
+            count={register.formality ? `${register.formality} register` : undefined}
+          >
+            {register.usage_note ? (
+              <Text style={styles.usageNote}>{register.usage_note}</Text>
+            ) : null}
+            {register.collocations.length > 0 ? (
+              <View style={styles.collList}>
+                {register.collocations.map((c) => (
+                  <View key={c} style={styles.collPill}>
+                    <Text style={styles.collText}>{c}</Text>
+                  </View>
+                ))}
+              </View>
+            ) : null}
+            {register.false_friends_en.length > 0 ? (
+              <View style={styles.ffNote}>
+                <Text style={styles.ffNoteText}>
+                  ⚠ <Text style={styles.ffStrong}>False friend{register.false_friends_en.length > 1 ? "s" : ""}:</Text>{" "}
+                  {register.false_friends_en.join(", ")}.
+                </Text>
+              </View>
+            ) : null}
+          </Section>
+        ) : null}
+
+        {/* Empty-state hint when no enrichment yet */}
+        {!enrichment ? (
+          <View style={styles.emptyHint}>
+            <Text style={styles.emptyHintText}>
+              No philology yet for this lemma — it will appear after the next enrichment pass.
+            </Text>
+          </View>
+        ) : null}
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+function Section({
+  title,
+  count,
+  accent,
+  children,
+}: {
+  title: string;
+  count?: string;
+  accent: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <View style={styles.section}>
+      <View style={styles.sectionLabel}>
+        <Text style={[styles.sectionLabelText, { color: accent }]}>{title}</Text>
+        {count ? <Text style={styles.sectionCount}>{count}</Text> : null}
+      </View>
+      {children}
+    </View>
+  );
+}
+
+function Chip({
+  kind,
+  label,
+  greek,
+}: {
+  kind: "pos" | "cog" | "pie" | "freq";
+  label: string;
+  greek?: string;
+}) {
+  const palette = {
+    pos: { bg: POLYGLOT_COLORS.surfaceMuted, fg: "#555" },
+    cog: { bg: POLYGLOT_COLORS.cognateTint, fg: POLYGLOT_COLORS.cognate },
+    pie: { bg: POLYGLOT_COLORS.etymologyTint, fg: POLYGLOT_COLORS.etymology },
+    freq: { bg: POLYGLOT_COLORS.surfaceMuted, fg: POLYGLOT_COLORS.textSecondary },
+  }[kind];
+  return (
+    <View style={[styles.chip, { backgroundColor: palette.bg }]}>
+      <Text style={[styles.chipText, { color: palette.fg }]}>
+        {label}
+        {greek ? <Text style={styles.chipGreek}>{" "}{greek}</Text> : null}
+      </Text>
+    </View>
+  );
+}
+
+function countLanguages(cogs: { language: string }[]): number {
+  return new Set(cogs.map((c) => c.language)).size;
+}
+
+function isGreekLatin(language: string): boolean {
+  const l = language.toLowerCase();
+  return l.startsWith("greek") || l.startsWith("latin") || l === "la" || l === "el";
+}
+
+function shortLang(language: string): string {
+  const map: Record<string, string> = {
+    english: "EN",
+    latin: "LA",
+    german: "DE",
+    french: "FR",
+    italian: "IT",
+    spanish: "ES",
+    russian: "RU",
+    sanskrit: "SA",
+    greek: "GR",
+  };
+  const key = language.toLowerCase().split(/[\s(]/)[0];
+  return map[key] ?? language.slice(0, 2).toUpperCase();
+}
+
+function shortRel(rel: string): string {
+  return rel
+    .replace(/-/g, " ")
+    .replace(/^from greek$/i, "from Greek")
+    .replace(/loanword from greek/i, "loanword");
+}
+
+const styles = StyleSheet.create({
+  root: { flex: 1, backgroundColor: POLYGLOT_COLORS.bg },
+  loadingWrap: {
+    flex: 1,
+    backgroundColor: POLYGLOT_COLORS.bg,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  topbar: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    paddingHorizontal: POLYGLOT_SPACING.pageH,
+    paddingVertical: 10,
+    borderBottomWidth: 1,
+    borderBottomColor: POLYGLOT_COLORS.border,
+    backgroundColor: POLYGLOT_COLORS.bg,
+  },
+  backLink: {
+    color: POLYGLOT_COLORS.accent,
+    fontSize: POLYGLOT_TYPE.body,
+    fontWeight: "500",
+  },
+  breadcrumb: {
+    fontSize: POLYGLOT_TYPE.meta,
+    color: POLYGLOT_COLORS.textTertiary,
+  },
+  scrollBody: {
+    paddingBottom: POLYGLOT_SPACING.bottomFloat,
+  },
+
+  /* Header */
+  head: {
+    paddingHorizontal: POLYGLOT_SPACING.pageH,
+    paddingTop: 18,
+    paddingBottom: 14,
+    borderBottomWidth: 1,
+    borderBottomColor: POLYGLOT_COLORS.border,
+  },
+  wordRow: {
+    flexDirection: "row",
+    alignItems: "baseline",
+    gap: 10,
+  },
+  greekForm: {
+    fontFamily: POLYGLOT_FONTS.greekDisplay,
+    fontSize: POLYGLOT_TYPE.heroGreek,
+    color: POLYGLOT_COLORS.text,
+    lineHeight: POLYGLOT_TYPE.heroGreek,
+  },
+  gloss: {
+    fontSize: POLYGLOT_TYPE.gloss,
+    fontFamily: POLYGLOT_FONTS.greekDisplay,
+    fontStyle: "italic",
+    marginTop: 6,
+    color: POLYGLOT_COLORS.text,
+  },
+  chips: {
+    flexDirection: "row",
+    gap: 5,
+    marginTop: 10,
+    flexWrap: "wrap",
+  },
+  chip: {
+    paddingHorizontal: 9,
+    paddingVertical: 4,
+    borderRadius: POLYGLOT_RADIUS.chip,
+  },
+  chipText: {
+    fontSize: 11,
+    fontWeight: "600",
+  },
+  chipGreek: {
+    fontFamily: POLYGLOT_FONTS.greekDisplay,
+    fontStyle: "italic",
+    fontSize: 13,
+  },
+
+  /* Sections */
+  section: {
+    paddingHorizontal: POLYGLOT_SPACING.pageH,
+    paddingTop: POLYGLOT_SPACING.sectionV,
+    paddingBottom: 4,
+    borderBottomWidth: 1,
+    borderBottomColor: POLYGLOT_COLORS.border,
+  },
+  sectionLabel: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    marginBottom: 10,
+  },
+  sectionLabelText: {
+    fontSize: POLYGLOT_TYPE.micro,
+    letterSpacing: 1.6,
+    textTransform: "uppercase",
+    fontWeight: "700",
+  },
+  sectionCount: {
+    fontSize: POLYGLOT_TYPE.micro,
+    color: POLYGLOT_COLORS.textTertiary,
+    letterSpacing: 0.4,
+  },
+
+  /* Etymology */
+  etyProse: {
+    fontSize: POLYGLOT_TYPE.body,
+    color: POLYGLOT_COLORS.text,
+    lineHeight: 22,
+  },
+  morph: {
+    marginTop: 10,
+    padding: 10,
+    backgroundColor: POLYGLOT_COLORS.surface,
+    borderRadius: POLYGLOT_RADIUS.callout,
+    borderWidth: 1,
+    borderColor: POLYGLOT_COLORS.border,
+    alignItems: "center",
+  },
+  morphText: {
+    fontFamily: POLYGLOT_FONTS.greekDisplay,
+    fontSize: 14,
+    color: POLYGLOT_COLORS.textSecondary,
+  },
+
+  /* Timeline */
+  timeline: {
+    position: "relative",
+    paddingLeft: 28,
+    paddingBottom: 4,
+  },
+  timelineRail: {
+    position: "absolute",
+    left: 7,
+    top: 6,
+    bottom: 6,
+    width: 2,
+    backgroundColor: POLYGLOT_COLORS.borderStrong,
+    opacity: 0.5,
+  },
+  stage: {
+    paddingBottom: 14,
+    position: "relative",
+  },
+  stageDot: {
+    position: "absolute",
+    left: -25,
+    top: 6,
+    width: 10,
+    height: 10,
+    borderRadius: 5,
+    borderWidth: 3,
+  },
+  stageBody: {},
+  stageEra: {
+    fontSize: POLYGLOT_TYPE.micro,
+    fontWeight: "700",
+    letterSpacing: 1.4,
+    textTransform: "uppercase",
+  },
+  stageForm: {
+    fontFamily: POLYGLOT_FONTS.greekDisplay,
+    fontSize: POLYGLOT_TYPE.stageForm,
+    marginTop: 2,
+    color: POLYGLOT_COLORS.text,
+  },
+  stageMeaning: {
+    fontSize: POLYGLOT_TYPE.bodySmall,
+    color: POLYGLOT_COLORS.text,
+    marginTop: 4,
+    lineHeight: 19,
+  },
+  stageNote: {
+    fontSize: POLYGLOT_TYPE.meta,
+    fontStyle: "italic",
+    color: POLYGLOT_COLORS.textSecondary,
+    marginTop: 4,
+    lineHeight: 17,
+  },
+
+  /* Cognates */
+  cogRow: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    gap: 10,
+    paddingVertical: 10,
+    borderBottomWidth: 1,
+    borderBottomColor: POLYGLOT_COLORS.border,
+  },
+  cogLeft: { flex: 1, minWidth: 0 },
+  cogForm: {
+    fontSize: POLYGLOT_TYPE.cogForm,
+    fontWeight: "600",
+    color: POLYGLOT_COLORS.text,
+  },
+  cogNote: {
+    fontSize: POLYGLOT_TYPE.meta,
+    color: POLYGLOT_COLORS.textSecondary,
+    marginTop: 3,
+    lineHeight: 17,
+  },
+  cogTag: { alignItems: "flex-end", gap: 3 },
+  cogLangPill: {
+    backgroundColor: POLYGLOT_COLORS.cognateTint,
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    borderRadius: 4,
+  },
+  cogLangText: {
+    fontSize: 9,
+    letterSpacing: 1.2,
+    textTransform: "uppercase",
+    color: POLYGLOT_COLORS.cognate,
+    fontWeight: "700",
+  },
+  cogRel: {
+    fontSize: POLYGLOT_TYPE.micro,
+    color: POLYGLOT_COLORS.textTertiary,
+  },
+
+  /* Quotes */
+  quoteCard: {
+    backgroundColor: POLYGLOT_COLORS.surface,
+    borderLeftWidth: 3,
+    borderLeftColor: POLYGLOT_COLORS.quote,
+    padding: 10,
+    borderRadius: POLYGLOT_RADIUS.callout,
+    marginBottom: 10,
+    borderWidth: 1,
+    borderColor: POLYGLOT_COLORS.border,
+  },
+  qtext: {
+    fontFamily: POLYGLOT_FONTS.greekDisplay,
+    fontSize: 17,
+    fontStyle: "italic",
+    color: POLYGLOT_COLORS.text,
+    lineHeight: 23,
+  },
+  qtrans: {
+    fontSize: POLYGLOT_TYPE.bodySmall,
+    color: POLYGLOT_COLORS.textSecondary,
+    marginTop: 4,
+  },
+  qsourceRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    marginTop: 6,
+  },
+  eraPill: {
+    paddingHorizontal: 6,
+    paddingVertical: 1,
+    borderRadius: 4,
+    borderWidth: 1,
+  },
+  eraPillText: {
+    fontSize: POLYGLOT_TYPE.micro,
+    fontWeight: "700",
+    letterSpacing: 0.6,
+    textTransform: "uppercase",
+  },
+  qsource: {
+    fontSize: POLYGLOT_TYPE.micro,
+    letterSpacing: 0.6,
+    textTransform: "uppercase",
+    color: POLYGLOT_COLORS.textTertiary,
+  },
+
+  /* Register */
+  usageNote: {
+    fontSize: POLYGLOT_TYPE.bodySmall,
+    color: POLYGLOT_COLORS.text,
+    lineHeight: 19,
+    marginBottom: 10,
+  },
+  collList: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 5,
+    marginBottom: 10,
+  },
+  collPill: {
+    backgroundColor: POLYGLOT_COLORS.surface,
+    borderWidth: 1,
+    borderColor: POLYGLOT_COLORS.border,
+    paddingHorizontal: 11,
+    paddingVertical: 5,
+    borderRadius: POLYGLOT_RADIUS.chip,
+  },
+  collText: {
+    fontFamily: POLYGLOT_FONTS.greekDisplay,
+    fontSize: 14,
+    color: POLYGLOT_COLORS.text,
+  },
+  ffNote: {
+    padding: 10,
+    backgroundColor: POLYGLOT_COLORS.warningTint,
+    borderRadius: POLYGLOT_RADIUS.callout,
+    marginBottom: 10,
+  },
+  ffNoteText: {
+    fontSize: POLYGLOT_TYPE.bodySmall,
+    color: POLYGLOT_COLORS.warning,
+    lineHeight: 19,
+  },
+  ffStrong: { fontWeight: "700" },
+
+  emptyHint: {
+    padding: 24,
+    alignItems: "center",
+  },
+  emptyHintText: {
+    fontSize: POLYGLOT_TYPE.bodySmall,
+    color: POLYGLOT_COLORS.textTertiary,
+    fontStyle: "italic",
+    textAlign: "center",
+  },
+});

--- a/frontend/app/polyglot-review.tsx
+++ b/frontend/app/polyglot-review.tsx
@@ -36,13 +36,18 @@ import {
   getReviewSession,
   submitSentenceReview,
   getReviewStats,
+  getLemmaDetail,
   type IntroCard,
+  type LemmaDetail,
   type ReviewSessionBundle,
   type SentencePayload,
   type WordRender,
   type AcquisitionStats,
   type ComprehensionSignal,
 } from "../lib/polyglot-api";
+import PolyglotLookupCard from "../lib/polyglot-lookup-card";
+import { POLYGLOT_COLORS, POLYGLOT_RADIUS } from "../lib/polyglot-design-colors";
+import { POLYGLOT_FONTS } from "../lib/polyglot-design-tokens";
 import {
   buildInterleavedSlots,
   cycleMark,
@@ -59,19 +64,23 @@ import {
   type SessionSlot,
 } from "../lib/polyglot-review-helpers";
 
+// 2026-05-21: palette aligned with the polyglot Modern Editorial design
+// (POLYGLOT_COLORS in lib/polyglot-design-colors.ts). Replaces the previous
+// dark-blue scheme so the review screen reads as part of the same surface
+// family as the reader (polyglot.tsx) and the lemma detail page.
 const C = {
-  bg: "#0f0f1a",
-  surface: "#1a1a2e",
-  border: "#2a2a40",
-  text: "#e0e0f0",
-  textDim: "#9090a8",
-  textMuted: "#6a6a82",
-  accent: "#7aa2f7",
-  target: "#bb9af7",
-  missed: "#c95f6f",
+  bg: POLYGLOT_COLORS.bg,
+  surface: POLYGLOT_COLORS.surface,
+  border: POLYGLOT_COLORS.border,
+  text: POLYGLOT_COLORS.text,
+  textDim: POLYGLOT_COLORS.textSecondary,
+  textMuted: POLYGLOT_COLORS.textTertiary,
+  accent: POLYGLOT_COLORS.accent,
+  target: POLYGLOT_COLORS.quote,        // re-uses quote-section purple for target highlight
+  missed: POLYGLOT_COLORS.warning,
   confused: "#d4a06b",
-  good: "#74c096",
-  noIdea: "#c95f6f",
+  good: POLYGLOT_COLORS.cognate,
+  noIdea: POLYGLOT_COLORS.warning,
 };
 
 type CardState = "front" | "back";
@@ -91,6 +100,11 @@ export default function PolyglotReview() {
   const [cardState, setCardState] = useState<CardState>("front");
   const [marks, setMarks] = useState<MarkSets>(emptyMarks);
   const [glossWordIdx, setGlossWordIdx] = useState<number | null>(null);
+  // Lazy-fetched lemma detail for the tapped word + intro card. Same pattern
+  // as polyglot.tsx — render the head row immediately from what we have, then
+  // stream enrichment in. detailRequestRef guards against stale responses.
+  const [lemmaDetailCache, setLemmaDetailCache] = useState<Record<number, LemmaDetail>>({});
+  const detailRequestRef = useRef(0);
 
   const [loading, setLoading] = useState(true);
   const [submitting, setSubmitting] = useState(false);
@@ -159,6 +173,24 @@ export default function PolyglotReview() {
       // time, but the user still gets the intro card UI.
     });
   }, [currentIntro]);
+
+  // Lazy-fetch full lemma detail for the current intro card AND the currently
+  // glossed word. Same dedup pattern as polyglot.tsx: detailRequestRef guards
+  // stale responses, lemmaDetailCache memoises by lemma_id.
+  useEffect(() => {
+    const targetLemmaId =
+      currentIntro?.lemma_id ??
+      (glossWordIdx != null ? currentSentence?.words[glossWordIdx]?.lemma_id ?? null : null);
+    if (targetLemmaId == null) return;
+    if (lemmaDetailCache[targetLemmaId]) return;
+    const reqId = ++detailRequestRef.current;
+    getLemmaDetail(targetLemmaId)
+      .then((detail) => {
+        if (detailRequestRef.current !== reqId) return;
+        setLemmaDetailCache((prev) => ({ ...prev, [targetLemmaId]: detail }));
+      })
+      .catch(() => {});
+  }, [currentIntro, glossWordIdx, currentSentence, lemmaDetailCache]);
 
   const advanceCard = useCallback(() => {
     setCardState("back");
@@ -280,7 +312,11 @@ export default function PolyglotReview() {
             {currentIntro.intro_kind === "rescue" ? "rescue card" : "new word"}
           </Text>
         </View>
-        <IntroCardView card={currentIntro} />
+        <IntroCardView
+          card={currentIntro}
+          detail={lemmaDetailCache[currentIntro.lemma_id] ?? null}
+          onViewDetails={() => router.push(`/polyglot-lemma/${currentIntro.lemma_id}`)}
+        />
         <View style={styles.actionRow}>
           <Pressable
             style={[styles.actionButton, styles.gotItButton]}
@@ -327,7 +363,25 @@ export default function PolyglotReview() {
           onWordTap={handleWordTap}
           glossWordIdx={glossWordIdx}
         />
-        {glossWord ? <GlossLine word={glossWord} /> : null}
+        {glossWord && glossWord.lemma_id != null ? (
+          <View style={styles.lookupSlot}>
+            <PolyglotLookupCard
+              lemmaForm={glossWord.lemma_form ?? glossWord.surface_form}
+              glossEn={glossWord.gloss_en}
+              pos={null}
+              ancientForm={
+                lemmaDetailCache[glossWord.lemma_id]?.cognate_lemma_form ??
+                lemmaDetailCache[glossWord.lemma_id]?.enrichment?.etymology?.ancient_form ??
+                null
+              }
+              enrichment={lemmaDetailCache[glossWord.lemma_id]?.enrichment ?? null}
+              frequencyRank={lemmaDetailCache[glossWord.lemma_id]?.frequency_rank ?? null}
+              surfaceForm={glossWord.surface_form}
+              onViewDetails={() => router.push(`/polyglot-lemma/${glossWord.lemma_id}`)}
+              onClose={() => setGlossWordIdx(null)}
+            />
+          </View>
+        ) : null}
       </View>
 
       <ReadingActions
@@ -346,26 +400,136 @@ export default function PolyglotReview() {
   );
 }
 
-function IntroCardView({ card }: { card: IntroCard }) {
+/**
+ * Modern Editorial intro card. Renders the head row + chips immediately from
+ * the IntroCard payload (gloss, POS, cognate). When `detail` arrives via the
+ * lazy fetch in PolyglotReview, three optional sections show below the hero:
+ * an etymology paragraph, a mini 3-column "across time" peek, and the top
+ * literary quote. Mirrors the "Teach iPhone · Refined Alif Stack" mockup
+ * thumbs-up'd in design-explorer round 1.
+ *
+ * Intentionally lean compared to the full lemma detail screen — the goal is
+ * 10-20 seconds of reading. A "View full philology ›" link takes the curious
+ * reader to the detail page when they want to go deeper.
+ */
+function IntroCardView({
+  card,
+  detail,
+  onViewDetails,
+}: {
+  card: IntroCard;
+  detail: LemmaDetail | null;
+  onViewDetails: () => void;
+}) {
   const isRescue = card.intro_kind === "rescue";
+  const enrichment = detail?.enrichment;
+  const ancientForm = card.cognate_lemma_form ?? enrichment?.etymology?.ancient_form ?? null;
+  const pieRoot = enrichment?.etymology?.pie_root ?? null;
+  const morph = enrichment?.etymology?.morphology ?? null;
+  const originNote = enrichment?.etymology?.origin_note ?? null;
+  const drift = enrichment?.diachrony ?? [];
+  const topQuote = enrichment && enrichment.quotes.length > 0 ? enrichment.quotes[0] : null;
+
   return (
-    <View style={styles.introCard}>
-      <Text style={styles.introHeading}>
-        {isRescue ? "Let's revisit this word" : "New word"}
-      </Text>
-      <Text style={styles.introLemma}>{card.lemma_form}</Text>
-      {card.pos ? <Text style={styles.introPos}>{card.pos}</Text> : null}
-      <Text style={styles.introGloss}>{card.gloss_en ?? "(no gloss)"}</Text>
-      {card.cognate_lemma_form ? (
-        <Text style={styles.introCognate}>
-          cognate: {card.cognate_lemma_form}
-        </Text>
+    <View style={styles.introWrap}>
+      {/* Hero card */}
+      <View style={styles.introHero}>
+        <Text style={styles.introHeroLemma}>{card.lemma_form}</Text>
+        <Text style={styles.introHeroLabel}>Meaning</Text>
+        <Text style={styles.introHeroGloss}>{card.gloss_en ?? "(no gloss)"}</Text>
+        <View style={styles.introChips}>
+          {card.pos ? (
+            <View style={[styles.introChip, { backgroundColor: POLYGLOT_COLORS.surfaceMuted }]}>
+              <Text style={[styles.introChipText, { color: POLYGLOT_COLORS.textSecondary }]}>
+                {card.pos}
+              </Text>
+            </View>
+          ) : null}
+          {ancientForm ? (
+            <View style={[styles.introChip, { backgroundColor: POLYGLOT_COLORS.cognateTint }]}>
+              <Text style={[styles.introChipText, { color: POLYGLOT_COLORS.cognate }]}>
+                Ancient{"  "}
+                <Text style={[styles.introChipGreek, { color: POLYGLOT_COLORS.cognate }]}>
+                  {ancientForm}
+                </Text>
+              </Text>
+            </View>
+          ) : null}
+          {pieRoot ? (
+            <View style={[styles.introChip, { backgroundColor: POLYGLOT_COLORS.etymologyTint }]}>
+              <Text style={[styles.introChipText, { color: POLYGLOT_COLORS.etymology }]}>
+                {pieRoot}
+              </Text>
+            </View>
+          ) : null}
+        </View>
+        {isRescue ? (
+          <Text style={styles.introRescueHint}>
+            You've seen this {card.times_seen} times but it hasn't stuck yet.
+          </Text>
+        ) : null}
+      </View>
+
+      {/* Etymology — only when enrichment loaded */}
+      {originNote ? (
+        <View style={[styles.introSection, { borderColor: POLYGLOT_COLORS.etymology + "33" }]}>
+          <Text style={[styles.introSectionLabel, { color: POLYGLOT_COLORS.etymology }]}>
+            Etymology
+          </Text>
+          <Text style={styles.introSectionBody}>{originNote}</Text>
+          {morph ? (
+            <View style={styles.introMorph}>
+              <Text style={styles.introMorphText}>{morph}</Text>
+            </View>
+          ) : null}
+        </View>
       ) : null}
-      {isRescue ? (
-        <Text style={styles.introHint}>
-          You've seen this {card.times_seen} times but it hasn't stuck yet.
-        </Text>
+
+      {/* Mini-drift — 2-3 stages inline */}
+      {drift.length >= 2 ? (
+        <View style={[styles.introSection, { borderColor: POLYGLOT_COLORS.border }]}>
+          <Text style={[styles.introSectionLabel, { color: POLYGLOT_COLORS.text }]}>
+            Across time
+          </Text>
+          <View style={styles.miniDrift}>
+            {drift.slice(0, 3).map((stage, idx) => (
+              <View
+                key={`mini-${idx}`}
+                style={[
+                  styles.miniStage,
+                  idx < Math.min(drift.length, 3) - 1 && styles.miniStageDivider,
+                ]}
+              >
+                <Text style={[styles.miniEra, { color: POLYGLOT_COLORS.text }]}>{stage.era}</Text>
+                <Text style={styles.miniForm}>{stage.form}</Text>
+                <Text style={styles.miniMeaning} numberOfLines={2}>
+                  {stage.meaning}
+                </Text>
+              </View>
+            ))}
+          </View>
+        </View>
       ) : null}
+
+      {/* Top quote */}
+      {topQuote ? (
+        <View style={[styles.introSection, { borderColor: POLYGLOT_COLORS.quote + "33" }]}>
+          <Text style={[styles.introSectionLabel, { color: POLYGLOT_COLORS.quote }]}>
+            In the literature
+          </Text>
+          <Text style={styles.introQuoteText}>{topQuote.text}</Text>
+          <Text style={styles.introQuoteSource}>
+            {topQuote.source} · {topQuote.era}
+          </Text>
+          <Text style={styles.introQuoteTrans}>"{topQuote.translation_en}"</Text>
+        </View>
+      ) : null}
+
+      {/* View details — always offered (even when enrichment hasn't streamed
+       *  in yet — the detail page will eagerly load it). */}
+      <Pressable onPress={onViewDetails} hitSlop={8} style={styles.viewDetailsRow}>
+        <Text style={styles.viewDetailsLink}>View full philology ›</Text>
+      </Pressable>
     </View>
   );
 }
@@ -431,27 +595,6 @@ function SentenceCard({
         )}
       </View>
     </>
-  );
-}
-
-function GlossLine({ word }: { word: WordRender }) {
-  const tag = word.is_function_word
-    ? "function word"
-    : word.is_proper_name
-      ? "proper name"
-      : word.is_target
-        ? "target"
-        : word.knowledge_state;
-  return (
-    <View style={styles.glossLine}>
-      <Text style={styles.glossLemma}>
-        {word.lemma_form ?? word.surface_form}
-      </Text>
-      <Text style={styles.glossTag}>{tag}</Text>
-      <Text style={styles.glossText}>
-        {word.gloss_en ?? "(no gloss)"}
-      </Text>
-    </View>
   );
 }
 
@@ -566,17 +709,71 @@ const styles = StyleSheet.create({
     backgroundColor: C.surface, padding: 24, borderRadius: 16,
     borderWidth: 1, borderColor: C.border, minHeight: 220,
   },
-  introCard: {
-    backgroundColor: C.surface, padding: 28, borderRadius: 16,
-    borderWidth: 1, borderColor: C.target, minHeight: 220,
-    alignItems: "center", justifyContent: "center", gap: 14,
+  /* Intro card — Modern Editorial. Hero card stacked with optional etymology /
+   * mini-drift / quote sections, each shown only when enrichment loaded. */
+  introWrap: { gap: 10 },
+  introHero: {
+    backgroundColor: C.surface, padding: 18, borderRadius: POLYGLOT_RADIUS.card,
+    borderWidth: 1, borderColor: C.border, alignItems: "center", gap: 6,
   },
-  introHeading: { color: C.target, fontSize: 13, letterSpacing: 1.4, textTransform: "uppercase" },
-  introLemma: { color: C.text, fontSize: 36, fontWeight: "600" },
-  introPos: { color: C.textMuted, fontSize: 13, fontStyle: "italic" },
-  introGloss: { color: C.accent, fontSize: 20, textAlign: "center" },
-  introCognate: { color: C.textDim, fontSize: 14, marginTop: 4 },
-  introHint: { color: C.confused, fontSize: 12, marginTop: 6, textAlign: "center" },
+  introHeroLemma: {
+    fontFamily: POLYGLOT_FONTS.greekDisplay, fontSize: 48, color: C.text, lineHeight: 52,
+  },
+  introHeroLabel: {
+    fontSize: 10, letterSpacing: 1.6, textTransform: "uppercase",
+    color: C.textMuted, marginTop: 6,
+  },
+  introHeroGloss: {
+    fontSize: 20, fontFamily: POLYGLOT_FONTS.greekDisplay, fontStyle: "italic", color: C.text,
+  },
+  introChips: {
+    flexDirection: "row", gap: 5, marginTop: 10, flexWrap: "wrap", justifyContent: "center",
+  },
+  introChip: { paddingHorizontal: 9, paddingVertical: 4, borderRadius: POLYGLOT_RADIUS.chip },
+  introChipText: { fontSize: 11, fontWeight: "600" },
+  introChipGreek: { fontFamily: POLYGLOT_FONTS.greekDisplay, fontStyle: "italic", fontSize: 13 },
+  introRescueHint: {
+    color: POLYGLOT_COLORS.warning, fontSize: 12, marginTop: 6, textAlign: "center",
+  },
+
+  introSection: {
+    backgroundColor: C.surface, padding: 14, borderRadius: POLYGLOT_RADIUS.card,
+    borderWidth: 1, gap: 6,
+  },
+  introSectionLabel: {
+    fontSize: 10, letterSpacing: 1.4, textTransform: "uppercase", fontWeight: "700",
+  },
+  introSectionBody: { fontSize: 13, color: C.text, lineHeight: 19 },
+  introMorph: {
+    marginTop: 6, padding: 8, backgroundColor: POLYGLOT_COLORS.etymologyTint,
+    borderRadius: 6, alignItems: "center",
+  },
+  introMorphText: {
+    fontFamily: POLYGLOT_FONTS.greekDisplay, fontSize: 14, color: POLYGLOT_COLORS.etymology,
+  },
+  miniDrift: { flexDirection: "row", gap: 0, marginTop: 2 },
+  miniStage: { flex: 1, paddingHorizontal: 6, paddingVertical: 6, alignItems: "center" },
+  miniStageDivider: { borderRightWidth: 1, borderRightColor: C.border },
+  miniEra: {
+    fontSize: 9, letterSpacing: 1.2, textTransform: "uppercase",
+    fontWeight: "700", marginBottom: 4,
+  },
+  miniForm: {
+    fontFamily: POLYGLOT_FONTS.greekDisplay, fontSize: 17, color: C.text,
+    lineHeight: 21, marginBottom: 3,
+  },
+  miniMeaning: { fontSize: 10, color: C.textDim, textAlign: "center", lineHeight: 13 },
+  introQuoteText: {
+    fontFamily: POLYGLOT_FONTS.greekDisplay, fontSize: 17, fontStyle: "italic",
+    color: C.text, lineHeight: 23, marginTop: 2,
+  },
+  introQuoteSource: {
+    fontSize: 10, letterSpacing: 0.8, textTransform: "uppercase",
+    color: C.textMuted, marginTop: 4,
+  },
+  introQuoteTrans: { fontSize: 12, color: C.textDim, marginTop: 4, fontStyle: "italic" },
+  viewDetailsRow: { alignSelf: "center", paddingVertical: 8 },
+  viewDetailsLink: { color: C.accent, fontSize: 13, fontWeight: "600" },
   sentenceGreek: {
     color: C.text, fontSize: 26, lineHeight: 40, textAlign: "center",
   },
@@ -601,18 +798,11 @@ const styles = StyleSheet.create({
   sentenceEnglish: {
     color: C.textDim, fontSize: 18, lineHeight: 26, textAlign: "center",
   },
-  glossLine: {
-    marginTop: 16, paddingTop: 12,
-    borderTopWidth: 1, borderTopColor: C.border,
-    flexDirection: "row", alignItems: "baseline", gap: 8, flexWrap: "wrap",
-  },
-  glossLemma: { color: C.text, fontSize: 18, fontWeight: "600" },
-  glossTag: {
-    color: C.textMuted, fontSize: 11,
-    backgroundColor: C.bg, paddingHorizontal: 6, paddingVertical: 2,
-    borderRadius: 6, overflow: "hidden",
-  },
-  glossText: { color: C.accent, fontSize: 16, flex: 1 },
+  /* Tapped-word lookup card slot — sits below the sentence inside the same
+   * sentence-card container. The PolyglotLookupCard component carries its
+   * own visual frame, so the slot just provides separation from the sentence
+   * above. */
+  lookupSlot: { marginTop: 14, paddingTop: 12, borderTopWidth: 1, borderTopColor: C.border },
   actionRow: {
     flexDirection: "row", marginTop: 24, gap: 8,
   },

--- a/frontend/app/polyglot.tsx
+++ b/frontend/app/polyglot.tsx
@@ -24,9 +24,13 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Ionicons } from "@expo/vector-icons";
 import {
   listStories, getPage, markWord, markRemainingKnown,
+  getLemmaDetail,
   type StorySummary, type PageView, type TokenView,
+  type LemmaDetail,
 } from "../lib/polyglot-api";
 import { renderTokens } from "../lib/polyglot-render-helpers";
+import PolyglotLookupCard from "../lib/polyglot-lookup-card";
+import { POLYGLOT_COLORS } from "../lib/polyglot-design-colors";
 
 // Per-page tap-cycle persistence. Red (0) and yellow (1) marks survive
 // page navigation and app reloads so the user keeps the visual record of
@@ -76,13 +80,20 @@ async function saveCyclePositions(
 // English). Marks persist per (story, page) in AsyncStorage so navigating
 // away and back preserves the exact taps the user made on that page,
 // independent of how the backend's ULK state has evolved since.
+//
+// 2026-05-21: palette aligned with the polyglot Modern Editorial design
+// (POLYGLOT_COLORS in lib/polyglot-design-colors.ts). The reader keeps the
+// serif Greek body — Cormorant Garamond / Georgia is the same family Modern
+// Editorial uses for the detail screen — but trades the dark warm-slate
+// surface for a light editorial one. Same visual language across reader,
+// lookup card, intro card, and the new lemma detail page.
 const C = {
-  bg: "#14121a",             // warm slate — softer than pure black for long reading
-  surface: "#1d1a26",        // bottom-bar surface
-  border: "#2f2a3a",
-  ink: "#ede4cf",            // body text — warm off-white, "paper ink"
-  inkMuted: "#a89c83",       // for chrome (page number, headers)
-  accent: "#a98ef0",         // selection underline
+  bg: POLYGLOT_COLORS.bg,
+  surface: POLYGLOT_COLORS.surface,
+  border: POLYGLOT_COLORS.border,
+  ink: POLYGLOT_COLORS.text,
+  inkMuted: POLYGLOT_COLORS.textSecondary,
+  accent: POLYGLOT_COLORS.accent,
   cycleRed: "#c95f6f",       // tap 1: "no idea" — full SRS enrollment
   cycleYellow: "#d4a06b",    // tap 2: "recognize after seeing English"
 };
@@ -116,6 +127,12 @@ export default function Polyglot() {
   // word.
   const [cyclePositions, setCyclePositions] = useState<Record<number, number>>({});
   const [glossByLemma, setGlossByLemma] = useState<Record<number, string | null>>({});
+  // Lazy-fetched lemma detail (with enrichment) for the currently-tapped
+  // word. The lookup card renders the head row immediately from `selected`
+  // (already loaded as part of the page); enrichment streams in here when
+  // available. Keyed by lemma_id so re-tapping the same word reuses the cache.
+  const [lemmaDetailCache, setLemmaDetailCache] = useState<Record<number, LemmaDetail>>({});
+  const detailRequestRef = useRef(0);
   const [bulkMarking, setBulkMarking] = useState(false);
   const scrollRef = useRef<ScrollView>(null);
   const insets = useSafeAreaInsets();
@@ -152,6 +169,25 @@ export default function Polyglot() {
     const startPage = story?.first_content_page_number ?? 1;
     loadPage(storyId, startPage);
   }, [storyId, loadPage, stories]);
+
+  // Lazy-fetch full lemma detail (with enrichment) when a word is tapped.
+  // The lookup card renders immediately from `selected`; enrichment fills in
+  // as soon as the network round-trip completes. detailRequestRef guards
+  // against stale responses if the user taps another word mid-flight.
+  useEffect(() => {
+    if (selected?.lemma_id == null) return;
+    const lemmaId = selected.lemma_id;
+    if (lemmaDetailCache[lemmaId]) return;  // already fetched
+    const reqId = ++detailRequestRef.current;
+    getLemmaDetail(lemmaId)
+      .then((detail) => {
+        if (detailRequestRef.current !== reqId) return;
+        setLemmaDetailCache((prev) => ({ ...prev, [lemmaId]: detail }));
+      })
+      .catch(() => {
+        // Best-effort: lookup card still renders without enrichment.
+      });
+  }, [selected, lemmaDetailCache]);
 
   // Tap-cycle handler. The act of tapping a word advances its position in
   // the three-state cycle:
@@ -296,28 +332,32 @@ export default function Polyglot() {
         </ScrollView>
       )}
 
-      {/* Lookup bar — surface word + English gloss + close. No lemma,
-          no POS, no action buttons. Cycle dot reflects current tap state. */}
+      {/* Lookup card — Modern Editorial. Renders the basic head row from the
+          already-loaded `selected` token, then streams in enrichment lazily.
+          The "View full philology ›" link routes to /polyglot-lemma/{id}. */}
       {selected && selected.lemma_id != null && (() => {
         const lemmaId = selected.lemma_id;
         const pos = cyclePositions[lemmaId];
         const dotColor =
           pos === 0 ? C.cycleRed
           : pos === 1 ? C.cycleYellow
-          : C.inkMuted;
+          : null;
         const gloss = glossByLemma[lemmaId] ?? selected.gloss_en;
+        const detail = lemmaDetailCache[lemmaId];
         return (
-          <View style={styles.lookupBar}>
-            <View style={styles.lookupRow}>
-              <View style={[styles.lookupDot, { backgroundColor: dotColor }]} />
-              <Text style={styles.lookupSurface}>{selected.surface}</Text>
-              <Text style={styles.lookupGloss} numberOfLines={2}>
-                {gloss ? `  ${gloss}` : "  …"}
-              </Text>
-              <Pressable onPress={() => setSelected(null)} style={styles.lookupClose}>
-                <Ionicons name="close" size={20} color={C.inkMuted} />
-              </Pressable>
-            </View>
+          <View style={styles.lookupSlot}>
+            <PolyglotLookupCard
+              lemmaForm={selected.lemma_form ?? selected.surface}
+              glossEn={gloss}
+              pos={selected.pos}
+              ancientForm={detail?.cognate_lemma_form ?? detail?.enrichment?.etymology?.ancient_form ?? null}
+              enrichment={detail?.enrichment ?? null}
+              frequencyRank={detail?.frequency_rank ?? null}
+              cycleColor={dotColor}
+              surfaceForm={selected.surface}
+              onViewDetails={() => router.push(`/polyglot-lemma/${lemmaId}`)}
+              onClose={() => setSelected(null)}
+            />
           </View>
         );
       })()}
@@ -420,13 +460,8 @@ const styles = StyleSheet.create({
     textDecorationColor: C.cycleYellow,
   },
 
-  lookupBar: { backgroundColor: C.surface, borderTopWidth: 1, borderColor: C.border,
-               paddingVertical: 14, paddingHorizontal: 20 },
-  lookupRow: { flexDirection: "row", alignItems: "center", flexWrap: "nowrap" },
-  lookupDot: { width: 10, height: 10, borderRadius: 5, marginRight: 10 },
-  lookupSurface: { color: C.ink, fontSize: 17, fontWeight: "600", fontFamily: SERIF },
-  lookupGloss: { color: C.ink, fontSize: 15, flex: 1, fontFamily: SERIF },
-  lookupClose: { padding: 4, marginLeft: 8 },
+  lookupSlot: { paddingHorizontal: 12, paddingTop: 8, paddingBottom: 4,
+                borderTopWidth: 1, borderColor: C.border, backgroundColor: C.bg },
 
   pageNav: { paddingHorizontal: 20, paddingVertical: 14,
              borderTopWidth: 1, borderColor: C.border, backgroundColor: C.surface },

--- a/frontend/lib/__tests__/fixtures/polyglot-enrichment.json
+++ b/frontend/lib/__tests__/fixtures/polyglot-enrichment.json
@@ -1,0 +1,432 @@
+{
+  "lemmas": [
+    {
+      "lemma_form": "άλογο",
+      "enrichment": {
+        "version": 1,
+        "etymology": {
+          "pie_root": "*leǵ- (to collect, gather, speak)",
+          "ancient_form": "ἄλογος",
+          "origin_note": "Originally an adjective meaning 'without reason, irrational' (ἀ- privative + λόγος 'reason, speech'). The semantic shift to 'horse' occurred in Byzantine Greek when τὸ ἄλογον 'the irrational [creature]' became the standard word for horse, displacing classical ἵππος. Horses were the archetypal irrational animals, lacking human λόγος.",
+          "morphology": "ἀ- (negative) + λόγος (reason) → 'without reason'"
+        },
+        "diachrony": [
+          {
+            "era": "Classical",
+            "form": "ἄλογος",
+            "meaning": "irrational, without reason, contrary to logic",
+            "note": "Philosophical term used by Plato and Aristotle for the non-rational parts of soul or nature"
+          },
+          {
+            "era": "Byzantine",
+            "form": "τὸ ἄλογον",
+            "meaning": "the irrational creature, specifically horse",
+            "note": "Neuter substantive narrowed from any irrational animal to horse, replacing ἵππος as the common word"
+          },
+          {
+            "era": "Modern",
+            "form": "άλογο",
+            "meaning": "horse",
+            "note": "Complete lexicalization; etymological sense unknown to most speakers"
+          }
+        ],
+        "cognates": [
+          {
+            "language": "English",
+            "form": "illogical",
+            "relation": "loanword-from-greek",
+            "gloss_en": null,
+            "note": "Same ἀ- + logic construction, preserves the original 'without reason' sense lost in Greek"
+          },
+          {
+            "language": "English",
+            "form": "hippopotamus",
+            "relation": "loanword-from-greek",
+            "gloss_en": null,
+            "note": "Contains ἵππος, the classical word that άλογο replaced"
+          },
+          {
+            "language": "Latin",
+            "form": "equus",
+            "relation": "shared-pie-root",
+            "gloss_en": "horse",
+            "note": "From PIE *h₁éḱwos; Romance languages kept this root while Greek took the 'irrational animal' path"
+          },
+          {
+            "language": "English",
+            "form": "analog",
+            "relation": "borrowed-via-latin",
+            "gloss_en": null,
+            "note": "Contains same ἀ- prefix but from λόγος 'ratio', meaning proportional"
+          }
+        ],
+        "quotes": [
+          {
+            "text": "τὸ ἄλογον τῆς ψυχῆς",
+            "source": "Plato, Republic 439d",
+            "era": "Classical",
+            "translation_en": "the irrational part of the soul"
+          },
+          {
+            "text": "τὰ ἄλογα ζῷα",
+            "source": "Aristotle, Politics 1254b",
+            "era": "Classical",
+            "translation_en": "the irrational animals"
+          }
+        ],
+        "register": {
+          "formality": "neutral",
+          "collocations": [
+            "άλογο κούρσας",
+            "καβαλάω το άλογο",
+            "άγριο άλογο",
+            "ούτε άλογο ούτε γάιδαρος"
+          ],
+          "false_friends_en": [
+            "analog"
+          ],
+          "usage_note": "Standard modern word for horse; ἵππος survives only in learned compounds like ιπποδρόμιο (racecourse) and ιπποπόταμος (hippopotamus)"
+        }
+      }
+    },
+    {
+      "lemma_form": "λόγος",
+      "enrichment": {
+        "version": 1,
+        "etymology": {
+          "pie_root": "*leǵ- (to collect, gather, speak)",
+          "ancient_form": "λόγος",
+          "origin_note": "From PIE *leǵ- 'to collect, gather,' extended to 'speak' (speaking as gathering words). Homer uses it for speech, tale, and reckoning. Heraclitus elevates it to cosmic organizing principle. By the classical period it encompasses reason, argument, ratio, proportion, and any form of structured rational discourse.",
+          "morphology": null
+        },
+        "diachrony": [
+          {
+            "era": "Homeric",
+            "form": "λόγος",
+            "meaning": "word, speech, tale, account, reckoning",
+            "note": "Everyday language: what is said, a story told, or a numerical calculation"
+          },
+          {
+            "era": "Classical",
+            "form": "λόγος",
+            "meaning": "rational discourse, argument, reason, proportion, account",
+            "note": "Heraclitus' cosmic principle; Plato's dialectic; Aristotle's logic; mathematical ratio"
+          },
+          {
+            "era": "Koine",
+            "form": "ὁ Λόγος",
+            "meaning": "The Word (divine creative principle)",
+            "note": "John 1:1 fuses Greek philosophical logos with Hebrew dabar (divine word/deed), making it theological"
+          },
+          {
+            "era": "Byzantine",
+            "form": "λόγος",
+            "meaning": "sermon, theological treatise, account, reason",
+            "note": "Patristic literature uses it for homilies and theological arguments"
+          },
+          {
+            "era": "Modern",
+            "form": "λόγος",
+            "meaning": "word, reason, speech, account; 'λόγω' (by reason of)",
+            "note": "Full semantic range preserved from everyday speech to philosophical weight"
+          }
+        ],
+        "cognates": [
+          {
+            "language": "English",
+            "form": "logic",
+            "relation": "borrowed-via-latin",
+            "gloss_en": null,
+            "note": "From λογική (τέχνη), the art of reasoning"
+          },
+          {
+            "language": "English",
+            "form": "catalogue",
+            "relation": "loanword-from-greek",
+            "gloss_en": null,
+            "note": "κατά + λόγος, a complete listing or account"
+          },
+          {
+            "language": "Latin",
+            "form": "legere",
+            "relation": "shared-pie-root",
+            "gloss_en": "to read, gather, collect",
+            "note": "Same PIE root with sense 'gather' → 'gather written words' → 'read'"
+          },
+          {
+            "language": "English",
+            "form": "lexicon",
+            "relation": "loanword-from-greek",
+            "gloss_en": null,
+            "note": "From related λέξις (word, expression)"
+          },
+          {
+            "language": "German",
+            "form": "lesen",
+            "relation": "shared-pie-root",
+            "gloss_en": "to read",
+            "note": "Germanic cognate from PIE *leǵ-"
+          }
+        ],
+        "quotes": [
+          {
+            "text": "ἐν ἀρχῇ ἦν ὁ λόγος",
+            "source": "John 1:1 (Septuagint)",
+            "era": "Koine",
+            "translation_en": "In the beginning was the Word"
+          },
+          {
+            "text": "τοῦ λόγου δὲ ἐόντος ξυνοῦ ζώουσιν οἱ πολλοὶ ὡς ἰδίαν ἔχοντες φρόνησιν",
+            "source": "Heraclitus, fragment 2",
+            "era": "Classical",
+            "translation_en": "Though the Logos is common, most live as if they had a private understanding"
+          },
+          {
+            "text": "ὁ ἄνθρωπος φύσει πολιτικὸν ζῷον καὶ λόγον ἔχον",
+            "source": "Aristotle, Politics 1253a",
+            "era": "Classical",
+            "translation_en": "Man is by nature a political animal and one possessing logos"
+          }
+        ],
+        "register": {
+          "formality": "neutral",
+          "collocations": [
+            "δίνω το λόγο μου",
+            "χωρίς λόγο",
+            "λόγω του ότι",
+            "λογής λογής",
+            "ο λόγος του"
+          ],
+          "false_friends_en": [
+            "logo"
+          ],
+          "usage_note": "Retains full classical semantic range in modern Greek; equally comfortable in everyday speech (my word, his speech) and philosophical contexts (human reason, rational account)"
+        }
+      }
+    },
+    {
+      "lemma_form": "καρδιά",
+      "enrichment": {
+        "version": 1,
+        "etymology": {
+          "pie_root": "*ḱerd- (heart)",
+          "ancient_form": "καρδία",
+          "origin_note": "Direct descendant of PIE *ḱerd- 'heart,' preserved with remarkable stability across Indo-European languages. Used literally for the physical organ and figuratively for the emotional and intellectual center. In Homer, the heart thinks as well as feels. Modern form drops the iota subscript of ancient -ίᾳ.",
+          "morphology": null
+        },
+        "diachrony": [
+          {
+            "era": "Homeric",
+            "form": "καρδίη / κραδίη",
+            "meaning": "heart (physical organ), seat of thought, emotion, and will",
+            "note": "Homeric psychology locates both thinking and feeling in the heart"
+          },
+          {
+            "era": "Classical",
+            "form": "καρδία",
+            "meaning": "heart (anatomical), seat of emotion, courage, desire",
+            "note": "Medical writers focus on physical organ; literary texts emphasize emotional center"
+          },
+          {
+            "era": "Koine",
+            "form": "καρδία",
+            "meaning": "heart, inner self, spiritual center",
+            "note": "New Testament uses it for moral/spiritual core: pure heart, hard heart, believing with the heart"
+          },
+          {
+            "era": "Byzantine",
+            "form": "καρδία",
+            "meaning": "heart (anatomical and spiritual/emotional)",
+            "note": "Both medical anatomy and spiritual literature (hesychasm focuses on prayer of the heart)"
+          },
+          {
+            "era": "Modern",
+            "form": "καρδιά",
+            "meaning": "heart (anatomical and emotional), courage, core, center",
+            "note": "Full metaphorical range: love, courage, sincerity, center of anything"
+          }
+        ],
+        "cognates": [
+          {
+            "language": "English",
+            "form": "heart",
+            "relation": "shared-pie-root",
+            "gloss_en": null,
+            "note": "Germanic reflex of PIE *ḱerd- with identical semantic range"
+          },
+          {
+            "language": "Latin",
+            "form": "cor, cordis",
+            "relation": "shared-pie-root",
+            "gloss_en": "heart",
+            "note": "Yields English 'cordial,' 'accord,' 'record,' 'courage' (via French cœur)"
+          },
+          {
+            "language": "English",
+            "form": "cardiac",
+            "relation": "loanword-from-greek",
+            "gloss_en": null,
+            "note": "Medical terminology borrowed from Greek"
+          },
+          {
+            "language": "French",
+            "form": "cœur",
+            "relation": "descendant",
+            "gloss_en": "heart",
+            "note": "From Latin cor"
+          },
+          {
+            "language": "English",
+            "form": "core",
+            "relation": "borrowed-via-latin",
+            "gloss_en": null,
+            "note": "Via French cœur from Latin cor, meaning center/heart of something"
+          }
+        ],
+        "quotes": [
+          {
+            "text": "κραδίη δέ οἱ ἔνδον ἐμέμυκεν",
+            "source": "Homer, Iliad 18.79",
+            "era": "Homeric",
+            "translation_en": "and his heart groaned within him"
+          },
+          {
+            "text": "μακάριοι οἱ καθαροὶ τῇ καρδίᾳ",
+            "source": "Matthew 5:8",
+            "era": "Koine",
+            "translation_en": "Blessed are the pure in heart"
+          },
+          {
+            "text": "Στην καρδιά μου να έχω πάντα την Ιθάκη",
+            "source": "Cavafy, Ithaca",
+            "era": "Modern",
+            "translation_en": "To always have Ithaca in my heart"
+          }
+        ],
+        "register": {
+          "formality": "neutral",
+          "collocations": [
+            "από καρδιάς",
+            "ραγίζω την καρδιά",
+            "καρδιά λιονταριού",
+            "με την καρδιά μου",
+            "στην καρδιά της πόλης"
+          ],
+          "false_friends_en": [
+            "card"
+          ],
+          "usage_note": "Equally natural for anatomical organ (heart attack, heart surgery) and emotional/metaphorical center (speak from the heart, lion-hearted, heart of the city); idiomatically productive"
+        }
+      }
+    },
+    {
+      "lemma_form": "φιλία",
+      "enrichment": {
+        "version": 1,
+        "etymology": {
+          "pie_root": "*bʰil- (to love, be fond)",
+          "ancient_form": "φιλία",
+          "origin_note": "From φίλος 'friend, dear one' (related to φιλέω 'to love') with abstract noun suffix -ία. Classical philosophy distinguishes φιλία (friendship-love between equals) from ἔρως (passionate desire) and ἀγάπη (selfless love). Aristotle devotes Nicomachean Ethics books 8-9 to analyzing three types of φιλία: based on utility, pleasure, or shared virtue.",
+          "morphology": "φίλος (friend, beloved) + -ία (abstract noun suffix) → 'friendship, affection'"
+        },
+        "diachrony": [
+          {
+            "era": "Classical",
+            "form": "φιλία",
+            "meaning": "friendship, love between equals, affection",
+            "note": "Central ethical concept; Aristotle distinguishes utility-friendship, pleasure-friendship, and virtue-friendship"
+          },
+          {
+            "era": "Koine",
+            "form": "φιλία",
+            "meaning": "friendship, worldly affection",
+            "note": "NT rarely uses it (James 4:4 condemns 'friendship with the world'), preferring ἀγάπη for Christian love"
+          },
+          {
+            "era": "Byzantine",
+            "form": "φιλία",
+            "meaning": "friendship, affection",
+            "note": "Less philosophically technical; standard word for friendship alongside ἀγάπη"
+          },
+          {
+            "era": "Modern",
+            "form": "φιλία",
+            "meaning": "friendship",
+            "note": "Standard word for friendship; lost classical philosophical granularity (Aristotle's three types no longer encoded in the word)"
+          }
+        ],
+        "cognates": [
+          {
+            "language": "English",
+            "form": "philosophy",
+            "relation": "loanword-from-greek",
+            "gloss_en": null,
+            "note": "φιλο- + σοφία, love of wisdom"
+          },
+          {
+            "language": "English",
+            "form": "Philadelphia",
+            "relation": "loanword-from-greek",
+            "gloss_en": null,
+            "note": "φιλο- + ἀδελφός, brotherly love"
+          },
+          {
+            "language": "English",
+            "form": "-phile suffix",
+            "relation": "loanword-from-greek",
+            "gloss_en": null,
+            "note": "Productive in English for 'lover of X': bibliophile, Francophile, audiophile"
+          },
+          {
+            "language": "English",
+            "form": "philanthropy",
+            "relation": "loanword-from-greek",
+            "gloss_en": null,
+            "note": "φιλο- + ἄνθρωπος, love of humanity"
+          },
+          {
+            "language": "Latin",
+            "form": "amicitia",
+            "relation": "calque",
+            "gloss_en": "friendship",
+            "note": "Not cognate but semantic parallel; from amicus (friend), as φιλία from φίλος"
+          }
+        ],
+        "quotes": [
+          {
+            "text": "ἡ φιλία ἰσότης ἐστί",
+            "source": "Pythagoras (attributed), cited by Diogenes Laertius",
+            "era": "Classical",
+            "translation_en": "Friendship is equality"
+          },
+          {
+            "text": "ὁ φίλος ἄλλος αὐτός",
+            "source": "Aristotle (attribution debated), Nicomachean Ethics tradition",
+            "era": "Classical",
+            "translation_en": "A friend is another self"
+          },
+          {
+            "text": "ἡ φιλία τοῦ κόσμου ἔχθρα τοῦ θεοῦ ἐστιν",
+            "source": "James 4:4",
+            "era": "Koine",
+            "translation_en": "Friendship with the world is enmity with God"
+          }
+        ],
+        "register": {
+          "formality": "neutral",
+          "collocations": [
+            "δεσμοί φιλίας",
+            "αληθινή φιλία",
+            "φιλία που κρατάει χρόνια",
+            "φιλία και αγάπη",
+            "σχέσεις φιλίας"
+          ],
+          "false_friends_en": [
+            "philia"
+          ],
+          "usage_note": "Slightly more formal or literary than simply φίλοι (friends); used to emphasize the quality, depth, or abstract concept of friendship rather than just naming the relationship"
+        }
+      }
+    }
+  ]
+}

--- a/frontend/lib/__tests__/language-context.test.ts
+++ b/frontend/lib/__tests__/language-context.test.ts
@@ -91,6 +91,7 @@ describe("routeLanguage classifier", () => {
   test("polyglot deep paths and future polyglot-* screens classify as 'el'", () => {
     expect(routeLanguage("/polyglot/some-deep-path")).toBe("el");
     expect(routeLanguage("/polyglot-anything-new")).toBe("el");
+    expect(routeLanguage("/polyglot-lemma/1245")).toBe("el");
   });
 
   test("homePathFor returns the right entry route per language", () => {

--- a/frontend/lib/__tests__/polyglot-enrichment-shape.test.ts
+++ b/frontend/lib/__tests__/polyglot-enrichment-shape.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Shape parity guard between the backend Pydantic `LemmaEnrichment` model and
+ * the frontend `LemmaEnrichment` TypeScript interface.
+ *
+ * The backend service writes a JSON payload validated by Pydantic. The
+ * frontend reads the same JSON as a typed object. If either side drifts (a
+ * field renamed, an enum value added, a required field made optional) without
+ * the other catching up, runtime crashes happen at the user.
+ *
+ * This test loads a real Sonnet-generated enrichment fixture (4 lemmas
+ * exercising etymology, multi-stage diachrony, multi-language cognates,
+ * literary quotes, register), narrows it to the TS type, and asserts every
+ * required field is populated. ts-jest catches type-level drift at compile
+ * time; the runtime assertions catch shape-level drift the type system can't
+ * see (e.g. era enum values that don't match POLYGLOT_ERA_COLORS).
+ *
+ * When updating the schema: regenerate the fixture via
+ * artifacts/polyglot-enrichment-poc/build_prompt.py then run
+ * `cp artifacts/polyglot-enrichment-poc/enrichment.json
+ *     frontend/lib/__tests__/fixtures/polyglot-enrichment.json`
+ * before pushing.
+ */
+import { readFileSync } from "fs";
+import { join } from "path";
+import {
+  LemmaCognate,
+  LemmaDiachronyStage,
+  LemmaEnrichment,
+  LemmaEra,
+  LemmaQuote,
+} from "../polyglot-api";
+import { POLYGLOT_ERA_COLORS } from "../polyglot-design-colors";
+
+type Fixture = {
+  lemmas: { lemma_form: string; enrichment: LemmaEnrichment }[];
+};
+
+const KNOWN_ERAS: ReadonlySet<LemmaEra> = new Set(
+  Object.keys(POLYGLOT_ERA_COLORS) as LemmaEra[],
+);
+
+function loadFixture(): Fixture {
+  const path = join(__dirname, "fixtures/polyglot-enrichment.json");
+  return JSON.parse(readFileSync(path, "utf8")) as Fixture;
+}
+
+describe("LemmaEnrichment shape parity", () => {
+  const fixture = loadFixture();
+
+  test("fixture contains the 4 POC lemmas", () => {
+    const forms = fixture.lemmas.map((l) => l.lemma_form);
+    expect(forms).toEqual(["άλογο", "λόγος", "καρδιά", "φιλία"]);
+  });
+
+  test.each(loadFixture().lemmas)(
+    "$lemma_form: parses into LemmaEnrichment with all required fields",
+    ({ lemma_form, enrichment }) => {
+      expect(enrichment.version).toBe(1);
+
+      // Etymology — origin_note is the only required string in the schema.
+      expect(enrichment.etymology).not.toBeNull();
+      expect(typeof enrichment.etymology!.origin_note).toBe("string");
+      expect(enrichment.etymology!.origin_note.length).toBeGreaterThan(20);
+
+      // Diachrony — at least one stage; every stage has a known era.
+      expect(enrichment.diachrony.length).toBeGreaterThan(0);
+      for (const stage of enrichment.diachrony) {
+        expect(KNOWN_ERAS.has(stage.era)).toBe(true);
+        expect(stage.form.length).toBeGreaterThan(0);
+        expect(stage.meaning.length).toBeGreaterThan(0);
+      }
+
+      // Cognates — at least one; every entry has the required trio.
+      expect(enrichment.cognates.length).toBeGreaterThan(0);
+      for (const cog of enrichment.cognates) {
+        expect(cog.language.length).toBeGreaterThan(0);
+        expect(cog.form.length).toBeGreaterThan(0);
+        expect(cog.relation.length).toBeGreaterThan(0);
+      }
+
+      // Quotes — required and at least one for the POC lemmas (philosophically
+      // famous words — anything weighty enough to enrich should have a quote).
+      expect(enrichment.quotes.length).toBeGreaterThan(0);
+      for (const q of enrichment.quotes) {
+        expect(KNOWN_ERAS.has(q.era)).toBe(true);
+        expect(q.text.length).toBeGreaterThan(0);
+        expect(q.translation_en.length).toBeGreaterThan(0);
+        expect(q.source.length).toBeGreaterThan(0);
+      }
+
+      // Register — when present, collocations and false-friends are arrays.
+      if (enrichment.register) {
+        expect(Array.isArray(enrichment.register.collocations)).toBe(true);
+        expect(Array.isArray(enrichment.register.false_friends_en)).toBe(true);
+      }
+
+      // Silence unused-var warning while keeping the destructure explicit.
+      void lemma_form;
+    },
+  );
+
+  test("every era in every stage maps to a design-token color", () => {
+    for (const { enrichment } of fixture.lemmas) {
+      for (const stage of enrichment.diachrony) {
+        expect(POLYGLOT_ERA_COLORS[stage.era]).toBeDefined();
+      }
+      for (const q of enrichment.quotes) {
+        expect(POLYGLOT_ERA_COLORS[q.era]).toBeDefined();
+      }
+    }
+  });
+});
+
+// Compile-time narrowing helper — if any of these field names drift, TS will
+// flag this file. Runtime not exercised.
+function _typeOnlyCheck(e: LemmaEnrichment) {
+  const _a: number = e.version;
+  const _b: LemmaDiachronyStage[] = e.diachrony;
+  const _c: LemmaCognate[] = e.cognates;
+  const _d: LemmaQuote[] = e.quotes;
+  void [_a, _b, _c, _d];
+}
+void _typeOnlyCheck;

--- a/frontend/lib/polyglot-api.ts
+++ b/frontend/lib/polyglot-api.ts
@@ -381,6 +381,100 @@ export type IntroCard = {
   cognate_lemma_form: string | null;
 };
 
+// ─── Lemma philology enrichment ─────────────────────────────────────────────
+// Mirrors `polyglot/app/schemas.py::LemmaEnrichment` 1:1. Shape parity is
+// enforced by frontend/lib/__tests__/polyglot-enrichment-shape.test.ts which
+// loads a backend-emitted fixture and asserts the TS interface accepts it.
+// When changing this shape: edit schemas.py FIRST, regen the fixture, then
+// update here.
+
+export type LemmaEra =
+  | "Mycenaean"
+  | "Homeric"
+  | "Classical"
+  | "Koine"
+  | "Byzantine"
+  | "Modern";
+
+export type LemmaCognateRelation =
+  | "loanword-from-greek"
+  | "shared-pie-root"
+  | "calque"
+  | "descendant"
+  | "borrowed-via-latin";
+
+export type LemmaFormality = "formal" | "neutral" | "colloquial" | "literary";
+
+export type LemmaEtymology = {
+  pie_root: string | null;
+  ancient_form: string | null;
+  origin_note: string;
+  morphology: string | null;
+};
+
+export type LemmaDiachronyStage = {
+  era: LemmaEra;
+  form: string;
+  meaning: string;
+  note: string | null;
+};
+
+export type LemmaCognate = {
+  language: string;
+  form: string;
+  relation: LemmaCognateRelation;
+  gloss_en: string | null;
+  note: string | null;
+};
+
+export type LemmaQuote = {
+  text: string;
+  source: string;
+  era: LemmaEra;
+  translation_en: string;
+};
+
+export type LemmaRegister = {
+  formality: LemmaFormality | null;
+  collocations: string[];
+  false_friends_en: string[];
+  usage_note: string | null;
+};
+
+export type LemmaEnrichment = {
+  version: number;
+  etymology: LemmaEtymology | null;
+  diachrony: LemmaDiachronyStage[];
+  cognates: LemmaCognate[];
+  quotes: LemmaQuote[];
+  register: LemmaRegister | null;
+};
+
+// Mirrors the `/api/lemmas/{lemma_id}/detail` response (profile.py).
+export type LemmaDetail = {
+  lemma_id: number;
+  language_code: string;
+  lemma_form: string;
+  lemma_bare: string;
+  pos: string | null;
+  gloss_en: string | null;
+  frequency_rank: number | null;
+  cefr_level: string | null;
+  word_category: string | null;
+  cognate_lemma_id: number | null;
+  cognate_lemma_form: string | null;
+  external_cognates: { lang: string; form: string; transparency: string; note?: string | null }[];
+  enrichment: LemmaEnrichment | null;
+  enrichment_status: string | null;
+  enriched_at: string | null;
+  knowledge_state: string | null;
+  times_seen: number;
+};
+
+export async function getLemmaDetail(lemmaId: number): Promise<LemmaDetail> {
+  return get(`/api/lemmas/${lemmaId}/detail`);
+}
+
 export type ReviewSessionBundle = {
   sentences: SentencePayload[];
   intro_cards: IntroCard[];

--- a/frontend/lib/polyglot-design-colors.ts
+++ b/frontend/lib/polyglot-design-colors.ts
@@ -1,0 +1,84 @@
+/**
+ * Polyglot design tokens — pure constants, no React Native imports.
+ *
+ * Split from polyglot-design-tokens.ts so Jest (ts-jest, node env) can import
+ * the era color map without pulling react-native. The full token surface
+ * (including Platform-dependent font fallbacks) lives in
+ * polyglot-design-tokens.ts; it re-exports these constants.
+ */
+
+/**
+ * Era → color. Used by the diachrony timeline dots, the era pills inside
+ * quote citations, and the chip in the lemma header. Five distinct hues across
+ * the warm/cool spectrum so the reader's eye instantly places a form in time.
+ */
+export const POLYGLOT_ERA_COLORS = {
+  Mycenaean: "#3a5a4a",
+  Homeric: "#5a8a6a",
+  Classical: "#4a7c8a",
+  Koine: "#6a5a8a",
+  Byzantine: "#8a5a4a",
+  Modern: "#c97a3a",
+} as const;
+
+export type PolyglotEra = keyof typeof POLYGLOT_ERA_COLORS;
+
+/**
+ * Base palette. Light/editorial surface, neutral text scale. Cognates and
+ * quote sections each have their own accent so the user can scan the
+ * detail page by color band.
+ */
+export const POLYGLOT_COLORS = {
+  bg: "#fafaf8",
+  surface: "#ffffff",
+  surfaceMuted: "#f3f1ec",
+  text: "#1a1a1a",
+  textSecondary: "#6b6b6b",
+  textTertiary: "#9b9b9b",
+  border: "#ececec",
+  borderStrong: "#d4c8b0",
+  accent: "#2c5f8d",
+  etymology: "#c97a3a",
+  cognate: "#2e7d6b",
+  quote: "#7d3a7a",
+  warning: "#c14a3a",
+  etymologyTint: "#fdf2e9",
+  cognateTint: "#e8f4ef",
+  quoteTint: "#f5edf4",
+  warningTint: "#fdebe7",
+} as const;
+
+export function eraColor(era: string | null | undefined): string {
+  if (!era) return POLYGLOT_COLORS.textSecondary;
+  return (POLYGLOT_ERA_COLORS as Record<string, string>)[era] ?? POLYGLOT_COLORS.textSecondary;
+}
+
+export const POLYGLOT_TYPE = {
+  heroGreek: 56,
+  heroGreekLarge: 72,
+  bodyGreek: 20,
+  stageForm: 21,
+  gloss: 20,
+  glossInline: 18,
+  cogForm: 15,
+  cogGreek: 17,
+  body: 14,
+  bodySmall: 13,
+  meta: 12,
+  micro: 10,
+} as const;
+
+export const POLYGLOT_SPACING = {
+  pageH: 16,
+  sectionV: 18,
+  rowGap: 10,
+  chipGap: 5,
+  bottomFloat: 60,
+} as const;
+
+export const POLYGLOT_RADIUS = {
+  card: 14,
+  chip: 999,
+  pill: 6,
+  callout: 8,
+} as const;

--- a/frontend/lib/polyglot-design-tokens.ts
+++ b/frontend/lib/polyglot-design-tokens.ts
@@ -1,0 +1,59 @@
+/**
+ * Polyglot design tokens — Modern Editorial.
+ *
+ * Single source of truth for the polyglot visual language across the reader,
+ * sentence review, intro card, lookup card, and lemma detail screen.
+ *
+ * Mirrors the locked design choices from the 2026-05-21 design-explorer round
+ * (Round 2: "Detail iPhone · Modern Editorial" + "Editorial w/ λόγος"). When
+ * tweaking a color or font size, change it here and every polyglot surface
+ * follows.
+ *
+ * Why a separate file instead of frontend/lib/theme.ts: theme.ts is Alif's
+ * Arabic palette (dark surface, Arabic font stack). Polyglot is the opposite
+ * aesthetic: light surface, Cormorant Garamond for Greek, color-coded eras.
+ *
+ * Color/spacing/type constants live in polyglot-design-colors.ts (pure, no RN
+ * imports — Jest can read them). Font fallbacks need Platform and live here.
+ */
+import { Platform } from "react-native";
+
+export {
+  POLYGLOT_ERA_COLORS,
+  POLYGLOT_COLORS,
+  POLYGLOT_TYPE,
+  POLYGLOT_SPACING,
+  POLYGLOT_RADIUS,
+  eraColor,
+} from "./polyglot-design-colors";
+export type { PolyglotEra } from "./polyglot-design-colors";
+
+/**
+ * Type scale. Greek display forms use Cormorant Garamond on iOS (loaded via
+ * Expo Font at app boot); falls back to system serif elsewhere. Body text is
+ * the system sans on iOS, sans-serif otherwise.
+ */
+export const POLYGLOT_FONTS = {
+  greekDisplay: Platform.select({
+    ios: "Cormorant Garamond",
+    android: "serif",
+    default: "'Cormorant Garamond', 'EB Garamond', Georgia, serif",
+  }),
+  // Body Greek (sentence rendering inside reader / review). Georgia has full
+  // polytonic coverage on iOS; system serif elsewhere.
+  greekBody: Platform.select({
+    ios: "Georgia",
+    android: "serif",
+    default: "Georgia, 'Noto Serif', serif",
+  }),
+  uiSans: Platform.select({
+    ios: "System",
+    android: "sans-serif",
+    default: "-apple-system, 'Inter', system-ui, sans-serif",
+  }),
+  mono: Platform.select({
+    ios: "Menlo",
+    android: "monospace",
+    default: "'JetBrains Mono', monospace",
+  }),
+} as const;

--- a/frontend/lib/polyglot-lookup-card.tsx
+++ b/frontend/lib/polyglot-lookup-card.tsx
@@ -1,0 +1,369 @@
+/**
+ * Middle-density lemma card for the reader's tap state and the review
+ * screen's word-tap state. Shows more than the existing one-line lookup bar
+ * (just `surface + gloss`) but far less than the full Modern Editorial detail
+ * page — the goal is to answer "what is this word?" in 3-5 seconds, with a
+ * "View details ›" link to the full page when curiosity is bigger.
+ *
+ * Content tiers (each optional, omitted gracefully if data absent):
+ *   1. Always: lemma form + gloss + POS
+ *   2. Compact diachrony peek: 1-line "Classical X → Modern Y" if available
+ *   3. Ancient Greek cognate hint
+ *   4. One literary quote (the first one — usually the most famous)
+ *   5. Top 2-3 collocations as pills
+ *   6. View-details link
+ *
+ * Mirrors the design vocabulary in polyglot-design-tokens.ts. Used by both
+ * polyglot.tsx (reader tap bar) and polyglot-review.tsx (word-tap inline).
+ *
+ * For Alif's analogue, see frontend/lib/review/WordInfoCard.tsx — much richer
+ * because Arabic has root families, wazn patterns, confusion analysis. The
+ * polyglot version is intentionally leaner.
+ */
+import React from "react";
+import { Pressable, StyleSheet, Text, View } from "react-native";
+import { LemmaDiachronyStage, LemmaEnrichment, LemmaQuote } from "./polyglot-api";
+import {
+  POLYGLOT_COLORS,
+  POLYGLOT_RADIUS,
+  POLYGLOT_SPACING,
+  POLYGLOT_TYPE,
+  eraColor,
+} from "./polyglot-design-colors";
+import { POLYGLOT_FONTS } from "./polyglot-design-tokens";
+
+export type LookupCardProps = {
+  /** Greek lemma form to display (with monotonic accents). */
+  lemmaForm: string;
+  /** English gloss. May be null while still loading from the backend. */
+  glossEn: string | null;
+  /** Part of speech (e.g. "noun (neuter)", "verb"). */
+  pos: string | null;
+  /** Ancient Greek cognate form (e.g. "ἄλογος" for "άλογο"). */
+  ancientForm: string | null;
+  /** Optional enrichment payload. When null, the card collapses to the core
+   *  head row and just shows the cognate hint if present. */
+  enrichment: LemmaEnrichment | null;
+  /** Frequency rank for display ("freq #N"). Null = unknown. */
+  frequencyRank?: number | null;
+  /** Tap-cycle state indicator color (red / yellow / clear). Null = no dot. */
+  cycleColor?: string | null;
+  /** Surface form actually tapped (e.g. "άλογα" when the lemma is "άλογο").
+   *  Shown as a smaller label on the head row so the user can see *what they
+   *  tapped* vs. the citation form. */
+  surfaceForm?: string | null;
+  /** Render a "View details ›" affordance routing to the full detail page. */
+  onViewDetails?: () => void;
+  /** Close-the-card affordance (× in the head row). */
+  onClose?: () => void;
+};
+
+export default function PolyglotLookupCard(props: LookupCardProps) {
+  const {
+    lemmaForm,
+    glossEn,
+    pos,
+    ancientForm,
+    enrichment,
+    frequencyRank,
+    cycleColor,
+    surfaceForm,
+    onViewDetails,
+    onClose,
+  } = props;
+
+  const driftPeek = enrichment ? pickDriftPeek(enrichment.diachrony) : null;
+  const topQuote: LemmaQuote | null =
+    enrichment && enrichment.quotes.length > 0 ? enrichment.quotes[0] : null;
+  const topCollocations: string[] = enrichment?.register?.collocations.slice(0, 3) ?? [];
+  const falseFriend = enrichment?.register?.false_friends_en?.[0];
+
+  return (
+    <View style={styles.card}>
+      {/* Head row — always present */}
+      <View style={styles.headRow}>
+        {cycleColor ? <View style={[styles.cycleDot, { backgroundColor: cycleColor }]} /> : null}
+        <Text style={styles.lemma}>{lemmaForm}</Text>
+        {surfaceForm && surfaceForm !== lemmaForm ? (
+          <Text style={styles.surface}>{surfaceForm}</Text>
+        ) : null}
+        {pos ? (
+          <View style={styles.posPill}>
+            <Text style={styles.posText}>{pos}</Text>
+          </View>
+        ) : null}
+        {frequencyRank != null ? (
+          <Text style={styles.freq}>#{frequencyRank}</Text>
+        ) : null}
+        {onClose ? (
+          <Pressable onPress={onClose} hitSlop={10} style={styles.close}>
+            <Text style={styles.closeText}>×</Text>
+          </Pressable>
+        ) : null}
+      </View>
+
+      {/* Gloss — appears below the head row on its own line for breathing room */}
+      {glossEn ? <Text style={styles.gloss}>{glossEn}</Text> : null}
+
+      {/* Ancient Greek cognate chip + drift peek live on the same row */}
+      {ancientForm || driftPeek ? (
+        <View style={styles.metaRow}>
+          {ancientForm ? (
+            <View style={styles.ancChip}>
+              <Text style={styles.ancLabel}>Ancient</Text>
+              <Text style={styles.ancForm}>{ancientForm}</Text>
+            </View>
+          ) : null}
+          {driftPeek ? <Text style={styles.driftPeek}>{driftPeek}</Text> : null}
+        </View>
+      ) : null}
+
+      {/* One literary quote — the first one. The era pill is colored. */}
+      {topQuote ? (
+        <View style={styles.quoteBlock}>
+          <Text style={styles.quoteText}>{topQuote.text}</Text>
+          <Text style={styles.quoteTrans}>"{topQuote.translation_en}"</Text>
+          <View style={styles.quoteSourceRow}>
+            <View style={[styles.eraPill, { backgroundColor: eraColor(topQuote.era) + "22", borderColor: eraColor(topQuote.era) }]}>
+              <Text style={[styles.eraPillText, { color: eraColor(topQuote.era) }]}>
+                {topQuote.era}
+              </Text>
+            </View>
+            <Text style={styles.quoteSource}>{topQuote.source}</Text>
+          </View>
+        </View>
+      ) : null}
+
+      {/* Top collocations as serif pills */}
+      {topCollocations.length > 0 ? (
+        <View style={styles.collRow}>
+          {topCollocations.map((c) => (
+            <View key={c} style={styles.collPill}>
+              <Text style={styles.collText}>{c}</Text>
+            </View>
+          ))}
+        </View>
+      ) : null}
+
+      {/* False-friend warning — compact one-liner */}
+      {falseFriend ? (
+        <Text style={styles.falseFriend}>
+          ⚠ False friend: <Text style={styles.falseFriendStrong}>{falseFriend}</Text>
+        </Text>
+      ) : null}
+
+      {/* View-details affordance — surfaces only when enrichment exists OR the
+       *  caller wants to push the page anyway. */}
+      {onViewDetails ? (
+        <Pressable onPress={onViewDetails} hitSlop={8} style={styles.viewDetails}>
+          <Text style={styles.viewDetailsText}>View full philology ›</Text>
+        </Pressable>
+      ) : null}
+    </View>
+  );
+}
+
+/**
+ * Compact diachrony summary: "Classical 'irrational' → Modern 'horse'".
+ * Picks first and last stage when there's drift; collapses when stages have
+ * the same meaning (no story to tell).
+ */
+function pickDriftPeek(stages: LemmaDiachronyStage[]): string | null {
+  if (stages.length < 2) return null;
+  const first = stages[0];
+  const last = stages[stages.length - 1];
+  if (first.meaning.toLowerCase() === last.meaning.toLowerCase()) return null;
+  return `${first.era} "${shortMeaning(first.meaning)}" → ${last.era} "${shortMeaning(last.meaning)}"`;
+}
+
+function shortMeaning(m: string): string {
+  // Take the leading clause up to the first comma so the peek stays one line
+  // on a 390px viewport. Strip trailing whitespace.
+  const idx = m.indexOf(",");
+  return (idx > 0 ? m.slice(0, idx) : m).trim();
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: POLYGLOT_COLORS.surface,
+    borderRadius: POLYGLOT_RADIUS.card,
+    borderWidth: 1,
+    borderColor: POLYGLOT_COLORS.border,
+    padding: 14,
+    gap: 8,
+  },
+  headRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+    flexWrap: "wrap",
+  },
+  cycleDot: {
+    width: 9,
+    height: 9,
+    borderRadius: 5,
+  },
+  lemma: {
+    fontFamily: POLYGLOT_FONTS.greekDisplay,
+    fontSize: 26,
+    color: POLYGLOT_COLORS.text,
+    lineHeight: 30,
+  },
+  surface: {
+    fontFamily: POLYGLOT_FONTS.greekBody,
+    fontSize: POLYGLOT_TYPE.body,
+    color: POLYGLOT_COLORS.textTertiary,
+    fontStyle: "italic",
+  },
+  posPill: {
+    backgroundColor: POLYGLOT_COLORS.surfaceMuted,
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderRadius: POLYGLOT_RADIUS.pill,
+  },
+  posText: {
+    fontSize: POLYGLOT_TYPE.micro,
+    color: POLYGLOT_COLORS.textSecondary,
+    fontWeight: "600",
+    letterSpacing: 0.4,
+    textTransform: "lowercase",
+  },
+  freq: {
+    fontSize: POLYGLOT_TYPE.micro,
+    color: POLYGLOT_COLORS.textTertiary,
+  },
+  close: {
+    marginLeft: "auto",
+    width: 22,
+    height: 22,
+    borderRadius: 11,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  closeText: {
+    fontSize: 22,
+    color: POLYGLOT_COLORS.textTertiary,
+    lineHeight: 22,
+  },
+  gloss: {
+    fontSize: POLYGLOT_TYPE.glossInline,
+    color: POLYGLOT_COLORS.text,
+    fontFamily: POLYGLOT_FONTS.greekDisplay,
+    fontStyle: "italic",
+  },
+  metaRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+    flexWrap: "wrap",
+  },
+  ancChip: {
+    flexDirection: "row",
+    alignItems: "baseline",
+    gap: 4,
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderRadius: POLYGLOT_RADIUS.pill,
+    backgroundColor: POLYGLOT_COLORS.cognateTint,
+  },
+  ancLabel: {
+    fontSize: POLYGLOT_TYPE.micro,
+    color: POLYGLOT_COLORS.cognate,
+    fontWeight: "700",
+    letterSpacing: 0.4,
+    textTransform: "uppercase",
+  },
+  ancForm: {
+    fontFamily: POLYGLOT_FONTS.greekDisplay,
+    fontSize: 16,
+    color: POLYGLOT_COLORS.cognate,
+    fontStyle: "italic",
+  },
+  driftPeek: {
+    flex: 1,
+    fontSize: POLYGLOT_TYPE.bodySmall,
+    color: POLYGLOT_COLORS.textSecondary,
+    fontStyle: "italic",
+  },
+  quoteBlock: {
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    backgroundColor: POLYGLOT_COLORS.quoteTint,
+    borderLeftWidth: 3,
+    borderLeftColor: POLYGLOT_COLORS.quote,
+    borderRadius: POLYGLOT_RADIUS.callout,
+    gap: 4,
+  },
+  quoteText: {
+    fontFamily: POLYGLOT_FONTS.greekDisplay,
+    fontSize: 17,
+    fontStyle: "italic",
+    color: POLYGLOT_COLORS.text,
+    lineHeight: 22,
+  },
+  quoteTrans: {
+    fontSize: POLYGLOT_TYPE.bodySmall,
+    color: POLYGLOT_COLORS.textSecondary,
+  },
+  quoteSourceRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    marginTop: 2,
+  },
+  eraPill: {
+    paddingHorizontal: 6,
+    paddingVertical: 1,
+    borderRadius: POLYGLOT_RADIUS.pill,
+    borderWidth: 1,
+  },
+  eraPillText: {
+    fontSize: POLYGLOT_TYPE.micro,
+    fontWeight: "700",
+    letterSpacing: 0.6,
+    textTransform: "uppercase",
+  },
+  quoteSource: {
+    fontSize: POLYGLOT_TYPE.micro,
+    color: POLYGLOT_COLORS.textTertiary,
+    letterSpacing: 0.3,
+  },
+  collRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: POLYGLOT_SPACING.chipGap,
+  },
+  collPill: {
+    backgroundColor: POLYGLOT_COLORS.surface,
+    borderColor: POLYGLOT_COLORS.border,
+    borderWidth: 1,
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    borderRadius: POLYGLOT_RADIUS.chip,
+  },
+  collText: {
+    fontFamily: POLYGLOT_FONTS.greekDisplay,
+    fontSize: 14,
+    color: POLYGLOT_COLORS.text,
+  },
+  falseFriend: {
+    fontSize: POLYGLOT_TYPE.bodySmall,
+    color: POLYGLOT_COLORS.warning,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    backgroundColor: POLYGLOT_COLORS.warningTint,
+    borderRadius: POLYGLOT_RADIUS.pill,
+  },
+  falseFriendStrong: {
+    fontWeight: "700",
+  },
+  viewDetails: {
+    alignSelf: "flex-start",
+    paddingTop: 2,
+  },
+  viewDetailsText: {
+    color: POLYGLOT_COLORS.accent,
+    fontSize: POLYGLOT_TYPE.bodySmall,
+    fontWeight: "600",
+  },
+});

--- a/polyglot/app/database.py
+++ b/polyglot/app/database.py
@@ -53,6 +53,9 @@ _ADDITIVE_COLUMN_DELTAS: list[tuple[str, str, str]] = [
     ("user_lemma_knowledge", "experiment_intro_shown_at", "DATETIME"),
     ("pages", "viewed_at", "DATETIME"),
     ("pages", "body_clean", "TEXT"),
+    ("lemmas", "enrichment_json", "JSON"),
+    ("lemmas", "enrichment_status", "VARCHAR(20)"),
+    ("lemmas", "enriched_at", "DATETIME"),
 ]
 
 # Indexes that should exist once the columns above are present.

--- a/polyglot/app/models.py
+++ b/polyglot/app/models.py
@@ -58,6 +58,9 @@ class Lemma(Base):
     # NULL = never checked; [] = checked, none found.
     cognates_json = Column(JSON, nullable=True)
     cognates_detected_at = Column(DateTime, nullable=True)
+    enrichment_json = Column(JSON, nullable=True)
+    enrichment_status = Column(String(20), nullable=True)
+    enriched_at = Column(DateTime, nullable=True)
     created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
 
     language = relationship("Language")

--- a/polyglot/app/routers/materials.py
+++ b/polyglot/app/routers/materials.py
@@ -28,6 +28,10 @@ from app.services.material_generator import (
     batch_generate_material,
     warm_sentence_cache,
 )
+from app.services.lemma_philology import (
+    batch_enrich,
+    find_unenriched_lemmas,
+)
 
 
 router = APIRouter(prefix="/api/materials", tags=["materials"])
@@ -79,3 +83,43 @@ def warm_cache(req: WarmCacheRequest) -> WarmCacheResponse:
         sentences_per_target=req.sentences_per_target,
     )
     return WarmCacheResponse(**result)
+
+
+# ─── Lemma philology enrichment ─────────────────────────────────────────────
+
+
+class EnrichRequest(BaseModel):
+    language_code: str = "el"
+    lemma_ids: Optional[list[int]] = None
+    max_lemmas: int = Field(default=10, ge=1, le=50)
+    include_failed: bool = False
+
+
+class EnrichResponse(BaseModel):
+    enriched: int
+    failed_lemma_ids: list[int]
+    skipped_lemma_ids: list[int]
+
+
+@router.post("/enrich-philology", response_model=EnrichResponse)
+def enrich_philology(req: EnrichRequest) -> EnrichResponse:
+    """Run philology enrichment.
+
+    Two modes:
+    - Caller supplies ``lemma_ids`` explicitly → enrich exactly those.
+    - Caller omits ``lemma_ids`` → pick up to ``max_lemmas`` un-enriched
+      lemmas from the engaged-vocabulary pool (those with a ULK row), ranked
+      by frequency. Used by the cron wrapper.
+    """
+    if req.lemma_ids:
+        ids = req.lemma_ids
+    else:
+        ids = find_unenriched_lemmas(
+            language_code=req.language_code,
+            limit=req.max_lemmas,
+            include_failed=req.include_failed,
+        )
+    if not ids:
+        return EnrichResponse(enriched=0, failed_lemma_ids=[], skipped_lemma_ids=[])
+    result = batch_enrich(language_code=req.language_code, lemma_ids=ids)
+    return EnrichResponse(**result)

--- a/polyglot/app/routers/profile.py
+++ b/polyglot/app/routers/profile.py
@@ -3,7 +3,13 @@ from sqlalchemy.orm import Session
 
 from app.database import get_db
 from app.models import Lemma, UserProfile
-from app.schemas import UserProfileOut, UserProfileUpdate, LemmaCognatesOut, CognateInfo
+from app.schemas import (
+    CognateInfo,
+    LemmaCognatesOut,
+    LemmaEnrichment,
+    UserProfileOut,
+    UserProfileUpdate,
+)
 from app.services.cognate_detector import get_user_profile, detect_external_cognates
 
 router = APIRouter(prefix="/api", tags=["profile"])
@@ -53,6 +59,58 @@ def get_lemma_cognates(lemma_id: int, db: Session = Depends(get_db)):
         detected_at=lemma.cognates_detected_at,
         cognate_lemma_id=lemma.cognate_lemma_id,
     )
+
+
+@router.get("/lemmas/{lemma_id}/detail")
+def get_lemma_detail(lemma_id: int, db: Session = Depends(get_db)):
+    """Full lemma payload for the detail screen: base info + cognate (Ancient
+    Greek) form + parsed enrichment_json (if any) + ULK summary.
+
+    Surfaces everything the Modern Editorial detail screen needs in one
+    round-trip. Returns 404 if the lemma doesn't exist.
+    """
+    lemma = db.get(Lemma, lemma_id)
+    if not lemma:
+        raise HTTPException(status_code=404, detail="lemma not found")
+
+    cognate_form = None
+    if lemma.cognate_lemma_id:
+        cog = db.get(Lemma, lemma.cognate_lemma_id)
+        if cog is not None:
+            cognate_form = cog.lemma_form
+
+    enrichment = None
+    if lemma.enrichment_json:
+        try:
+            enrichment = LemmaEnrichment.model_validate(lemma.enrichment_json).model_dump(mode="json")
+        except Exception:
+            enrichment = None  # corrupt — let caller refresh
+
+    knowledge_state = None
+    times_seen = 0
+    if lemma.knowledge is not None:
+        knowledge_state = lemma.knowledge.knowledge_state
+        times_seen = lemma.knowledge.times_seen or 0
+
+    return {
+        "lemma_id": lemma.lemma_id,
+        "language_code": lemma.language_code,
+        "lemma_form": lemma.lemma_form,
+        "lemma_bare": lemma.lemma_bare,
+        "pos": lemma.pos,
+        "gloss_en": lemma.gloss_en,
+        "frequency_rank": lemma.frequency_rank,
+        "cefr_level": lemma.cefr_level,
+        "word_category": lemma.word_category,
+        "cognate_lemma_id": lemma.cognate_lemma_id,
+        "cognate_lemma_form": cognate_form,
+        "external_cognates": lemma.cognates_json or [],
+        "enrichment": enrichment,
+        "enrichment_status": lemma.enrichment_status,
+        "enriched_at": lemma.enriched_at.isoformat() if lemma.enriched_at else None,
+        "knowledge_state": knowledge_state,
+        "times_seen": times_seen,
+    }
 
 
 @router.post("/cognates/detect")

--- a/polyglot/app/schemas.py
+++ b/polyglot/app/schemas.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 # ─── Languages ─────────────────────────────────────────────────────────────
@@ -127,3 +127,77 @@ class LemmaCognatesOut(BaseModel):
     cognates: list[CognateInfo]
     detected_at: datetime | None
     cognate_lemma_id: int | None       # Modern↔Ancient Greek link (if any)
+
+
+# ─── Lemma enrichment (philology / etymology / diachrony / quotes) ──────────
+# Single source of truth for the LemmaEnrichment shape. Both the enrichment
+# service (lemma_philology.py) and the frontend (frontend/lib/types.ts) target
+# this shape; the corresponding TS interfaces mirror it 1:1 and a Jest test
+# loads the same JSON fixture this module emits.
+#
+# Eras are normalized to a fixed enum so the frontend can color-code stages
+# without per-lemma surprises.
+
+LEMMA_ERA = ("Mycenaean", "Homeric", "Classical", "Koine", "Byzantine", "Modern")
+LemmaEra = str  # constrained at JSON-schema layer in lemma_philology._gen_schema
+
+
+class LemmaEtymology(BaseModel):
+    pie_root: str | None = None        # e.g. "*ḱerd- (heart)"
+    ancient_form: str | None = None    # polytonic, e.g. "καρδία"
+    origin_note: str                   # 1-2 sentence prose origin
+    morphology: str | None = None      # e.g. "ἀ- (neg) + λόγος (reason)"
+
+
+class LemmaDiachronyStage(BaseModel):
+    era: str                           # one of LEMMA_ERA
+    form: str                          # form at this era (often shifted)
+    meaning: str                       # meaning at this era
+    note: str | None = None            # one-liner context
+
+
+class LemmaCognate(BaseModel):
+    language: str                      # "English" / "Latin" / "German" / etc.
+    form: str
+    relation: str                      # see lemma_philology._gen_schema enum
+    gloss_en: str | None = None        # for non-English cognates
+    note: str | None = None            # false-friend warning, semantic drift
+
+
+class LemmaQuote(BaseModel):
+    text: str                          # ≤25 words
+    source: str                        # "Plato, Republic 439d"
+    era: str                           # one of LEMMA_ERA
+    translation_en: str
+
+
+class LemmaRegister(BaseModel):
+    formality: str | None = None       # "formal" | "neutral" | "colloquial" | "literary"
+    collocations: list[str] = Field(default_factory=list)
+    false_friends_en: list[str] = Field(default_factory=list)
+    usage_note: str | None = None
+
+
+class LemmaEnrichment(BaseModel):
+    """Philological enrichment payload for a single lemma. Carried in
+    `Lemma.enrichment_json` and surfaced to the learner in the lookup card +
+    lemma detail screen (Modern Editorial design, 2026-05-21)."""
+    model_config = ConfigDict(protected_namespaces=())
+
+    version: int = 1
+    etymology: LemmaEtymology | None = None
+    diachrony: list[LemmaDiachronyStage] = Field(default_factory=list)
+    cognates: list[LemmaCognate] = Field(default_factory=list)
+    quotes: list[LemmaQuote] = Field(default_factory=list)
+    register: LemmaRegister | None = None
+
+
+class LemmaEnrichmentRequest(BaseModel):
+    lemma_ids: list[int]
+    language_code: str = "el"
+
+
+class LemmaEnrichmentBatchResult(BaseModel):
+    enriched: int
+    failed_lemma_ids: list[int]
+    skipped_lemma_ids: list[int]       # glossless / variant / function word

--- a/polyglot/app/services/lemma_philology.py
+++ b/polyglot/app/services/lemma_philology.py
@@ -1,0 +1,579 @@
+"""Philological enrichment for lemmas.
+
+Generates ``Lemma.enrichment_json`` payloads using Claude Sonnet via the
+``claude -p --json-schema`` CLI. Surfaced in the lookup card + lemma detail
+screen (Modern Editorial design).
+
+Pipeline mirrors ``material_generator.batch_generate_material`` for SQLite
+write-lock discipline:
+
+    Phase 1 — DB read:   pull lemmas + glosses + POS, close session.
+    Phase 2 — LLM work:  one Sonnet call per batch (~4 lemmas), no DB held.
+    Phase 3 — DB write:  open fresh session, write enrichment + stamp status.
+
+Constraints:
+- **Verification not applicable** (no per-token mappings to verify).
+  Quality control is the JSON-schema constraint (eras enum, required fields)
+  plus a per-lemma sanity check on the parsed payload before writing.
+- **Sonnet, not Haiku** — etymology + literary quotes need real reasoning;
+  Haiku produces shallow output that doesn't carry the design's weight.
+- **Glossless lemmas are skipped** — if we don't know what the word means we
+  can't ask Claude to philologize it. Same rule as the picker / generator.
+- **Variant lemmas are skipped** — they re-use the canonical's enrichment.
+  Function-word + proper-name lemmas are also skipped (no philological
+  payoff).
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from app import database
+from app.models import Lemma
+from app.schemas import LemmaEnrichment
+
+log = logging.getLogger(__name__)
+
+
+_MODEL_ALIASES = {
+    "sonnet": "claude-sonnet-4-5-20250929",
+    "haiku": "claude-haiku-4-5-20251001",
+}
+
+
+def _resolve_model(raw: str) -> str:
+    return _MODEL_ALIASES.get(raw.strip().lower(), raw)
+
+
+ENRICH_MODEL = _resolve_model(os.environ.get("POLYGLOT_ENRICH_MODEL", "sonnet"))
+ENRICH_TIMEOUT_S = int(os.environ.get("POLYGLOT_ENRICH_TIMEOUT", "240"))
+ENRICH_BATCH_SIZE = max(1, int(os.environ.get("POLYGLOT_ENRICH_BATCH_SIZE", "4")))
+
+LANG_DISPLAY = {
+    "el": "Modern Greek",
+    "grc": "Ancient Greek",
+    "la": "Latin",
+}
+
+
+def _log_dir() -> Path:
+    path = Path(__file__).resolve().parents[2] / "data" / "logs"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _log_pipeline(entry: dict) -> None:
+    try:
+        path = _log_dir() / f"enrichment_pipeline_{datetime.now():%Y-%m-%d}.jsonl"
+        entry = {"ts": datetime.now().isoformat(), **entry}
+        with open(path, "a") as f:
+            f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+    except Exception:
+        pass
+
+
+# ─── Data carriers ─────────────────────────────────────────────────────────
+
+
+@dataclass
+class _EnrichTarget:
+    lemma_id: int
+    lemma_form: str
+    pos: str
+    gloss_en: str
+    cognate_form: Optional[str]   # Ancient Greek cognate if any, for context
+
+
+# ─── Prompt + schema ───────────────────────────────────────────────────────
+
+
+def _gen_prompt(language_code: str, targets: list[_EnrichTarget]) -> str:
+    lang = LANG_DISPLAY.get(language_code, language_code)
+    target_block_lines = []
+    for t in targets:
+        line = (
+            f"- lemma_form: {t.lemma_form}\n"
+            f"  pos: {t.pos}\n"
+            f"  gloss_en: {t.gloss_en}"
+        )
+        if t.cognate_form:
+            line += f"\n  ancient_cognate: {t.cognate_form}"
+        target_block_lines.append(line)
+    target_block = "\n".join(target_block_lines)
+    return f"""You are a {lang} philology assistant. For each lemma below,
+produce rich enrichment for an intermediate learner who is literate and
+curious — they care about etymology, semantic drift across eras, cross-language
+cognates, and how the word lives in literature.
+
+For each lemma, produce a structured JSON entry. Field guidance:
+
+ETYMOLOGY (1 object):
+- pie_root: the reconstructed Proto-Indo-European root with asterisk and gloss
+  in parentheses, e.g. "*ḱerd- (heart)". Null only if etymology is truly opaque
+  or non-IE (Pre-Greek substrate, Semitic loan, etc.).
+- ancient_form: the Ancient Greek citation form with full polytonic accents,
+  e.g. "ἄλογος", "λόγος", "καρδία". For Latin or Ancient Greek lemmas, this is
+  the parent/source form.
+- origin_note: 1-2 sentence prose explanation of the word's origin and any
+  notable morphological compounding. Write for a reader, not a database.
+- morphology: a structural breakdown if the word is transparently compound,
+  e.g. "ἀ- (negative) + λόγος (reason) → 'without reason'". Null for simple
+  roots.
+
+DIACHRONY (ordered list, ancient to modern):
+- 2-5 stages tracking meaning shift. Each stage: era (one of
+  Mycenaean / Homeric / Classical / Koine / Byzantine / Modern), form used at
+  that era (often the same form but with shifted sense), the meaning then, and
+  an optional one-line note for context.
+- Skip eras with no meaningful change — only include a stage when the meaning
+  or register shifts.
+
+COGNATES (list, 3-6 entries):
+- Cross-language relatives. Pick high-utility ones for an English speaker.
+- relation enum: "loanword-from-greek" (English took it from Greek),
+  "borrowed-via-latin" (Latin borrowed Greek, then English from Latin),
+  "shared-pie-root" (both languages inherit from PIE), "calque" (semantic
+  parallel, not cognate), "descendant" (Romance from Latin form of Greek).
+- gloss_en for non-English forms. Optional note for false-friend warnings or
+  semantic drift.
+
+QUOTES (list, 1-3 entries):
+- Short, ≤25 words each. Famous, surprising, or representative usages across
+  eras. Translations to English.
+- Source must be specific enough to locate: "Homer, Iliad 1.5", "Plato,
+  Republic 484a", "John 1:1", "Cavafy, Ithaca". Avoid bare attributions.
+- Skip if no good attestation exists.
+
+REGISTER (1 object):
+- formality: how the modern form sits today — "formal" / "neutral" /
+  "colloquial" / "literary". Null if unclear or evenly distributed.
+- collocations: 3-5 common modern collocations, with accents.
+- false_friends_en: English words that look or sound similar but mean
+  something different (false-friend trap). Empty list if none.
+- usage_note: 1 sentence on modern usage flavor — when a learner would (or
+  wouldn't) reach for this word vs. a synonym.
+
+VERSION: always 1.
+
+Style:
+- Greek text uses polytonic for Ancient/Koine/Byzantine, monotonic for Modern.
+- Translations in plain English, no scholarly markup. Be evocative but
+  precise — this surfaces in a learning UI, not a journal article.
+- Be honest about gaps. If you don't know a Mycenaean form, omit that stage.
+  If you don't know a PIE root, set pie_root to null.
+
+Lemmas:
+{target_block}
+"""
+
+
+def _gen_schema() -> dict:
+    era_enum = ["Mycenaean", "Homeric", "Classical", "Koine", "Byzantine", "Modern"]
+    relation_enum = [
+        "loanword-from-greek",
+        "shared-pie-root",
+        "calque",
+        "descendant",
+        "borrowed-via-latin",
+    ]
+    formality_enum = ["formal", "neutral", "colloquial", "literary"]
+    return {
+        "type": "object",
+        "properties": {
+            "lemmas": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "lemma_form": {"type": "string"},
+                        "enrichment": {
+                            "type": "object",
+                            "properties": {
+                                "version": {"type": "integer"},
+                                "etymology": {
+                                    "type": "object",
+                                    "properties": {
+                                        "pie_root": {"type": ["string", "null"]},
+                                        "ancient_form": {"type": ["string", "null"]},
+                                        "origin_note": {"type": "string"},
+                                        "morphology": {"type": ["string", "null"]},
+                                    },
+                                    "required": ["origin_note"],
+                                },
+                                "diachrony": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "era": {"type": "string", "enum": era_enum},
+                                            "form": {"type": "string"},
+                                            "meaning": {"type": "string"},
+                                            "note": {"type": ["string", "null"]},
+                                        },
+                                        "required": ["era", "form", "meaning"],
+                                    },
+                                },
+                                "cognates": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "language": {"type": "string"},
+                                            "form": {"type": "string"},
+                                            "relation": {
+                                                "type": "string",
+                                                "enum": relation_enum,
+                                            },
+                                            "gloss_en": {"type": ["string", "null"]},
+                                            "note": {"type": ["string", "null"]},
+                                        },
+                                        "required": ["language", "form", "relation"],
+                                    },
+                                },
+                                "quotes": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "text": {"type": "string"},
+                                            "source": {"type": "string"},
+                                            "era": {"type": "string", "enum": era_enum},
+                                            "translation_en": {"type": "string"},
+                                        },
+                                        "required": ["text", "source", "era", "translation_en"],
+                                    },
+                                },
+                                "register": {
+                                    "type": "object",
+                                    "properties": {
+                                        "formality": {
+                                            "type": ["string", "null"],
+                                            "enum": [*formality_enum, None],
+                                        },
+                                        "collocations": {
+                                            "type": "array",
+                                            "items": {"type": "string"},
+                                        },
+                                        "false_friends_en": {
+                                            "type": "array",
+                                            "items": {"type": "string"},
+                                        },
+                                        "usage_note": {"type": ["string", "null"]},
+                                    },
+                                },
+                            },
+                            "required": ["version", "diachrony", "cognates", "quotes"],
+                        },
+                    },
+                    "required": ["lemma_form", "enrichment"],
+                },
+            },
+        },
+        "required": ["lemmas"],
+    }
+
+
+# ─── CLI call ──────────────────────────────────────────────────────────────
+
+
+def _call_cli(cmd: list[str], timeout_s: int) -> Optional[dict]:
+    """Run ``claude -p --json-schema`` and return parsed ``structured_output``.
+
+    Mirrors ``material_generator._call_cli`` — same fallback to ``result`` if
+    structured_output is absent (some CLI builds). Returns ``None`` on any
+    failure (timeout, non-zero, parse error).
+    """
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout_s)
+    except subprocess.TimeoutExpired:
+        log.warning("Claude CLI timed out after %ds", timeout_s)
+        return None
+    if proc.returncode != 0:
+        log.warning("Claude CLI failed (exit %d): %s", proc.returncode, proc.stderr[:500])
+        return None
+    try:
+        wrapper = json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        log.warning("Could not parse CLI envelope JSON: %s", proc.stdout[:300])
+        return None
+    if not isinstance(wrapper, dict):
+        return None
+    structured = wrapper.get("structured_output")
+    if isinstance(structured, dict):
+        return structured
+    result_str = wrapper.get("result", "")
+    if not result_str:
+        return None
+    try:
+        parsed = json.loads(result_str)
+        return parsed if isinstance(parsed, dict) else None
+    except json.JSONDecodeError:
+        return None
+
+
+def _enrich_batch_call(
+    language_code: str,
+    targets: list[_EnrichTarget],
+) -> Optional[dict[str, LemmaEnrichment]]:
+    """One Sonnet call → ``{lemma_form: LemmaEnrichment}``.
+
+    Returns ``None`` on total LLM failure. Missing entries for individual
+    lemmas come back as absent keys (caller marks them failed).
+    """
+    if not targets:
+        return {}
+    prompt = _gen_prompt(language_code, targets)
+    cmd = [
+        "claude", "-p",
+        "--output-format", "json",
+        "--model", ENRICH_MODEL,
+        "--json-schema", json.dumps(_gen_schema()),
+        prompt,
+    ]
+    started = time.time()
+    structured = _call_cli(cmd, ENRICH_TIMEOUT_S)
+    elapsed = time.time() - started
+    if not structured:
+        _log_pipeline({
+            "event": "enrich_batch_failed",
+            "language_code": language_code,
+            "lemma_ids": [t.lemma_id for t in targets],
+            "elapsed_s": round(elapsed, 1),
+            "model": ENRICH_MODEL,
+        })
+        return None
+    parsed: dict[str, LemmaEnrichment] = {}
+    for item in structured.get("lemmas", []) or []:
+        if not isinstance(item, dict):
+            continue
+        form = item.get("lemma_form")
+        payload = item.get("enrichment")
+        if not isinstance(form, str) or not isinstance(payload, dict):
+            continue
+        try:
+            parsed[form] = LemmaEnrichment.model_validate(payload)
+        except Exception as e:
+            log.warning("Failed to validate enrichment for %s: %s", form, e)
+            continue
+    _log_pipeline({
+        "event": "enrich_batch_returned",
+        "language_code": language_code,
+        "lemma_ids": [t.lemma_id for t in targets],
+        "parsed_count": len(parsed),
+        "elapsed_s": round(elapsed, 1),
+        "model": ENRICH_MODEL,
+    })
+    return parsed
+
+
+# ─── Orchestration ─────────────────────────────────────────────────────────
+
+
+def _snapshot_targets(db: Session, language_code: str, lemma_ids: list[int]) -> tuple[list[_EnrichTarget], list[int]]:
+    """Return (eligible targets, skipped ids).
+
+    Skipped: glossless, variant, function_word, proper_name. The picker /
+    learner UI never surfaces these as standalone lemmas worth philologizing.
+    """
+    lemmas = (
+        db.query(Lemma)
+        .filter(Lemma.lemma_id.in_(lemma_ids))
+        .filter(Lemma.language_code == language_code)
+        .all()
+    )
+    targets: list[_EnrichTarget] = []
+    skipped: list[int] = []
+    by_id = {l.lemma_id: l for l in lemmas}
+    cognate_ids = [l.cognate_lemma_id for l in lemmas if l.cognate_lemma_id]
+    cognate_forms: dict[int, str] = {}
+    if cognate_ids:
+        for cog in db.query(Lemma).filter(Lemma.lemma_id.in_(cognate_ids)).all():
+            cognate_forms[cog.lemma_id] = cog.lemma_form
+
+    for lid in lemma_ids:
+        lemma = by_id.get(lid)
+        if lemma is None:
+            skipped.append(lid)
+            continue
+        if lemma.canonical_lemma_id is not None:
+            skipped.append(lid)
+            continue
+        if lemma.word_category in ("function_word", "proper_name"):
+            skipped.append(lid)
+            continue
+        if not (lemma.gloss_en or "").strip():
+            skipped.append(lid)
+            continue
+        cognate_form = cognate_forms.get(lemma.cognate_lemma_id) if lemma.cognate_lemma_id else None
+        targets.append(_EnrichTarget(
+            lemma_id=lemma.lemma_id,
+            lemma_form=lemma.lemma_form,
+            pos=lemma.pos or "",
+            gloss_en=lemma.gloss_en or "",
+            cognate_form=cognate_form,
+        ))
+    return targets, skipped
+
+
+def batch_enrich(
+    language_code: str,
+    lemma_ids: list[int],
+) -> dict:
+    """Enrich the given lemmas. Returns a summary dict:
+
+        {"enriched": int, "failed_lemma_ids": [...], "skipped_lemma_ids": [...]}
+
+    Internally splits ``lemma_ids`` into chunks of ``ENRICH_BATCH_SIZE`` and
+    issues one Sonnet call per chunk. Each chunk independently commits, so a
+    partial run still yields persisted enrichment for the successful chunks.
+    """
+    if not lemma_ids:
+        return {"enriched": 0, "failed_lemma_ids": [], "skipped_lemma_ids": []}
+
+    db = database.SessionLocal()
+    try:
+        targets, skipped = _snapshot_targets(db, language_code, lemma_ids)
+    finally:
+        db.close()
+
+    if not targets:
+        return {"enriched": 0, "failed_lemma_ids": [], "skipped_lemma_ids": skipped}
+
+    total_enriched = 0
+    failed: list[int] = []
+
+    for i in range(0, len(targets), ENRICH_BATCH_SIZE):
+        chunk = targets[i:i + ENRICH_BATCH_SIZE]
+        parsed = _enrich_batch_call(language_code, chunk)
+        if parsed is None:
+            # Total LLM failure for this chunk — mark all as failed and stamp
+            # status='failed' so the next cron can retry on a fresh run.
+            failed.extend(t.lemma_id for t in chunk)
+            _stamp_failure(language_code, [t.lemma_id for t in chunk])
+            continue
+
+        chunk_enriched, chunk_failed = _write_chunk(language_code, chunk, parsed)
+        total_enriched += chunk_enriched
+        failed.extend(chunk_failed)
+
+    _log_pipeline({
+        "event": "batch_enrich_done",
+        "language_code": language_code,
+        "requested": len(lemma_ids),
+        "eligible": len(targets),
+        "enriched": total_enriched,
+        "failed": len(failed),
+        "skipped": len(skipped),
+    })
+    return {
+        "enriched": total_enriched,
+        "failed_lemma_ids": failed,
+        "skipped_lemma_ids": skipped,
+    }
+
+
+def _write_chunk(
+    language_code: str,
+    chunk: list[_EnrichTarget],
+    parsed: dict[str, LemmaEnrichment],
+) -> tuple[int, list[int]]:
+    """Persist parsed enrichments for one chunk. Returns (enriched, failed_ids).
+
+    Phase 3 of the read/LLM/write pattern. Single commit per chunk.
+    """
+    now = datetime.now(timezone.utc)
+    enriched = 0
+    failed: list[int] = []
+    db = database.SessionLocal()
+    try:
+        for target in chunk:
+            payload = parsed.get(target.lemma_form)
+            lemma = db.query(Lemma).filter(Lemma.lemma_id == target.lemma_id).first()
+            if lemma is None:
+                failed.append(target.lemma_id)
+                continue
+            if payload is None:
+                lemma.enrichment_status = "failed"
+                failed.append(target.lemma_id)
+                continue
+            lemma.enrichment_json = payload.model_dump(mode="json")
+            lemma.enrichment_status = "done"
+            lemma.enriched_at = now
+            enriched += 1
+        db.commit()
+    except Exception:
+        db.rollback()
+        log.exception("Failed to commit enrichments (language=%s)", language_code)
+        failed = [t.lemma_id for t in chunk]
+        enriched = 0
+    finally:
+        db.close()
+    return enriched, failed
+
+
+def _stamp_failure(language_code: str, lemma_ids: list[int]) -> None:
+    """Stamp enrichment_status='failed' on lemmas whose chunk's LLM call failed
+    entirely. The next cron pass can retry by filtering on this status."""
+    if not lemma_ids:
+        return
+    db = database.SessionLocal()
+    try:
+        for lemma in db.query(Lemma).filter(Lemma.lemma_id.in_(lemma_ids)).all():
+            lemma.enrichment_status = "failed"
+        db.commit()
+    except Exception:
+        db.rollback()
+        log.exception("Failed to stamp enrichment failure (language=%s)", language_code)
+    finally:
+        db.close()
+
+
+def find_unenriched_lemmas(
+    language_code: str = "el",
+    limit: int = 10,
+    include_failed: bool = False,
+) -> list[int]:
+    """Return lemma_ids that still need enrichment.
+
+    Selection criteria mirror the philology service's own eligibility:
+    canonical, not function-word/proper-name, has a gloss. Among eligible
+    lemmas, prefer those with a UserLemmaKnowledge row (the learner has
+    actually engaged with them) — no point philologizing words no one studies.
+    Order: by frequency_rank when present (so the most common words enrich
+    first), then lemma_id.
+    """
+    from sqlalchemy import or_
+    from app.models import UserLemmaKnowledge
+
+    db = database.SessionLocal()
+    try:
+        status_filter = Lemma.enrichment_status.is_(None)
+        if include_failed:
+            status_filter = or_(status_filter, Lemma.enrichment_status == "failed")
+        rows = (
+            db.query(Lemma.lemma_id, Lemma.frequency_rank)
+            .join(UserLemmaKnowledge, UserLemmaKnowledge.lemma_id == Lemma.lemma_id)
+            .filter(
+                Lemma.language_code == language_code,
+                Lemma.canonical_lemma_id.is_(None),
+                (Lemma.word_category.is_(None) | Lemma.word_category.notin_(
+                    ["function_word", "proper_name"]
+                )),
+                Lemma.gloss_en.isnot(None),
+                status_filter,
+            )
+            .all()
+        )
+    finally:
+        db.close()
+    rows.sort(key=lambda r: (r[1] is None, r[1] or 0, r[0]))
+    return [r[0] for r in rows[:limit]]

--- a/polyglot/scripts/enrich_lemma_philology.py
+++ b/polyglot/scripts/enrich_lemma_philology.py
@@ -1,0 +1,68 @@
+"""Run one philology-enrichment pass for the configured language.
+
+Standalone wrapper around ``lemma_philology.batch_enrich`` so the cron job
+can call a Python script directly without going through the HTTP endpoint.
+Exits 0 on success (including "nothing to enrich"), 1 on hard failure.
+
+Usage:
+
+    .venv/bin/python scripts/enrich_lemma_philology.py --language el --max-lemmas 10
+    .venv/bin/python scripts/enrich_lemma_philology.py --lemma-ids 1245 1247
+
+By default, picks up to ``--max-lemmas`` un-enriched lemmas from the engaged-
+vocabulary pool (those with a UserLemmaKnowledge row), ranked by frequency
+rank ascending. Lemmas without ULK rows are skipped — no point philologizing
+words the learner has never touched.
+
+Env vars:
+
+    POLYGLOT_ENRICH_MODEL                  Claude model (default: sonnet)
+    POLYGLOT_ENRICH_TIMEOUT                CLI timeout in seconds (default: 240)
+    POLYGLOT_ENRICH_BATCH_SIZE             lemmas per Sonnet call (default: 4)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+
+from app.services.lemma_philology import batch_enrich, find_unenriched_lemmas
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Enrich polyglot lemmas with philological data.")
+    parser.add_argument("--language", default="el", help="Language code (el/grc/la). Default: el")
+    parser.add_argument("--max-lemmas", type=int, default=10,
+                        help="Max lemmas to enrich per pass. Default: 10")
+    parser.add_argument("--lemma-ids", type=int, nargs="*", default=None,
+                        help="Enrich exactly these lemma IDs (overrides --max-lemmas).")
+    parser.add_argument("--include-failed", action="store_true",
+                        help="Also pick lemmas whose previous enrichment failed.")
+    parser.add_argument("--verbose", "-v", action="store_true")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+
+    if args.lemma_ids:
+        ids = args.lemma_ids
+    else:
+        ids = find_unenriched_lemmas(
+            language_code=args.language,
+            limit=args.max_lemmas,
+            include_failed=args.include_failed,
+        )
+    if not ids:
+        print(json.dumps({"enriched": 0, "failed_lemma_ids": [], "skipped_lemma_ids": []}))
+        return 0
+
+    result = batch_enrich(language_code=args.language, lemma_ids=ids)
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/polyglot/tests/test_lemma_philology.py
+++ b/polyglot/tests/test_lemma_philology.py
@@ -1,0 +1,251 @@
+"""Tests for ``lemma_philology.batch_enrich``.
+
+Strategy mirrors ``test_material_generator.py``: patch the module-level
+``subprocess.run`` so tests run offline with canned Claude responses.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+import pytest
+
+from app.models import Lemma, UserLemmaKnowledge
+from app.services import lemma_philology as lp
+
+
+@dataclass
+class _FakeProc:
+    stdout: str
+    stderr: str = ""
+    returncode: int = 0
+
+
+def _envelope(structured: dict) -> str:
+    return json.dumps({"structured_output": structured, "result": ""})
+
+
+def _seed_lemma(db, *, form: str, gloss: str = "x", pos: str = "noun",
+                cognate_id: int | None = None,
+                canonical: int | None = None,
+                word_category: str | None = None) -> Lemma:
+    lemma = Lemma(
+        language_code="el",
+        lemma_form=form,
+        lemma_bare=form,
+        gloss_en=gloss,
+        pos=pos,
+        source="test",
+        cognate_lemma_id=cognate_id,
+        canonical_lemma_id=canonical,
+        word_category=word_category,
+    )
+    db.add(lemma)
+    db.flush()
+    return lemma
+
+
+def _seed_ulk(db, lemma_id: int) -> UserLemmaKnowledge:
+    ulk = UserLemmaKnowledge(
+        lemma_id=lemma_id,
+        knowledge_state="acquiring",
+        acquisition_box=1,
+        acquisition_next_due=datetime.now(timezone.utc),
+    )
+    db.add(ulk)
+    db.flush()
+    return ulk
+
+
+@pytest.fixture
+def fake_claude(monkeypatch):
+    state = {"script": [], "calls": []}
+
+    def fake_run(cmd, capture_output=False, text=False, timeout=None):
+        state["calls"].append(cmd)
+        if not state["script"]:
+            raise AssertionError("Unexpected extra Claude call")
+        return state["script"].pop(0)
+
+    monkeypatch.setattr(lp.subprocess, "run", fake_run)
+    return state
+
+
+# Minimal canonical enrichment payload that matches the JSON schema and the
+# Pydantic model. Used as the fake Claude response in happy-path tests.
+def _good_payload(form: str) -> dict:
+    return {
+        "version": 1,
+        "etymology": {
+            "pie_root": "*ḱerd- (heart)",
+            "ancient_form": "καρδία",
+            "origin_note": f"Origin note for {form}.",
+            "morphology": None,
+        },
+        "diachrony": [
+            {"era": "Classical", "form": form, "meaning": "heart", "note": None},
+            {"era": "Modern", "form": form, "meaning": "heart", "note": None},
+        ],
+        "cognates": [
+            {"language": "English", "form": "heart", "relation": "shared-pie-root",
+             "gloss_en": None, "note": None},
+        ],
+        "quotes": [
+            {"text": "καρδίας μου", "source": "Test source", "era": "Classical",
+             "translation_en": "my heart"},
+        ],
+        "register": {
+            "formality": "neutral",
+            "collocations": ["κ μ"],
+            "false_friends_en": [],
+            "usage_note": None,
+        },
+    }
+
+
+def test_batch_enrich_happy_path(tmp_db, fake_claude):
+    """One lemma, one valid enrichment → row written with status=done."""
+    with tmp_db() as db:
+        lemma = _seed_lemma(db, form="καρδιά", gloss="heart")
+        db.commit()
+        lemma_id = lemma.lemma_id
+
+    fake_claude["script"].append(_FakeProc(stdout=_envelope({
+        "lemmas": [{"lemma_form": "καρδιά", "enrichment": _good_payload("καρδιά")}],
+    })))
+
+    result = lp.batch_enrich(language_code="el", lemma_ids=[lemma_id])
+
+    assert result["enriched"] == 1
+    assert result["failed_lemma_ids"] == []
+    assert result["skipped_lemma_ids"] == []
+    assert len(fake_claude["calls"]) == 1
+
+    with tmp_db() as db:
+        lemma = db.query(Lemma).filter(Lemma.lemma_id == lemma_id).first()
+        assert lemma.enrichment_status == "done"
+        assert lemma.enrichment_json is not None
+        assert lemma.enrichment_json["etymology"]["origin_note"].startswith("Origin note")
+        assert lemma.enriched_at is not None
+
+
+def test_glossless_lemma_is_skipped(tmp_db, fake_claude):
+    """Lemmas without a gloss never reach the LLM call."""
+    with tmp_db() as db:
+        lemma = _seed_lemma(db, form="ξξ", gloss="")
+        db.commit()
+        lemma_id = lemma.lemma_id
+
+    result = lp.batch_enrich(language_code="el", lemma_ids=[lemma_id])
+
+    assert result["enriched"] == 0
+    assert lemma_id in result["skipped_lemma_ids"]
+    assert len(fake_claude["calls"]) == 0  # never called the LLM
+
+
+def test_variant_lemma_is_skipped(tmp_db, fake_claude):
+    """Variant lemmas (canonical_lemma_id set) inherit their canonical's
+    enrichment rather than getting their own."""
+    with tmp_db() as db:
+        canonical = _seed_lemma(db, form="γέροντας", gloss="old man")
+        db.commit()
+        variant = _seed_lemma(db, form="γερων", gloss="old man",
+                              canonical=canonical.lemma_id)
+        db.commit()
+        variant_id = variant.lemma_id
+
+    result = lp.batch_enrich(language_code="el", lemma_ids=[variant_id])
+
+    assert result["enriched"] == 0
+    assert variant_id in result["skipped_lemma_ids"]
+    assert len(fake_claude["calls"]) == 0
+
+
+def test_function_word_is_skipped(tmp_db, fake_claude):
+    with tmp_db() as db:
+        lemma = _seed_lemma(db, form="το", gloss="the",
+                            word_category="function_word")
+        db.commit()
+        lemma_id = lemma.lemma_id
+
+    result = lp.batch_enrich(language_code="el", lemma_ids=[lemma_id])
+
+    assert result["enriched"] == 0
+    assert lemma_id in result["skipped_lemma_ids"]
+    assert len(fake_claude["calls"]) == 0
+
+
+def test_llm_failure_stamps_status_failed(tmp_db, fake_claude):
+    """Total LLM failure (non-zero exit) → enrichment_status='failed', no JSON."""
+    with tmp_db() as db:
+        lemma = _seed_lemma(db, form="καρδιά", gloss="heart")
+        db.commit()
+        lemma_id = lemma.lemma_id
+
+    fake_claude["script"].append(_FakeProc(stdout="", stderr="boom", returncode=1))
+
+    result = lp.batch_enrich(language_code="el", lemma_ids=[lemma_id])
+
+    assert result["enriched"] == 0
+    assert lemma_id in result["failed_lemma_ids"]
+
+    with tmp_db() as db:
+        lemma = db.query(Lemma).filter(Lemma.lemma_id == lemma_id).first()
+        assert lemma.enrichment_status == "failed"
+        assert lemma.enrichment_json is None
+
+
+def test_partial_response_marks_missing_as_failed(tmp_db, fake_claude):
+    """Two lemmas requested, only one returned → other lands in failed list
+    and gets status='failed'."""
+    with tmp_db() as db:
+        a = _seed_lemma(db, form="καρδιά", gloss="heart")
+        b = _seed_lemma(db, form="λόγος", gloss="word")
+        db.commit()
+        ids = [a.lemma_id, b.lemma_id]
+
+    fake_claude["script"].append(_FakeProc(stdout=_envelope({
+        "lemmas": [{"lemma_form": "καρδιά", "enrichment": _good_payload("καρδιά")}],
+    })))
+
+    result = lp.batch_enrich(language_code="el", lemma_ids=ids)
+
+    assert result["enriched"] == 1
+    assert ids[1] in result["failed_lemma_ids"]
+
+
+def test_find_unenriched_picks_engaged_vocabulary(tmp_db, monkeypatch):
+    """find_unenriched_lemmas should only return lemmas with a ULK row."""
+    with tmp_db() as db:
+        engaged = _seed_lemma(db, form="καρδιά", gloss="heart")
+        # No ULK for this one — should be skipped
+        _seed_lemma(db, form="λόγος", gloss="word")
+        db.commit()
+        _seed_ulk(db, engaged.lemma_id)
+        db.commit()
+        engaged_id = engaged.lemma_id
+
+    ids = lp.find_unenriched_lemmas(language_code="el", limit=10)
+    assert ids == [engaged_id]
+
+
+def test_fixture_round_trip_matches_pydantic_shape():
+    """The real-world enrichment fixture from the POC must parse cleanly into
+    LemmaEnrichment. Guard against silent drift between the prompt's JSON
+    schema and the Pydantic model."""
+    from pathlib import Path
+    from app.schemas import LemmaEnrichment
+
+    fixture = Path(__file__).resolve().parents[2] / "artifacts" / "polyglot-enrichment-poc" / "enrichment.json"
+    if not fixture.exists():
+        pytest.skip("Fixture not present; run artifacts/polyglot-enrichment-poc/build_prompt.py")
+    data = json.loads(fixture.read_text())
+    for item in data["lemmas"]:
+        e = LemmaEnrichment.model_validate(item["enrichment"])
+        assert e.etymology is not None
+        assert e.etymology.origin_note
+        assert len(e.diachrony) > 0
+        assert len(e.cognates) > 0
+        # version must be 1
+        assert e.version == 1


### PR DESCRIPTION
## Summary
- **Backend (commit 1):** Pydantic `LemmaEnrichment` schema, three new `Lemma` columns (`enrichment_json`, `enrichment_status`, `enriched_at`), Claude Sonnet philology service following the read/LLM/write three-phase pattern, `/api/materials/enrich-philology` endpoint, `/api/lemmas/{id}/detail` full-payload endpoint, and `scripts/enrich_lemma_philology.py` CLI runner for cron.
- **Frontend (commit 2):** New `polyglot-lemma/[id].tsx` Modern Editorial detail screen, new shared `polyglot-lookup-card.tsx` (middle-density), new `polyglot-design-tokens.ts` + `polyglot-design-colors.ts` (single source of truth for palette + era colors). Reader and review screens rebuilt: palette swapped to Modern Editorial, IntroCardView redesigned with hero + chips + optional etymology / mini-drift / quote sections, GlossLine replaced with the lookup card on word-tap. Shape parity between Pydantic and TS guarded by a Jest test that loads a real Sonnet-emitted fixture.

## Design source
Locked in the 2026-05-21 design-explorer round 2: "Detail iPhone · Modern Editorial" (3-era case) + "Editorial w/ λόγος" (5-era case) + "Teach iPhone · Refined Alif Stack" (the intro card mockup variant).

## What's NOT in this PR (separate concerns)
- Picker change for LLM-first sentence preference + page-sentence cooldown
- Running enrichment cron in prod / generating real enrichment data for live lemmas
- Restyling the story-list screen