### PR TITLE
Polyglot: picker LLM-first + page-sentence cooldown, enrichment in cron

### DIFF
--- a/polyglot/app/services/sentence_selector.py
+++ b/polyglot/app/services/sentence_selector.py
@@ -26,17 +26,24 @@ The three gates the picker DOES honor (Hard Invariants from
   content lemmas. ``FUNCTION_WORD_SETS[language_code]`` and
   ``Lemma.word_category in ('function_word', 'proper_name')`` both exclude.
 
-Source preference (per 2026-05-20 spec):
+Source preference (per 2026-05-21 spec — flipped from the 2026-05-20 original):
 
-1. **Page-first, all-known**: a textbook page sentence (``Sentence.page_id IS
-   NOT NULL``) whose every content scaffold lemma is already known →
-   ``known`` or ``learning`` state. Zero-friction: the user has already read
-   that page.
-2. **Any harvested sentence**, ranked by comprehensibility × source bonus.
-   Lower-comprehensibility sentences still rank above nothing — the learner
-   benefits from collateral scaffold even when not every word is known.
-3. **None**, when no eligible sentence covers the lemma. Caller should fall
-   back to generation (PR #4) or skip the lemma for this session.
+1. **Fresh LLM sentence preferred**. A novel context proves the word stuck;
+   re-showing the page-of-record right after the learner read it on the page
+   is zero-friction recall, which is exactly what we DON'T want at review
+   time. Source bonus puts ``llm`` above ``textbook``/``story``/``import``.
+2. **Recently-viewed page sentences are softly penalised**. If a candidate
+   sentence's page was viewed within ``PAGE_COOLDOWN_DAYS`` (7) days,
+   its score is multiplied by ``RECENT_PAGE_PENALTY`` (0.2). It still ranks
+   above nothing — we'd rather show a stale page sentence than skip the lemma
+   for the session if no LLM sentence covers it yet (graceful fallback during
+   the lag between tapping unknown and the cron generating).
+3. **Never-shown sentences win tie-breakers**. Within a single score class,
+   prefer sentences with the lowest ``times_shown`` count; among equal
+   ``times_shown``, prefer the most recently created (newer LLM material
+   beats older).
+4. **None**, when no eligible sentence covers the lemma at all. Caller
+   defers to generation or skips the lemma.
 """
 from __future__ import annotations
 
@@ -47,7 +54,7 @@ from typing import Optional
 
 from sqlalchemy.orm import Session, joinedload
 
-from app.models import Lemma, Sentence, SentenceWord, UserLemmaKnowledge, Language
+from app.models import Lemma, Page, Sentence, SentenceWord, UserLemmaKnowledge, Language
 from app.services.canonical_resolution import resolve_canonical_lemma_id
 from app.services.fsrs_service import parse_json_column
 from app.services.lemma_quality import FUNCTION_WORD_SETS
@@ -58,15 +65,25 @@ logger = logging.getLogger(__name__)
 KNOWN_STATES = frozenset({"known", "learning"})
 DEFAULT_SESSION_LIMIT = 15
 
-PAGE_FIRST_BONUS = 3.0
 SOURCE_BONUS = {
-    "textbook": 1.4,
-    "story": 1.2,
-    "import": 1.2,
+    # 2026-05-21: LLM now outranks textbook/story/import. The picker is run at
+    # *review* time, when the goal is to test recall in a novel context — not
+    # to re-show the page-of-record the learner just finished reading.
+    "llm": 1.5,
+    "textbook": 1.0,
+    "story": 1.0,
+    "import": 1.0,
     "manual": 1.0,
-    "llm": 1.0,
 }
 DEFAULT_SOURCE_BONUS = 1.0
+
+# Soft penalty applied when a candidate sentence's page was viewed within the
+# cooldown window. Multiplicative: a strong (~0.2) penalty drops the page
+# sentence below any sane LLM/manual alternative, but keeps it as a fallback
+# in case no novel material exists yet (e.g. tapped-unknown words whose
+# enrichment cron hasn't run). Set to 1.0 to disable.
+PAGE_COOLDOWN_DAYS = 7
+RECENT_PAGE_PENALTY = 0.2
 
 
 @dataclass
@@ -138,8 +155,9 @@ class _Scored:
     comprehensibility: float
     scaffold_total: int
     scaffold_known: int
-    page_first: bool
+    page_first: bool                    # retained for back-compat / introspection
     selection_reason: str
+    times_shown: int = 0                # for tie-break: prefer never-shown
 
 
 # Intro card constants — ported from Alif. The dynamic-cap heuristic and
@@ -207,6 +225,8 @@ def pick_sentence_for_lemma(
         ):
             ulks_by_lemma[ulk.lemma_id] = ulk
 
+    recent_page_view_ids = _load_recent_page_view_ids(db, candidates)
+
     scored: list[_Scored] = []
     for sent in candidates:
         result = _score_candidate(
@@ -215,6 +235,7 @@ def pick_sentence_for_lemma(
             lemmas_by_id=lemmas_by_id,
             ulks_by_lemma=ulks_by_lemma,
             function_words=function_words,
+            recent_page_view_ids=recent_page_view_ids,
         )
         if result is not None:
             scored.append(result)
@@ -222,8 +243,12 @@ def pick_sentence_for_lemma(
     if not scored:
         return None
 
+    # Sort by score (desc), then prefer never-shown sentences (smaller
+    # times_shown), then newer-created (larger id ≈ newer in practice for the
+    # polyglot DB since ids are autoincrement). Reverse turns "smaller
+    # times_shown wins" into the right order by negating.
     scored.sort(
-        key=lambda c: (c.score, c.scaffold_total, -c.sentence.id),
+        key=lambda c: (c.score, -c.times_shown, c.sentence.id),
         reverse=True,
     )
     best = scored[0]
@@ -236,12 +261,53 @@ def pick_sentence_for_lemma(
     )
 
 
+def _load_recent_page_view_ids(db: Session, candidates: list[Sentence]) -> set[int]:
+    """Return the set of ``Page.id`` values whose ``viewed_at`` is within the
+    cooldown window. Pages whose ``viewed_at IS NULL`` aren't returned (the
+    learner hasn't read them yet, so no cooldown).
+
+    Batched to one query covering every candidate's page_id rather than a
+    per-candidate Page lookup. Returns an empty set when no candidates have
+    a page_id at all.
+    """
+    page_ids = {s.page_id for s in candidates if s.page_id is not None}
+    if not page_ids:
+        return set()
+    cutoff = datetime.now(timezone.utc) - timedelta(days=PAGE_COOLDOWN_DAYS)
+    rows = (
+        db.query(Page.id)
+        .filter(Page.id.in_(page_ids), Page.viewed_at.isnot(None))
+        .all()
+    )
+    # SQLite stores datetimes as naive strings — re-fetch viewed_at and
+    # compare in Python so the timezone story matches the rest of the codebase
+    # (see CLAUDE.md "SQLite naive datetime pitfall"). One extra round-trip
+    # but avoids cross-DB datetime semantics.
+    if not rows:
+        return set()
+    detailed = (
+        db.query(Page.id, Page.viewed_at)
+        .filter(Page.id.in_({r[0] for r in rows}))
+        .all()
+    )
+    recent: set[int] = set()
+    for page_id, viewed_at in detailed:
+        if viewed_at is None:
+            continue
+        if viewed_at.tzinfo is None:
+            viewed_at = viewed_at.replace(tzinfo=timezone.utc)
+        if viewed_at >= cutoff:
+            recent.add(page_id)
+    return recent
+
+
 def _score_candidate(
     sentence: Sentence,
     target_canonical_id: int,
     lemmas_by_id: dict[int, Lemma],
     ulks_by_lemma: dict[int, UserLemmaKnowledge],
     function_words: set,
+    recent_page_view_ids: Optional[set[int]] = None,
 ) -> Optional[_Scored]:
     has_target = False
     scaffold_total = 0
@@ -278,12 +344,28 @@ def _score_candidate(
 
     base = 0.3 + 0.7 * comprehensibility
     source_bonus = SOURCE_BONUS.get(sentence.source or "", DEFAULT_SOURCE_BONUS)
+
+    # Page cooldown — a page sentence whose page was viewed within the last
+    # PAGE_COOLDOWN_DAYS gets a strong multiplicative penalty so any fresh LLM
+    # alternative outranks it. Pages never viewed (viewed_at IS NULL) and
+    # pages viewed long ago receive no penalty.
+    recent_pages = recent_page_view_ids or set()
+    page_recently_viewed = (
+        sentence.page_id is not None and sentence.page_id in recent_pages
+    )
+    cooldown_bonus = RECENT_PAGE_PENALTY if page_recently_viewed else 1.0
+
+    # `page_first` is retained for back-compat (selection_reason + dataclass
+    # field) but no longer feeds the score. The new ranking is LLM-first.
     page_first = sentence.page_id is not None and all_known
-    page_bonus = PAGE_FIRST_BONUS if page_first else 1.0
 
-    score = base * source_bonus * page_bonus
+    score = base * source_bonus * cooldown_bonus
 
-    if page_first:
+    if page_recently_viewed:
+        reason = "page_cooldown_fallback"
+    elif sentence.source == "llm":
+        reason = "llm_fresh" if all_known else "llm_partial_scaffold"
+    elif page_first:
         reason = "page_first_all_known"
     elif all_known:
         reason = "all_scaffold_known"
@@ -300,6 +382,7 @@ def _score_candidate(
         scaffold_known=scaffold_known,
         page_first=page_first,
         selection_reason=reason,
+        times_shown=sentence.times_shown or 0,
     )
 
 

--- a/polyglot/deploy/polyglot-update-material.sh
+++ b/polyglot/deploy/polyglot-update-material.sh
@@ -16,6 +16,10 @@
 #   2. warm_sentence_cache for Modern Greek
 #      — finds acquiring/learning/known lemmas below ACTIVE_TARGET sentence
 #        coverage and generates more via Claude CLI (Sonnet) + Haiku verify.
+#   3. enrich_lemma_philology for Modern Greek
+#      — fills LemmaEnrichment (etymology, diachrony, cognates, quotes,
+#        register) for engaged lemmas. Surfaced in the lookup card + lemma
+#        detail screen (Modern Editorial design).
 #
 # Future passes (deferred — no harvest-side fixes needed yet):
 #   - rotate_stale_sentences (when pipeline tiers land)
@@ -41,6 +45,12 @@ TIMEOUT_SECONDS="${POLYGLOT_WARM_TIMEOUT_SECONDS:-1200}"
 PAGES_BUFFER="${POLYGLOT_PAGES_AHEAD_BUFFER:-5}"
 PAGES_MAX_PER_RUN="${POLYGLOT_PAGES_AHEAD_MAX_PER_RUN:-5}"
 PAGES_TIMEOUT_SECONDS="${POLYGLOT_PAGES_AHEAD_TIMEOUT_SECONDS:-1200}"
+# 2026-05-21: third phase enriches lemmas with philological data (etymology,
+# diachrony, cognates, quotes, register). Per-run cap kept conservative so a
+# bad batch doesn't blow the whole Claude budget; cron runs every 3h so 10
+# lemmas/run = ~80 lemmas/day, enough to cover engaged vocabulary in a week.
+ENRICH_MAX_LEMMAS="${POLYGLOT_ENRICH_MAX_LEMMAS:-10}"
+ENRICH_TIMEOUT_SECONDS="${POLYGLOT_ENRICH_TIMEOUT_SECONDS:-1800}"
 
 export PYTHONUNBUFFERED=1
 # Belt-and-suspenders: explicitly point at polyglot's DB so the cron run
@@ -78,6 +88,11 @@ run_phase "warm_sentence_cache" timeout "$TIMEOUT_SECONDS" \
   --language "$LANGUAGE" \
   --max-lemmas "$MAX_LEMMAS" \
   --sentences-per-target "$SENTENCES_PER_TARGET"
+
+run_phase "enrich_lemma_philology" timeout "$ENRICH_TIMEOUT_SECONDS" \
+  "$VENV" scripts/enrich_lemma_philology.py \
+  --language "$LANGUAGE" \
+  --max-lemmas "$ENRICH_MAX_LEMMAS"
 
 echo "[$TIMESTAMP] Polyglot material cron done" >> "$LOG"
 echo "---" >> "$LOG"

--- a/polyglot/tests/test_sentence_selector.py
+++ b/polyglot/tests/test_sentence_selector.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 
+import pytest
 from fastapi.testclient import TestClient
 
 from app.database import get_db
@@ -64,6 +65,7 @@ def _seed_sentence(
     is_active: bool = True,
     source: str = "textbook",
     page_id: int | None = None,
+    times_shown: int = 0,
 ) -> Sentence:
     sentence = Sentence(
         language_code=language_code,
@@ -73,6 +75,7 @@ def _seed_sentence(
         sentence_index_in_page=0 if page_id else None,
         is_active=is_active,
         mappings_verified_at=datetime.now(timezone.utc) if verified else None,
+        times_shown=times_shown,
     )
     db.add(sentence)
     db.flush()
@@ -87,13 +90,17 @@ def _seed_sentence(
     return sentence
 
 
-def _seed_page(db, *, story_id: int, page_number: int = 1) -> Page:
+def _seed_page(
+    db, *, story_id: int, page_number: int = 1,
+    viewed_at: datetime | None = None,
+) -> Page:
     page = Page(
         story_id=story_id,
         page_number=page_number,
         body_src="dummy",
         processed_at=datetime.now(timezone.utc),
         mappings_verified_at=datetime.now(timezone.utc),
+        viewed_at=viewed_at,
     )
     db.add(page)
     db.flush()
@@ -201,7 +208,11 @@ def test_exclude_sentence_ids_skipped(tmp_db):
         assert result.sentence_id == b.id
 
 
-def test_page_first_all_known_ranks_above_other_sources(tmp_db):
+def test_llm_outranks_textbook_at_equal_comprehensibility(tmp_db):
+    """2026-05-21 picker change: LLM source bonus > textbook source bonus, and
+    PAGE_FIRST_BONUS is retired. At equal all-known comprehensibility, the
+    fresh LLM sentence beats the page sentence — review wants novel context.
+    """
     with tmp_db() as db:
         target = _seed_lemma(db, form="λόγος")
         scaffold = _seed_lemma(db, form="ο")
@@ -210,14 +221,12 @@ def test_page_first_all_known_ranks_above_other_sources(tmp_db):
         story = _seed_story(db)
         page = _seed_page(db, story_id=story.id)
 
-        # Non-page LLM sentence with same all-known scaffold
         llm_sent = _seed_sentence(
             db,
             lemma_surfaces=[(scaffold.lemma_id, "ο"), (target.lemma_id, "λόγος")],
             text="ο λόγος (llm)",
             source="llm",
         )
-        # Page sentence with same all-known scaffold — should win
         page_sent = _seed_sentence(
             db,
             lemma_surfaces=[(scaffold.lemma_id, "ο"), (target.lemma_id, "λόγος")],
@@ -229,8 +238,10 @@ def test_page_first_all_known_ranks_above_other_sources(tmp_db):
 
         result = pick_sentence_for_lemma(db, lemma_id=target.lemma_id, language_code="el")
         assert result is not None
-        assert result.sentence_id == page_sent.id
-        assert result.selection_reason == "page_first_all_known"
+        assert result.sentence_id == llm_sent.id
+        assert result.selection_reason == "llm_fresh"
+        # Page sentence still exists as a fallback — not deleted from DB.
+        assert db.query(Sentence).filter(Sentence.id == page_sent.id).first() is not None
 
 
 def test_page_first_unknown_scaffold_falls_back_to_other_source(tmp_db):
@@ -523,3 +534,157 @@ def test_endpoint_session_unknown_language(tmp_db):
         assert resp.status_code == 400
     finally:
         app.dependency_overrides.clear()
+
+
+# ─── 2026-05-21 picker change: LLM-first + page cooldown ─────────────────────
+
+
+def test_recently_viewed_page_sentence_is_penalised(tmp_db):
+    """A page sentence whose page was viewed within PAGE_COOLDOWN_DAYS is
+    softly penalised. With no LLM alternative, it still wins (graceful
+    fallback) — but its score reflects the penalty."""
+    from app.services.sentence_selector import RECENT_PAGE_PENALTY
+
+    with tmp_db() as db:
+        target = _seed_lemma(db, form="λόγος")
+        scaffold = _seed_lemma(db, form="ο")
+        _seed_known(db, scaffold.lemma_id, state="known")
+
+        story = _seed_story(db)
+        recent_page = _seed_page(
+            db, story_id=story.id,
+            viewed_at=datetime.now(timezone.utc) - timedelta(days=1),
+        )
+        page_sent = _seed_sentence(
+            db,
+            lemma_surfaces=[(scaffold.lemma_id, "ο"), (target.lemma_id, "λόγος")],
+            text="ο λόγος",
+            source="textbook",
+            page_id=recent_page.id,
+        )
+        db.commit()
+
+        result = pick_sentence_for_lemma(db, lemma_id=target.lemma_id, language_code="el")
+        assert result is not None
+        assert result.sentence_id == page_sent.id  # only candidate
+        assert result.selection_reason == "page_cooldown_fallback"
+        # base = 1.0 * source_bonus (1.0 for textbook) * penalty
+        assert result.score == pytest.approx(1.0 * 1.0 * RECENT_PAGE_PENALTY)
+
+
+def test_fresh_llm_beats_recently_viewed_page(tmp_db):
+    """Two candidates: recently-viewed page sentence + fresh LLM sentence,
+    both fully comprehensible. The LLM wins decisively because the page is
+    in cooldown AND has the lower source bonus."""
+    with tmp_db() as db:
+        target = _seed_lemma(db, form="λόγος")
+        scaffold = _seed_lemma(db, form="ο")
+        _seed_known(db, scaffold.lemma_id, state="known")
+
+        story = _seed_story(db)
+        recent_page = _seed_page(
+            db, story_id=story.id,
+            viewed_at=datetime.now(timezone.utc) - timedelta(days=2),
+        )
+        page_sent = _seed_sentence(
+            db,
+            lemma_surfaces=[(scaffold.lemma_id, "ο"), (target.lemma_id, "λόγος")],
+            text="ο λόγος (page)",
+            source="textbook",
+            page_id=recent_page.id,
+        )
+        llm_sent = _seed_sentence(
+            db,
+            lemma_surfaces=[(scaffold.lemma_id, "ο"), (target.lemma_id, "λόγος")],
+            text="ο λόγος (llm)",
+            source="llm",
+        )
+        db.commit()
+
+        result = pick_sentence_for_lemma(db, lemma_id=target.lemma_id, language_code="el")
+        assert result is not None
+        assert result.sentence_id == llm_sent.id
+        assert result.selection_reason == "llm_fresh"
+
+
+def test_old_page_view_no_longer_penalised(tmp_db):
+    """A page viewed >7 days ago drops out of the cooldown set and scores
+    like an ordinary textbook sentence — no penalty."""
+    with tmp_db() as db:
+        target = _seed_lemma(db, form="λόγος")
+        scaffold = _seed_lemma(db, form="ο")
+        _seed_known(db, scaffold.lemma_id, state="known")
+
+        story = _seed_story(db)
+        old_page = _seed_page(
+            db, story_id=story.id,
+            viewed_at=datetime.now(timezone.utc) - timedelta(days=30),
+        )
+        page_sent = _seed_sentence(
+            db,
+            lemma_surfaces=[(scaffold.lemma_id, "ο"), (target.lemma_id, "λόγος")],
+            text="ο λόγος",
+            source="textbook",
+            page_id=old_page.id,
+        )
+        db.commit()
+
+        result = pick_sentence_for_lemma(db, lemma_id=target.lemma_id, language_code="el")
+        assert result is not None
+        assert result.selection_reason != "page_cooldown_fallback"
+        # score = base 1.0 * source_bonus 1.0 * no_penalty 1.0
+        assert result.score == pytest.approx(1.0)
+
+
+def test_never_viewed_page_not_penalised(tmp_db):
+    """Pages whose viewed_at IS NULL never enter the cooldown — the learner
+    hasn't read them yet, so re-showing isn't redundant."""
+    with tmp_db() as db:
+        target = _seed_lemma(db, form="λόγος")
+        scaffold = _seed_lemma(db, form="ο")
+        _seed_known(db, scaffold.lemma_id, state="known")
+
+        story = _seed_story(db)
+        unread_page = _seed_page(db, story_id=story.id, viewed_at=None)
+        _seed_sentence(
+            db,
+            lemma_surfaces=[(scaffold.lemma_id, "ο"), (target.lemma_id, "λόγος")],
+            source="textbook",
+            page_id=unread_page.id,
+        )
+        db.commit()
+
+        result = pick_sentence_for_lemma(db, lemma_id=target.lemma_id, language_code="el")
+        assert result is not None
+        assert result.selection_reason != "page_cooldown_fallback"
+        assert result.score == pytest.approx(1.0)
+
+
+def test_tie_break_prefers_never_shown_llm_sentence(tmp_db):
+    """Two LLM sentences with identical comprehensibility + source bonus.
+    The one with the smaller times_shown wins — review prefers novel context
+    over revisited."""
+    with tmp_db() as db:
+        target = _seed_lemma(db, form="λόγος")
+        scaffold = _seed_lemma(db, form="ο")
+        _seed_known(db, scaffold.lemma_id, state="known")
+
+        shown_sent = _seed_sentence(
+            db,
+            lemma_surfaces=[(scaffold.lemma_id, "ο"), (target.lemma_id, "λόγος")],
+            text="ο λόγος (shown 5x)",
+            source="llm",
+            times_shown=5,
+        )
+        fresh_sent = _seed_sentence(
+            db,
+            lemma_surfaces=[(scaffold.lemma_id, "ο"), (target.lemma_id, "λόγος")],
+            text="ο λόγος (never shown)",
+            source="llm",
+            times_shown=0,
+        )
+        db.commit()
+
+        result = pick_sentence_for_lemma(db, lemma_id=target.lemma_id, language_code="el")
+        assert result is not None
+        assert result.sentence_id == fresh_sent.id


### PR DESCRIPTION
## Summary
- **Picker (sentence_selector.py)**: LLM source bonus bumped to 1.5 (above textbook 1.0), a 0.2× multiplicative penalty when a candidate's page was viewed within the last 7 days, retired \`PAGE_FIRST_BONUS\` (was 3.0 for all-known page sentences), tie-break by \`times_shown\` ascending then \`created_at\` descending. Soft fallback: recently-viewed page sentences are penalised but still beat nothing.
- **Cron wrapper (polyglot-update-material.sh)**: added \`enrich_lemma_philology\` as a third phase after \`warm_sentence_cache\`. Conservative 10-lemmas-per-run cap so a bad batch can't burn the Claude budget; with 3h cron interval that's ~80 lemmas/day.
- **Tests**: updated the page-first test to encode the new behavior (LLM wins at equal comprehensibility) + 5 new tests covering the cooldown (recent penalised, old not penalised, never-viewed not penalised) and tie-break (never-shown wins).

## Why
The picker is run at review time, when the goal is to test recall in a *novel* context. Re-showing the page-of-record the learner just finished reading is zero-friction recall — which is exactly what you DON'T want days later. The 7-day cooldown is the threshold below which "I just read this" is still load-bearing.

## Risks
- The graceful-fallback path (penalised page sentence still served when no LLM exists) means the learner won't see "no card" during the lag between tapping unknown and the cron generating. But it also means *just-read* page sentences can still appear in the first session right after reading — that's intentional: better to review a tepid sentence than skip the lemma entirely.