### PR TITLE
Polyglot enrichment: in-process lock + bump cron cap to 30/run

### DIFF
--- a/polyglot/app/routers/materials.py
+++ b/polyglot/app/routers/materials.py
@@ -108,8 +108,9 @@ def enrich_philology(req: EnrichRequest) -> EnrichResponse:
     Two modes:
     - Caller supplies ``lemma_ids`` explicitly → enrich exactly those.
     - Caller omits ``lemma_ids`` → pick up to ``max_lemmas`` un-enriched
-      lemmas from the engaged-vocabulary pool (those with a ULK row), ranked
-      by frequency. Used by the cron wrapper.
+      lemmas from the engaged-vocabulary pool, prioritised by review proximity:
+      acquiring (next-due first) → learning/lapsed → encountered. `known`
+      lemmas are excluded. Used by the cron wrapper.
     """
     if req.lemma_ids:
         ids = req.lemma_ids

--- a/polyglot/app/services/lemma_philology.py
+++ b/polyglot/app/services/lemma_philology.py
@@ -29,6 +29,7 @@ import json
 import logging
 import os
 import subprocess
+import threading
 import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -617,6 +618,9 @@ def _snapshot_targets(db: Session, language_code: str, lemma_ids: list[int]) -> 
     return targets, skipped
 
 
+_enrich_lock = threading.Lock()
+
+
 def batch_enrich(
     language_code: str,
     lemma_ids: list[int],
@@ -628,57 +632,74 @@ def batch_enrich(
     Internally splits ``lemma_ids`` into chunks of ``ENRICH_BATCH_SIZE`` and
     issues one Sonnet call per chunk. Each chunk independently commits, so a
     partial run still yields persisted enrichment for the successful chunks.
+
+    Process-level non-blocking lock prevents overlapping runs from picking the
+    same un-enriched lemmas and double-spending Claude budget. Mirrors
+    ``material_generator._warm_cache_lock``. Returns ``{"skipped": True,
+    "reason": "enrich_busy"}`` if another run is already in progress.
     """
     if not lemma_ids:
         return {"enriched": 0, "failed_lemma_ids": [], "skipped_lemma_ids": []}
 
-    db = database.SessionLocal()
+    if not _enrich_lock.acquire(blocking=False):
+        log.info("Enrichment already running; skipping this invocation")
+        return {
+            "skipped": True,
+            "reason": "enrich_busy",
+            "enriched": 0,
+            "failed_lemma_ids": [],
+            "skipped_lemma_ids": list(lemma_ids),
+        }
     try:
-        targets, skipped = _snapshot_targets(db, language_code, lemma_ids)
+        db = database.SessionLocal()
+        try:
+            targets, skipped = _snapshot_targets(db, language_code, lemma_ids)
+        finally:
+            db.close()
+
+        if not targets:
+            return {"enriched": 0, "failed_lemma_ids": [], "skipped_lemma_ids": skipped}
+
+        total_enriched = 0
+        failed: list[int] = []
+
+        for i in range(0, len(targets), ENRICH_BATCH_SIZE):
+            chunk = targets[i:i + ENRICH_BATCH_SIZE]
+            parsed = _enrich_batch_call(language_code, chunk)
+            if parsed is None:
+                # Total LLM failure for this chunk — mark all as failed and stamp
+                # status='failed' so the next cron can retry on a fresh run.
+                failed.extend(t.lemma_id for t in chunk)
+                _stamp_failure(language_code, [t.lemma_id for t in chunk])
+                continue
+
+            # Best-effort fact-check on etymology + diachrony. Returns {} on
+            # total Haiku failure — we still write the Sonnet output as-is, just
+            # without a verifier-clean stamp.
+            verdicts = _verify_enrichment_facts(language_code, parsed, chunk)
+
+            chunk_enriched, chunk_failed = _write_chunk(
+                language_code, chunk, parsed, verdicts=verdicts,
+            )
+            total_enriched += chunk_enriched
+            failed.extend(chunk_failed)
+
+        _log_pipeline({
+            "event": "batch_enrich_done",
+            "language_code": language_code,
+            "requested": len(lemma_ids),
+            "eligible": len(targets),
+            "enriched": total_enriched,
+            "failed": len(failed),
+            "skipped": len(skipped),
+        })
+        return {
+            "enriched": total_enriched,
+            "failed_lemma_ids": failed,
+            "skipped_lemma_ids": skipped,
+        }
     finally:
