### PR TITLE
Polyglot: bigger vocab sample, greedy lemmatizer, enrichment verifier

### DIFF
--- a/polyglot/app/services/languages/el.py
+++ b/polyglot/app/services/languages/el.py
@@ -109,10 +109,12 @@ class ModernGreekProvider:
         # simplemma's dictionary is lowercase — uppercase headings ("ΠΟΛΙΤΙΣΜΟΙ")
         # won't match unless we fold case first. We still feed the original
         # case to simplemma in case it has casing rules; if that returns the
-        # surface unchanged, retry with .lower().
-        lemma = simplemma.lemmatize(surface, lang=self._SIMPLEMMA_LANG)
+        # surface unchanged, retry with .lower(). greedy=True (2026-05-21) lets
+        # simplemma match comparatives + irregular plurals it'd otherwise leave
+        # unchanged — small but free recall gain.
+        lemma = simplemma.lemmatize(surface, lang=self._SIMPLEMMA_LANG, greedy=True)
         if lemma == surface and not surface.islower():
-            lemma = simplemma.lemmatize(surface.lower(), lang=self._SIMPLEMMA_LANG)
+            lemma = simplemma.lemmatize(surface.lower(), lang=self._SIMPLEMMA_LANG, greedy=True)
         confidence = 1.0 if lemma.lower() != surface.lower() else 0.5
         return LemmaCandidate(
             lemma=lemma,

--- a/polyglot/app/services/lemma_philology.py
+++ b/polyglot/app/services/lemma_philology.py
@@ -55,7 +55,9 @@ def _resolve_model(raw: str) -> str:
 
 
 ENRICH_MODEL = _resolve_model(os.environ.get("POLYGLOT_ENRICH_MODEL", "sonnet"))
+VERIFY_MODEL = _resolve_model(os.environ.get("POLYGLOT_ENRICH_VERIFY_MODEL", "haiku"))
 ENRICH_TIMEOUT_S = int(os.environ.get("POLYGLOT_ENRICH_TIMEOUT", "240"))
+VERIFY_TIMEOUT_S = int(os.environ.get("POLYGLOT_ENRICH_VERIFY_TIMEOUT", "180"))
 ENRICH_BATCH_SIZE = max(1, int(os.environ.get("POLYGLOT_ENRICH_BATCH_SIZE", "4")))
 
 LANG_DISPLAY = {
@@ -116,10 +118,28 @@ cognates, and how the word lives in literature.
 
 For each lemma, produce a structured JSON entry. Field guidance:
 
+FACTUAL ACCURACY ON PHILOLOGY:
+- These claims will be surfaced to a learner who trusts the app's etymology.
+  A wrong PIE root or a wrong claim about what a word meant in Byzantine
+  Greek is a real problem — much worse than an honest "we don't know."
+- If you are not confident a PIE root is correct, set `pie_root: null`
+  rather than guess. Same for any diachronic stage: omit the stage rather
+  than invent a plausible-sounding meaning.
+- When citing a derivation that is one of multiple competing hypotheses,
+  say so explicitly in origin_note ("one hypothesis is...", "traditionally
+  derived from X, though some scholars prefer Y"). Don't present
+  hypotheses as fact.
+- DO NOT chain etymology through unrelated roots. E.g., for a contracted
+  form, the PIE root field should be the root of the SEMANTIC PARENT (the
+  preposition's source, not the article's source). When in doubt, set null.
+
 ETYMOLOGY (1 object):
 - pie_root: the reconstructed Proto-Indo-European root with asterisk and gloss
-  in parentheses, e.g. "*ḱerd- (heart)". Null only if etymology is truly opaque
-  or non-IE (Pre-Greek substrate, Semitic loan, etc.).
+  in parentheses, e.g. "*ḱerd- (heart)". Null when:
+  * etymology is truly opaque or non-IE (Pre-Greek substrate, Semitic loan)
+  * the word is a contraction/compound where the PIE root field would be
+    ambiguous (which constituent's root?)
+  * you are not confident in the reconstruction
 - ancient_form: the Ancient Greek citation form with full polytonic accents,
   e.g. "ἄλογος", "λόγος", "καρδία". For Latin or Ancient Greek lemmas, this is
   the parent/source form.
@@ -136,6 +156,10 @@ DIACHRONY (ordered list, ancient to modern):
   an optional one-line note for context.
 - Skip eras with no meaningful change — only include a stage when the meaning
   or register shifts.
+- If you don't know what a word specifically meant in a particular era, OMIT
+  that stage. Never claim "in Byzantine Greek X meant Y" unless you are
+  confident — that's the exact kind of error the learner will catch when
+  they look it up.
 
 COGNATES (list, 3-6 entries):
 - Cross-language relatives. Pick high-utility ones for an English speaker.
@@ -375,6 +399,175 @@ def _enrich_batch_call(
     return parsed
 
 
+# ─── Fact-verification pass (Haiku) ────────────────────────────────────────
+# Mirrors material_generator's verify pattern: after Sonnet generates rich
+# content, send the *factual* slices (etymology + diachrony) to Haiku for a
+# cheap accuracy check. Per user spec (2026-05-21), quotes/cognates/register
+# are NOT verified — those are memory hooks where mild inaccuracy is fine.
+# Etymology and diachrony are claims the learner will trust, so wrong PIE
+# roots and wrong "in era X this meant Y" are real problems.
+
+
+def _verify_prompt(language_code: str, items: list[dict]) -> str:
+    lang = LANG_DISPLAY.get(language_code, language_code)
+    block_lines = []
+    for it in items:
+        e = it["etymology"] or {}
+        block_lines.append(
+            f"[lemma_id={it['lemma_id']}] {it['lemma_form']} ({it['gloss_en']})\n"
+            f"  etymology.pie_root: {e.get('pie_root')!r}\n"
+            f"  etymology.ancient_form: {e.get('ancient_form')!r}\n"
+            f"  etymology.origin_note: {e.get('origin_note', '')[:300]!r}\n"
+            f"  etymology.morphology: {e.get('morphology')!r}\n"
+            f"  diachrony stages:"
+        )
+        for stage in it["diachrony"]:
+            block_lines.append(
+                f"    - era={stage['era']}, form={stage['form']!r}, "
+                f"meaning={stage['meaning'][:120]!r}"
+            )
+    items_block = "\n".join(block_lines)
+    return f"""You are a {lang} philology fact-checker. For each lemma below,
+review ONLY the etymology and diachrony claims (ignore quotes, cognates,
+register — those are not your concern). Flag anything that is:
+
+1. A clearly WRONG PIE root attribution (e.g. claiming a root that gives a
+   different word entirely, or chaining etymology through an unrelated form).
+2. A WRONG factual claim about what a word meant in a specific era.
+3. A FOLK ETYMOLOGY presented as fact (e.g. "ξέρω derives from ξηρός 'dry'"
+   is a popular folk etymology, not the standard derivation).
+
+DO NOT flag:
+- Anything you're not >90% confident is wrong (when uncertain, mark "ok").
+- Stylistic disagreements, prose phrasing, or "I would have said it
+  differently" issues.
+- Quote attributions, cognate choices, register classification — those are
+  out of scope here.
+
+For each lemma, return a verdict:
+- "ok": etymology + diachrony look correct (or any errors are too minor to bother).
+- "etymology_issue": specific factual problem in the etymology block. Put the
+  correction in `note`.
+- "diachrony_issue": specific factual problem in one of the diachrony stages.
+  Put the correction in `note`.
+
+Be parsimonious — most should come back "ok". Only flag when you're confident
+the published claim would be challenged by a philology reference.
+
+Lemmas:
+{items_block}
+"""
+
+
+def _verify_schema() -> dict:
+    return {
+        "type": "object",
+        "properties": {
+            "verdicts": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "lemma_id": {"type": "integer"},
+                        "verdict": {
+                            "type": "string",
+                            "enum": ["ok", "etymology_issue", "diachrony_issue"],
+                        },
+                        "note": {"type": ["string", "null"]},
+                    },
+                    "required": ["lemma_id", "verdict"],
+                },
+            },
+        },
+        "required": ["verdicts"],
+    }
+
+
+@dataclass
+class _Verdict:
+    lemma_id: int
+    verdict: str   # "ok" | "etymology_issue" | "diachrony_issue"
+    note: Optional[str]
+
+
+def _verify_enrichment_facts(
+    language_code: str,
+    parsed: dict[str, LemmaEnrichment],
+    targets: list[_EnrichTarget],
+) -> dict[int, _Verdict]:
+    """Haiku check on etymology + diachrony factual accuracy. Returns
+    ``{lemma_id: _Verdict}`` covering only lemmas that came back from
+    Sonnet (others fail upstream and never reach here).
+
+    On total LLM failure, returns an empty dict — caller treats this as
+    "no extra information" and writes the Sonnet output as-is. This is
+    intentional: the verifier is best-effort. A timed-out Haiku shouldn't
+    block the user from seeing enrichment that's probably fine.
+    """
+    targets_by_form = {t.lemma_form: t for t in targets}
+    items: list[dict] = []
+    for form, e in parsed.items():
+        t = targets_by_form.get(form)
+        if t is None:
+            continue
+        items.append({
+            "lemma_id": t.lemma_id,
+            "lemma_form": form,
+            "gloss_en": t.gloss_en,
+            "etymology": e.etymology.model_dump() if e.etymology else None,
+            "diachrony": [s.model_dump() for s in e.diachrony],
+        })
+    if not items:
+        return {}
+
+    cmd = [
+        "claude", "-p",
+        "--output-format", "json",
+        "--model", VERIFY_MODEL,
+        "--json-schema", json.dumps(_verify_schema()),
+        _verify_prompt(language_code, items),
+    ]
+    started = time.time()
+    structured = _call_cli(cmd, VERIFY_TIMEOUT_S)
+    elapsed = time.time() - started
+    if not structured:
+        _log_pipeline({
+            "event": "verify_failed",
+            "language_code": language_code,
+            "lemma_ids": [it["lemma_id"] for it in items],
+            "elapsed_s": round(elapsed, 1),
+            "model": VERIFY_MODEL,
+        })
+        return {}
+
+    verdicts: dict[int, _Verdict] = {}
+    for v in structured.get("verdicts", []) or []:
+        if not isinstance(v, dict):
+            continue
+        lid = v.get("lemma_id")
+        kind = v.get("verdict")
+        if not isinstance(lid, int) or kind not in ("ok", "etymology_issue", "diachrony_issue"):
+            continue
+        verdicts[lid] = _Verdict(
+            lemma_id=lid, verdict=kind, note=v.get("note") or None,
+        )
+
+    flagged = [v for v in verdicts.values() if v.verdict != "ok"]
+    _log_pipeline({
+        "event": "verify_returned",
+        "language_code": language_code,
+        "lemma_count": len(items),
+        "verdict_count": len(verdicts),
+        "flagged": [
+            {"lemma_id": v.lemma_id, "verdict": v.verdict, "note": v.note}
+            for v in flagged
+        ],
+        "elapsed_s": round(elapsed, 1),
+        "model": VERIFY_MODEL,
+    })
+    return verdicts
+
+
 # ─── Orchestration ─────────────────────────────────────────────────────────
 
 
@@ -461,7 +654,14 @@ def batch_enrich(
             _stamp_failure(language_code, [t.lemma_id for t in chunk])
             continue
 
-        chunk_enriched, chunk_failed = _write_chunk(language_code, chunk, parsed)
+        # Best-effort fact-check on etymology + diachrony. Returns {} on
+        # total Haiku failure — we still write the Sonnet output as-is, just
+        # without a verifier-clean stamp.
+        verdicts = _verify_enrichment_facts(language_code, parsed, chunk)
+
+        chunk_enriched, chunk_failed = _write_chunk(
+            language_code, chunk, parsed, verdicts=verdicts,
+        )
         total_enriched += chunk_enriched
         failed.extend(chunk_failed)
 
@@ -485,11 +685,20 @@ def _write_chunk(
     language_code: str,
     chunk: list[_EnrichTarget],
     parsed: dict[str, LemmaEnrichment],
+    verdicts: Optional[dict[int, _Verdict]] = None,
 ) -> tuple[int, list[int]]:
     """Persist parsed enrichments for one chunk. Returns (enriched, failed_ids).
 
     Phase 3 of the read/LLM/write pattern. Single commit per chunk.
+
+    When ``verdicts`` flags a lemma as ``etymology_issue`` / ``diachrony_issue``,
+    the payload is still written (since rejecting it loses all 5 slices including
+    the unverified-OK ones), but ``enrichment_status`` is stamped as
+    ``done_flagged`` and the verifier's note is appended to the payload's
+    ``_verifier_note`` field so downstream consumers can react. ``done`` =
+    Sonnet + Haiku both OK; ``done_unverified`` = Haiku failed to run.
     """
+    verdicts = verdicts or {}
     now = datetime.now(timezone.utc)
     enriched = 0
     failed: list[int] = []
@@ -505,8 +714,18 @@ def _write_chunk(
                 lemma.enrichment_status = "failed"
                 failed.append(target.lemma_id)
                 continue
-            lemma.enrichment_json = payload.model_dump(mode="json")
-            lemma.enrichment_status = "done"
+            data = payload.model_dump(mode="json")
+            verdict = verdicts.get(target.lemma_id)
+            if verdict is None:
+                lemma.enrichment_status = "done_unverified"
+            elif verdict.verdict == "ok":
+                lemma.enrichment_status = "done"
+            else:
+                lemma.enrichment_status = "done_flagged"
+                data["_verifier_note"] = {
+                    "verdict": verdict.verdict, "note": verdict.note,
+                }
+            lemma.enrichment_json = data
             lemma.enriched_at = now
             enriched += 1
         db.commit()
@@ -550,6 +769,11 @@ def find_unenriched_lemmas(
     actually engaged with them) — no point philologizing words no one studies.
     Order: by frequency_rank when present (so the most common words enrich
     first), then lemma_id.
+
+    With ``include_failed=True``, also re-picks lemmas whose previous
+    enrichment failed entirely (status='failed') OR was written but flagged
+    by the verifier (status='done_flagged'). Use to clean up known-bad
+    enrichment after a prompt improvement.
     """
     from sqlalchemy import or_
     from app.models import UserLemmaKnowledge
@@ -558,7 +782,11 @@ def find_unenriched_lemmas(
     try:
         status_filter = Lemma.enrichment_status.is_(None)
         if include_failed:
-            status_filter = or_(status_filter, Lemma.enrichment_status == "failed")
+            status_filter = or_(
+                status_filter,
+                Lemma.enrichment_status == "failed",
+                Lemma.enrichment_status == "done_flagged",
+            )
         rows = (
             db.query(Lemma.lemma_id, Lemma.frequency_rank)
             .join(UserLemmaKnowledge, UserLemmaKnowledge.lemma_id == Lemma.lemma_id)

--- a/polyglot/app/services/material_generator.py
+++ b/polyglot/app/services/material_generator.py
@@ -100,8 +100,24 @@ SENTENCES_PER_TARGET = max(1, int(os.environ.get("POLYGLOT_SENTENCES_PER_TARGET"
 ACTIVE_TARGET = max(1, int(os.environ.get("POLYGLOT_ACTIVE_TARGET", "3")))
 
 # Known-words sample passed to the generation prompt. Larger = more lexical
-# diversity in generated sentences, but the prompt gets bigger.
-KNOWN_SAMPLE_SIZE = 60
+# diversity in generated sentences, but the prompt gets bigger. Bumped from
+# 60 → 500 on 2026-05-21 once polyglot's engaged-vocabulary pool grew to
+# ~2.4k lemmas. With only 60, Sonnet ran out of scaffold vocabulary fast and
+# reached for words outside the DB (78% validation-rejection rate). Matches
+# Alif's sample size — Alif has been generating well from the get-go with
+# this value.
+KNOWN_SAMPLE_SIZE = 500
+
+# Minimum weight for inverse-frequency sampling. Floors a hugely-overused
+# word's probability so it can still appear occasionally if the LLM really
+# wants it — but most picks go to under-represented vocabulary.
+MIN_SAMPLE_WEIGHT = 0.05
+
+# Words covered by more than this many existing sentences land on the
+# "avoid" list passed to the LLM as an explicit instruction. The threshold
+# is computed dynamically per run (max of MEDIAN * 1.5 and ABS_FLOOR).
+AVOID_ABS_FLOOR = 3
+MAX_AVOID_WORDS = 30
 
 LANG_DISPLAY = {
     "el": "Modern Greek",
@@ -154,9 +170,11 @@ class GeneratedSentence:
 
 
 def _gen_prompt(language_code: str, targets: list[GenTarget],
-                known_sample: list[str], sentences_per_target: int) -> str:
+                known_sample: list[str], sentences_per_target: int,
+                avoid_words: Optional[list[str]] = None) -> str:
     lang = LANG_DISPLAY.get(language_code, language_code)
     known_block = ", ".join(known_sample[:KNOWN_SAMPLE_SIZE]) or "(none)"
+    avoid_block = ", ".join(avoid_words) if avoid_words else "(none)"
     target_block = "\n".join(
         f"  {i}. {t.lemma_form}"
         + (f" ({t.pos})" if t.pos else "")
@@ -167,18 +185,26 @@ def _gen_prompt(language_code: str, targets: list[GenTarget],
     return f"""You are generating natural {lang} practice sentences for a learner.
 
 For each target lemma below, produce {sentences_per_target} short sentences
-(6–12 words each) that use the lemma in its primary sense. Prefer sentences
-the learner can almost-decode using the known-words pool — only the target
-should be the new word.
+(6–12 words each) that use the lemma in its primary sense. Every non-target
+word in the sentence MUST come from the known-words pool below — sentences
+that reach for vocabulary outside the pool will be rejected by the validator
+and the work wasted.
 
 Rules:
 - Use the target lemma exactly once per sentence (any inflected form is fine).
 - {register_instruction} No headlines, no all-caps, no proper-noun
   heavy contexts unless the target itself is a proper noun.
 - Provide a faithful English translation. Do not transliterate.
-- Reuse vocabulary from the known-words pool wherever natural.
+- Use only vocabulary from the known-words pool below for every non-target
+  word. If you can't construct a natural sentence within this constraint,
+  return fewer sentences rather than reaching outside the pool.
+- Avoid the listed over-represented words — pick less-used vocabulary from
+  the pool to keep the corpus diverse.
 
-Known-words pool (sample): {known_block}
+Known-words pool ({len(known_sample)} words available, all in the learner's vocabulary):
+{known_block}
+
+Words to avoid (already over-represented): {avoid_block}
 
 Targets:
 {target_block}
@@ -261,6 +287,7 @@ def generate_sentences_batch(
     targets: list[GenTarget],
     known_sample: list[str],
     sentences_per_target: int = SENTENCES_PER_TARGET,
+    avoid_words: Optional[list[str]] = None,
 ) -> list[GeneratedSentence]:
     """One Sonnet call → list of (target_index, text, english).
 
@@ -269,7 +296,8 @@ def generate_sentences_batch(
     """
     if not targets:
         return []
-    prompt = _gen_prompt(language_code, targets, known_sample, sentences_per_target)
+    prompt = _gen_prompt(language_code, targets, known_sample,
+                        sentences_per_target, avoid_words=avoid_words)
     cmd = [
         "claude", "-p",
         "--output-format", "json",
@@ -500,25 +528,113 @@ def verify_sentence_mappings_llm(
 # ─── Orchestration ─────────────────────────────────────────────────────────
 
 
-def _snapshot_known_sample(db: Session, language_code: str, exclude_lemma_ids: set[int]) -> list[str]:
-    """Bare forms the learner already knows. Used as scaffold hints in the
-    generation prompt.
+def _snapshot_known_pool(
+    db: Session, language_code: str, exclude_lemma_ids: set[int],
+) -> list[dict]:
+    """Full engaged-vocabulary pool. Each entry is
+    ``{"lemma_id": int, "lemma_form": str}``.
 
-    Drawn from acquiring/learning/known states. Excludes target lemmas so the
-    LLM doesn't accidentally treat them as "already known."
+    Drawn from acquiring/learning/known ULK states (the lemmas the learner
+    has *touched*), filtered to canonical lemmas (skip variants — they re-use
+    the canonical's identity downstream). Function words + proper names are
+    NOT excluded here; the validator handles those separately and they
+    sometimes belong inside generated sentences as connectives.
+
+    Returns the full pool so caller can apply inverse-frequency weighting.
+    No SQLite limit — at ~2.4k engaged lemmas this is still <1ms.
     """
     rows = (
-        db.query(Lemma.lemma_form)
+        db.query(Lemma.lemma_id, Lemma.lemma_form)
         .join(UserLemmaKnowledge, UserLemmaKnowledge.lemma_id == Lemma.lemma_id)
         .filter(
             Lemma.language_code == language_code,
+            Lemma.canonical_lemma_id.is_(None),
             UserLemmaKnowledge.knowledge_state.in_(["acquiring", "learning", "known"]),
-            ~Lemma.lemma_id.in_(exclude_lemma_ids) if exclude_lemma_ids else True,
         )
-        .limit(400)
+    )
+    if exclude_lemma_ids:
+        rows = rows.filter(~Lemma.lemma_id.in_(exclude_lemma_ids))
+    return [
+        {"lemma_id": lid, "lemma_form": lf}
+        for lid, lf in rows.all()
+        if lf
+    ]
+
+
+def _content_sentence_counts(db: Session, language_code: str) -> dict[int, int]:
+    """For every lemma_id, how many active+verified Sentence rows reference
+    it. Powers the inverse-frequency weighting AND the avoid-list — words
+    that already appear in many sentences should be down-weighted (don't
+    keep generating more material for already-saturated vocabulary).
+    """
+    from sqlalchemy import func
+    rows = (
+        db.query(SentenceWord.lemma_id, func.count(func.distinct(Sentence.id)))
+        .join(Sentence, Sentence.id == SentenceWord.sentence_id)
+        .filter(
+            Sentence.language_code == language_code,
+            Sentence.is_active.is_(True),
+            Sentence.mappings_verified_at.isnot(None),
+            SentenceWord.lemma_id.isnot(None),
+        )
+        .group_by(SentenceWord.lemma_id)
         .all()
     )
-    return [r[0] for r in rows if r[0]]
+    return {lid: cnt for lid, cnt in rows}
+
+
+def _sample_known_words_weighted(
+    pool: list[dict],
+    counts: dict[int, int],
+    sample_size: int = KNOWN_SAMPLE_SIZE,
+) -> list[str]:
+    """Inverse-frequency weighted sampling. Words appearing in many existing
+    sentences get lower probability so the LLM is nudged toward
+    under-represented vocabulary. Jittered to keep selection non-deterministic
+    across runs. Returns lemma_form strings.
+
+    Ported from Alif's ``sample_known_words_weighted`` in sentence_generator.py
+    — same shape, same weighting law, smaller surface to keep polyglot lean.
+    """
+    import random
+    if len(pool) <= sample_size:
+        return [w["lemma_form"] for w in pool]
+
+    weighted: list[tuple[float, dict]] = []
+    for w in pool:
+        cnt = counts.get(w["lemma_id"], 0)
+        weight = max(MIN_SAMPLE_WEIGHT, 1.0 / (1 + cnt))
+        jittered = weight * random.uniform(0.5, 1.5)
+        weighted.append((jittered, w))
+    weighted.sort(key=lambda x: x[0], reverse=True)
+    return [w["lemma_form"] for _, w in weighted[:sample_size]]
+
+
+def _compute_avoid_words(
+    pool: list[dict],
+    counts: dict[int, int],
+) -> Optional[list[str]]:
+    """Return up to MAX_AVOID_WORDS lemma_form strings the LLM should avoid.
+
+    Threshold: a lemma is "over-represented" if its sentence count is at
+    least max(median * 1.5, AVOID_ABS_FLOOR). Ports the threshold logic from
+    Alif's ``get_avoid_words`` so the polyglot corpus stays diverse for the
+    same reasons.
+    """
+    import statistics
+    if not counts:
+        return None
+    vals = sorted(counts.values())
+    median = statistics.median(vals)
+    threshold = max(median * 1.5, AVOID_ABS_FLOOR)
+    by_id_to_form = {w["lemma_id"]: w["lemma_form"] for w in pool}
+    over = [
+        (lid, cnt) for lid, cnt in counts.items()
+        if cnt >= threshold and lid in by_id_to_form
+    ]
+    over.sort(key=lambda x: x[1], reverse=True)
+    result = [by_id_to_form[lid] for lid, _ in over[:MAX_AVOID_WORDS]]
+    return result or None
 
 
 def batch_generate_material(
@@ -576,11 +692,15 @@ def batch_generate_material(
             return {"generated": 0, "words_covered": 0, "words_failed": lemma_ids}
 
         lemma_lookup = build_lemma_lookup(db, language_code)
-        known_sample = _snapshot_known_sample(
+        known_pool = _snapshot_known_pool(
             db, language_code, exclude_lemma_ids={t.lemma_id for t in targets}
         )
+        sentence_counts = _content_sentence_counts(db, language_code)
     finally:
         db.close()
+
+    known_sample = _sample_known_words_weighted(known_pool, sentence_counts, KNOWN_SAMPLE_SIZE)
+    avoid_words = _compute_avoid_words(known_pool, sentence_counts)
 
     # ── Phase 2a: Sonnet generation ──
     raw_sentences = generate_sentences_batch(
@@ -588,6 +708,7 @@ def batch_generate_material(
         targets=targets,
         known_sample=known_sample,
         sentences_per_target=sentences_per_target,
+        avoid_words=avoid_words,
     )
     if not raw_sentences:
         return {

--- a/polyglot/tests/test_lemma_philology.py
+++ b/polyglot/tests/test_lemma_philology.py
@@ -26,6 +26,22 @@ def _envelope(structured: dict) -> str:
     return json.dumps({"structured_output": structured, "result": ""})
 
 
+def _verify_ok_for(*lemma_ids: int) -> _FakeProc:
+    """Canned 'all OK' verifier response covering the given lemma_ids."""
+    return _FakeProc(stdout=_envelope({
+        "verdicts": [
+            {"lemma_id": lid, "verdict": "ok"} for lid in lemma_ids
+        ],
+    }))
+
+
+def _verify_flagged_for(lemma_id: int, kind: str = "etymology_issue",
+                       note: str = "PIE root incorrect") -> _FakeProc:
+    return _FakeProc(stdout=_envelope({
+        "verdicts": [{"lemma_id": lemma_id, "verdict": kind, "note": note}],
+    }))
+
+
 def _seed_lemma(db, *, form: str, gloss: str = "x", pos: str = "noun",
                 cognate_id: int | None = None,
                 canonical: int | None = None,
@@ -105,7 +121,8 @@ def _good_payload(form: str) -> dict:
 
 
 def test_batch_enrich_happy_path(tmp_db, fake_claude):
-    """One lemma, one valid enrichment → row written with status=done."""
+    """One lemma, one valid enrichment + verifier passes → row written with
+    status=done. Two Claude calls total: Sonnet generation + Haiku verify."""
     with tmp_db() as db:
         lemma = _seed_lemma(db, form="καρδιά", gloss="heart")
         db.commit()
@@ -114,20 +131,90 @@ def test_batch_enrich_happy_path(tmp_db, fake_claude):
     fake_claude["script"].append(_FakeProc(stdout=_envelope({
         "lemmas": [{"lemma_form": "καρδιά", "enrichment": _good_payload("καρδιά")}],
     })))
+    fake_claude["script"].append(_verify_ok_for(lemma_id))
 
     result = lp.batch_enrich(language_code="el", lemma_ids=[lemma_id])
 
     assert result["enriched"] == 1
     assert result["failed_lemma_ids"] == []
     assert result["skipped_lemma_ids"] == []
-    assert len(fake_claude["calls"]) == 1
+    assert len(fake_claude["calls"]) == 2
 
     with tmp_db() as db:
         lemma = db.query(Lemma).filter(Lemma.lemma_id == lemma_id).first()
         assert lemma.enrichment_status == "done"
         assert lemma.enrichment_json is not None
         assert lemma.enrichment_json["etymology"]["origin_note"].startswith("Origin note")
+        assert "_verifier_note" not in lemma.enrichment_json
         assert lemma.enriched_at is not None
+
+
+def test_verifier_flagged_writes_done_flagged(tmp_db, fake_claude):
+    """When Haiku flags etymology, the payload is still written but status
+    becomes 'done_flagged' and the verifier note is attached to enrichment_json."""
+    with tmp_db() as db:
+        lemma = _seed_lemma(db, form="στο", gloss="in the")
+        db.commit()
+        lemma_id = lemma.lemma_id
+
+    fake_claude["script"].append(_FakeProc(stdout=_envelope({
+        "lemmas": [{"lemma_form": "στο", "enrichment": _good_payload("στο")}],
+    })))
+    fake_claude["script"].append(_verify_flagged_for(
+        lemma_id, "etymology_issue", "PIE *steh₂- is wrong",
+    ))
+
+    result = lp.batch_enrich(language_code="el", lemma_ids=[lemma_id])
+    assert result["enriched"] == 1
+
+    with tmp_db() as db:
+        lemma = db.query(Lemma).filter(Lemma.lemma_id == lemma_id).first()
+        assert lemma.enrichment_status == "done_flagged"
+        assert lemma.enrichment_json["_verifier_note"]["verdict"] == "etymology_issue"
+        assert "PIE *steh₂-" in lemma.enrichment_json["_verifier_note"]["note"]
+
+
+def test_verifier_failure_writes_done_unverified(tmp_db, fake_claude):
+    """When the Haiku verifier call itself fails (timeout / non-zero exit),
+    the Sonnet output is still written but stamped 'done_unverified' so a
+    later cron can re-pick if desired."""
+    with tmp_db() as db:
+        lemma = _seed_lemma(db, form="καρδιά", gloss="heart")
+        db.commit()
+        lemma_id = lemma.lemma_id
+
+    fake_claude["script"].append(_FakeProc(stdout=_envelope({
+        "lemmas": [{"lemma_form": "καρδιά", "enrichment": _good_payload("καρδιά")}],
+    })))
+    # Verifier call fails (non-zero exit)
+    fake_claude["script"].append(_FakeProc(stdout="", stderr="boom", returncode=1))
+
+    result = lp.batch_enrich(language_code="el", lemma_ids=[lemma_id])
+    assert result["enriched"] == 1
+
+    with tmp_db() as db:
+        lemma = db.query(Lemma).filter(Lemma.lemma_id == lemma_id).first()
+        assert lemma.enrichment_status == "done_unverified"
+        assert lemma.enrichment_json is not None  # Sonnet payload written
+
+
+def test_find_unenriched_with_include_failed_picks_done_flagged(tmp_db, fake_claude):
+    """Manual `--include-failed` re-pick should grab done_flagged lemmas too,
+    so a prompt improvement can clean up known-bad enrichment."""
+    with tmp_db() as db:
+        a = _seed_lemma(db, form="στο", gloss="in the")
+        _seed_ulk(db, a.lemma_id)
+        a.enrichment_status = "done_flagged"
+        a.enrichment_json = {"version": 1, "etymology": {"origin_note": "bad"}}
+        db.commit()
+        a_id = a.lemma_id
+
+    # Without include_failed, the done_flagged lemma is skipped.
+    assert lp.find_unenriched_lemmas(language_code="el", limit=10) == []
+    # With include_failed, it shows up.
+    assert lp.find_unenriched_lemmas(
+        language_code="el", limit=10, include_failed=True,
+    ) == [a_id]
 
 
 def test_glossless_lemma_is_skipped(tmp_db, fake_claude):
@@ -208,6 +295,8 @@ def test_partial_response_marks_missing_as_failed(tmp_db, fake_claude):
     fake_claude["script"].append(_FakeProc(stdout=_envelope({
         "lemmas": [{"lemma_form": "καρδιά", "enrichment": _good_payload("καρδιά")}],
     })))
+    # Verifier only sees καρδιά (λόγος was never parsed); OK for it.
+    fake_claude["script"].append(_verify_ok_for(ids[0]))
 
     result = lp.batch_enrich(language_code="el", lemma_ids=ids)
 


### PR DESCRIPTION
## Summary
- **Sentence generation**: \`KNOWN_SAMPLE_SIZE\` 60→500 (matches Alif's value). Inverse-frequency weighted sampling + avoid-words list so under-represented vocab gets surfaced. Prompt strengthened with explicit "every non-target word MUST come from this pool" rule. \`simplemma greedy=True\` salvages ~3% of inflected forms.
- **Enrichment quality**: prompt overhaul with explicit "factual accuracy" rules (null over guess; omit unsure stages; flag folk etymology as such). New Haiku fact-verify pass on etymology + diachrony only. New statuses (\`done\` / \`done_flagged\` / \`done_unverified\` / \`failed\`); \`done_flagged\` rows still write the Sonnet payload + attach a verifier note.

## Diagnostic (data driving the change)
- Today's cron pass: 27 sentences stored / 100 candidates → 22% acceptance rate
- 33 unique "unknown" words flagged today: 13 plain lemmatizer fixes (already worked), 1 greedy-only fix, 3 suffix-fallback candidates, 16 genuinely missing from DB. **The big lever is sample size, not lemmatizer tuning.**
- 2/10 manual backfilled enrichments had factual errors: στο PIE root wrong; ξέρω etymology presented folk-etymology as fact. Verifier prompt designed to catch exactly these.

## What happens after merge
- Deploy + the 11:45 UTC cron picks up new sample size automatically.
- Manually re-enrich the existing 10 backfilled lemmas with \`--include-failed --lemma-ids 70,92,215,297,334,366,384,541,685,715\` so στο + ξέρω no longer have errors.