-        db.close()
-
-    if not targets:
-        return {"enriched": 0, "failed_lemma_ids": [], "skipped_lemma_ids": skipped}
-
-    total_enriched = 0
-    failed: list[int] = []
-
-    for i in range(0, len(targets), ENRICH_BATCH_SIZE):
-        chunk = targets[i:i + ENRICH_BATCH_SIZE]
-        parsed = _enrich_batch_call(language_code, chunk)
-        if parsed is None:
-            # Total LLM failure for this chunk — mark all as failed and stamp
-            # status='failed' so the next cron can retry on a fresh run.
-            failed.extend(t.lemma_id for t in chunk)
-            _stamp_failure(language_code, [t.lemma_id for t in chunk])
-            continue
-
-        # Best-effort fact-check on etymology + diachrony. Returns {} on
-        # total Haiku failure — we still write the Sonnet output as-is, just
-        # without a verifier-clean stamp.
-        verdicts = _verify_enrichment_facts(language_code, parsed, chunk)
-
-        chunk_enriched, chunk_failed = _write_chunk(
-            language_code, chunk, parsed, verdicts=verdicts,
-        )
-        total_enriched += chunk_enriched
-        failed.extend(chunk_failed)
-
-    _log_pipeline({
-        "event": "batch_enrich_done",
-        "language_code": language_code,
-        "requested": len(lemma_ids),
-        "eligible": len(targets),
-        "enriched": total_enriched,
-        "failed": len(failed),
-        "skipped": len(skipped),
-    })
-    return {
-        "enriched": total_enriched,
-        "failed_lemma_ids": failed,
-        "skipped_lemma_ids": skipped,
-    }
+        _enrich_lock.release()
 
 
 def _write_chunk(

--- a/polyglot/deploy/polyglot-update-material.sh
+++ b/polyglot/deploy/polyglot-update-material.sh
@@ -50,9 +50,11 @@ PAGES_TIMEOUT_SECONDS="${POLYGLOT_PAGES_AHEAD_TIMEOUT_SECONDS:-1200}"
 # acquiring (sorted by next-due) → learning/lapsed → encountered. `known`
 # lemmas are excluded — once a word is learnt the lookup card stops being
 # load-bearing. See find_unenriched_lemmas docstring for the full policy.
-# Per-run cap kept conservative so a bad batch doesn't blow the whole Claude
-# budget; cron runs every 3h.
-ENRICH_MAX_LEMMAS="${POLYGLOT_ENRICH_MAX_LEMMAS:-10}"
+# Cap sized for heavy-reading days: at ~70s/batch × 4 lemmas/batch, 30 lemmas
+# takes ~9 min — well under the 30-min phase timeout, leaving headroom for
+# slow Claude responses. An in-process lock in batch_enrich prevents two
+# overlapping cron runs from double-spending Claude on the same lemmas.
+ENRICH_MAX_LEMMAS="${POLYGLOT_ENRICH_MAX_LEMMAS:-30}"
 ENRICH_TIMEOUT_SECONDS="${POLYGLOT_ENRICH_TIMEOUT_SECONDS:-1800}"
 
 export PYTHONUNBUFFERED=1

--- a/polyglot/tests/test_lemma_philology.py
+++ b/polyglot/tests/test_lemma_philology.py
@@ -378,6 +378,28 @@ def test_find_unenriched_buckets_acquiring_before_encountered(tmp_db):
     assert ids == expected
 
 
+def test_batch_enrich_skips_when_lock_held(tmp_db, fake_claude):
+    """Concurrency lock: a second concurrent call returns immediately without
+    spending any Claude budget. Mirrors warm_sentence_cache's lock pattern —
+    prevents two overlapping cron runs from double-enriching the same lemmas
+    when per-run caps are raised."""
+    with tmp_db() as db:
+        lemma = _seed_lemma(db, form="καρδιά", gloss="heart")
+        db.commit()
+        lemma_id = lemma.lemma_id
+
+    assert lp._enrich_lock.acquire(blocking=False)
+    try:
+        result = lp.batch_enrich(language_code="el", lemma_ids=[lemma_id])
+    finally:
+        lp._enrich_lock.release()
+
+    assert result["skipped"] is True
+    assert result["reason"] == "enrich_busy"
+    assert result["enriched"] == 0
+    assert fake_claude["calls"] == []
+
+
 def test_fixture_round_trip_matches_pydantic_shape():
     """The real-world enrichment fixture from the POC must parse cleanly into
     LemmaEnrichment. Guard against silent drift between the prompt's JSON


### PR DESCRIPTION
## Summary

- Add `_enrich_lock` (threading lock) around `batch_enrich` so overlapping cron runs / manual backfills don't pick the same un-enriched lemmas and double-spend Claude budget. Mirrors `material_generator._warm_cache_lock`.
- Bump `POLYGLOT_ENRICH_MAX_LEMMAS` cron default from **10 → 30**. At ~70s/batch × 4 lemmas/batch, 30 lemmas takes ~9 min — well under the 30-min phase timeout. 240 lemmas/day max at the current 3-hourly cadence, generous for heavy-reading days.

## Why

Heavy reading days can tap dozens of unknown lemmas. Previously the cron drained 10/run = 80/day max, which lagged behind a real reading session. Bumping to 30/run handles realistic inflow without needing manual backfills.

## Lock-discipline audit

Confirmed clean across the enrichment pipeline. Every code path follows the prescribed "phase 1 read+close → phase 2 LLM (no session) → phase 3 write+commit+close" cycle:

| Function | DB session | LLM call |
|---|---|---|
| `find_unenriched_lemmas` | opens → query → close | none |
| `_snapshot_targets` | receives `db` for read | none |
| `batch_enrich` outer loop | closed before LLM (line 640) | per-batch |
| `_enrich_batch_call` | no session | Sonnet ~60s |
| `_verify_enrichment_facts` | no session | Haiku ~10s |
| `_write_chunk` | own session, fast write+commit | none inside |
| `_stamp_failure` | own session, fast write+commit | none |

The new `_enrich_lock` is a process-level threading lock — not a DB lock. It serialises concurrent invocations at the Python level so they don't race on the un-enriched lemma queue. DB lock holding is unchanged: still milliseconds at a time, only during the per-chunk commit.

## Test

- `test_batch_enrich_skips_when_lock_held` — a concurrent call returns `skipped=True` immediately and makes zero Claude calls.