### PR TITLE
Polyglot review typography: actually load EB Garamond, drop italic

### DIFF
--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -20,6 +20,14 @@ import {
   NotoSans_400Regular,
   NotoSans_400Regular_Italic,
 } from "@expo-google-fonts/noto-sans";
+// Greek display/body face for Polyglot. Loaded here (the single useFonts call
+// for the whole app) so it's actually available at runtime — the prior
+// Cormorant Garamond reference in polyglot-design-tokens was never registered,
+// so Greek silently fell back to Georgia (web) / system sans (iOS).
+import {
+  EBGaramond_400Regular,
+  EBGaramond_600SemiBold,
+} from "@expo-google-fonts/eb-garamond";
 import { colors } from "../lib/theme";
 import { netStatus, useNetStatus } from "../lib/net-status";
 import { flushQueue } from "../lib/sync-queue";
@@ -41,6 +49,8 @@ export default function Layout() {
     NotoNaskhArabic_700Bold,
     NotoSans_400Regular,
     NotoSans_400Regular_Italic,
+    EBGaramond_400Regular,
+    EBGaramond_600SemiBold,
   });
   const online = useNetStatus();
 

--- a/frontend/app/polyglot-lemma/[id].tsx
+++ b/frontend/app/polyglot-lemma/[id].tsx
@@ -502,7 +502,6 @@ const styles = StyleSheet.create({
   gloss: {
     fontSize: POLYGLOT_TYPE.gloss,
     fontFamily: POLYGLOT_FONTS.greekDisplay,
-    fontStyle: "italic",
     marginTop: 6,
     color: POLYGLOT_COLORS.text,
   },
@@ -523,7 +522,6 @@ const styles = StyleSheet.create({
   },
   chipGreek: {
     fontFamily: POLYGLOT_FONTS.greekDisplay,
-    fontStyle: "italic",
     fontSize: 13,
   },
 
@@ -623,7 +621,6 @@ const styles = StyleSheet.create({
   },
   stageNote: {
     fontSize: POLYGLOT_TYPE.meta,
-    fontStyle: "italic",
     color: POLYGLOT_COLORS.textSecondary,
     marginTop: 4,
     lineHeight: 17,
@@ -683,7 +680,6 @@ const styles = StyleSheet.create({
   qtext: {
     fontFamily: POLYGLOT_FONTS.greekDisplay,
     fontSize: 17,
-    fontStyle: "italic",
     color: POLYGLOT_COLORS.text,
     lineHeight: 23,
   },
@@ -763,7 +759,6 @@ const styles = StyleSheet.create({
   emptyHintText: {
     fontSize: POLYGLOT_TYPE.bodySmall,
     color: POLYGLOT_COLORS.textTertiary,
-    fontStyle: "italic",
     textAlign: "center",
   },
 });

--- a/frontend/app/polyglot-review.tsx
+++ b/frontend/app/polyglot-review.tsx
@@ -844,14 +844,14 @@ const styles = StyleSheet.create({
     color: C.textMuted, marginTop: 6,
   },
   introHeroGloss: {
-    fontSize: 20, fontFamily: POLYGLOT_FONTS.greekDisplay, fontStyle: "italic", color: C.text,
+    fontSize: 21, fontFamily: POLYGLOT_FONTS.greekBody, color: C.text,
   },
   introChips: {
     flexDirection: "row", gap: 5, marginTop: 10, flexWrap: "wrap", justifyContent: "center",
   },
   introChip: { paddingHorizontal: 9, paddingVertical: 4, borderRadius: POLYGLOT_RADIUS.chip },
   introChipText: { fontSize: 11, fontWeight: "600" },
-  introChipGreek: { fontFamily: POLYGLOT_FONTS.greekDisplay, fontStyle: "italic", fontSize: 13 },
+  introChipGreek: { fontFamily: POLYGLOT_FONTS.greekDisplay, fontSize: 13 },
   introRescueHint: {
     color: POLYGLOT_COLORS.warning, fontSize: 12, marginTop: 6, textAlign: "center",
   },
@@ -884,19 +884,19 @@ const styles = StyleSheet.create({
   },
   miniMeaning: { fontSize: 10, color: C.textDim, textAlign: "center", lineHeight: 13 },
   introQuoteText: {
-    fontFamily: POLYGLOT_FONTS.greekDisplay, fontSize: 17, fontStyle: "italic",
-    color: C.text, lineHeight: 23, marginTop: 2,
+    fontFamily: POLYGLOT_FONTS.greekBody, fontSize: 18,
+    color: C.text, lineHeight: 25, marginTop: 2,
   },
   introQuoteSource: {
     fontSize: 10, letterSpacing: 0.8, textTransform: "uppercase",
     color: C.textMuted, marginTop: 4,
   },
-  introQuoteTrans: { fontSize: 12, color: C.textDim, marginTop: 4, fontStyle: "italic" },
+  introQuoteTrans: { fontSize: 12, color: C.textDim, marginTop: 4 },
   viewDetailsRow: { alignSelf: "center", paddingVertical: 8 },
   viewDetailsLink: { color: C.accent, fontSize: 13, fontWeight: "600" },
   sentenceGreek: {
-    color: C.text, fontSize: 30, lineHeight: 46, textAlign: "left",
-    fontFamily: POLYGLOT_FONTS.greekDisplay, letterSpacing: 0.2,
+    color: C.text, fontSize: 32, lineHeight: 48, textAlign: "left",
+    fontFamily: POLYGLOT_FONTS.greekBody, letterSpacing: 0.2,
   },
   missedWord: {
     color: C.missed,
@@ -913,8 +913,8 @@ const styles = StyleSheet.create({
   answerSectionHidden: { opacity: 0 },
   divider: { height: 1, width: 48, backgroundColor: C.textMuted, marginBottom: 16 },
   sentenceEnglish: {
-    color: C.textDim, fontSize: 20, lineHeight: 28, textAlign: "left",
-    fontFamily: POLYGLOT_FONTS.greekDisplay, fontStyle: "italic",
+    color: C.textDim, fontSize: 21, lineHeight: 29, textAlign: "left",
+    fontFamily: POLYGLOT_FONTS.greekBody,
   },
   /* Tapped-word lookup card slot — sits below the sentence inside the same
    * sentence-card container. The PolyglotLookupCard component carries its

--- a/frontend/app/polyglot-stats.tsx
+++ b/frontend/app/polyglot-stats.tsx
@@ -550,7 +550,7 @@ const s = StyleSheet.create({
   },
   cardTitle: { color: C.text, fontSize: 14, fontWeight: "600" },
   cardSub: { color: C.textDim, fontSize: 12 },
-  emptyText: { color: C.textDim, fontStyle: "italic", fontSize: 13 },
+  emptyText: { color: C.textDim, fontSize: 13 },
 
   // Today tiles
   tileGrid: { flexDirection: "row", flexWrap: "wrap", gap: 10 },
@@ -667,5 +667,5 @@ const s = StyleSheet.create({
   activityTime: { color: C.textFaint, fontSize: 10, marginTop: 2 },
 
   error: { color: C.unknown, padding: 20 },
-  footer: { color: C.textFaint, fontSize: 11, marginTop: 14, fontStyle: "italic", textAlign: "center" },
+  footer: { color: C.textFaint, fontSize: 11, marginTop: 14, textAlign: "center" },
 });

--- a/frontend/lib/polyglot-design-tokens.ts
+++ b/frontend/lib/polyglot-design-tokens.ts
@@ -11,7 +11,7 @@
  *
  * Why a separate file instead of frontend/lib/theme.ts: theme.ts is Alif's
  * Arabic palette (dark surface, Arabic font stack). Polyglot is the opposite
- * aesthetic: light surface, Cormorant Garamond for Greek, color-coded eras.
+ * aesthetic: light surface, EB Garamond for Greek, color-coded eras.
  *
  * Color/spacing/type constants live in polyglot-design-colors.ts (pure, no RN
  * imports — Jest can read them). Font fallbacks need Platform and live here.
@@ -29,23 +29,23 @@ export {
 export type { PolyglotEra } from "./polyglot-design-colors";
 
 /**
- * Type scale. Greek display forms use Cormorant Garamond on iOS (loaded via
- * Expo Font at app boot); falls back to system serif elsewhere. Body text is
- * the system sans on iOS, sans-serif otherwise.
+ * Greek faces. Both display and body are EB Garamond, registered in
+ * app/_layout.tsx via @expo-google-fonts/eb-garamond. expo-font registers each
+ * weight under its exact JS-constant name on iOS / Android / web alike, so we
+ * reference those keys directly. (The previous "Cormorant Garamond" string was
+ * never registered anywhere, so Greek silently fell back to Georgia/system — the
+ * bug this replaces. There is no Platform.select here on purpose: the registered
+ * family name is identical across platforms.)
+ *
+ * EB Garamond carries Greek (monotonic + most polytonic) and Latin, covering
+ * all three Polyglot languages. No italic face is loaded — Polyglot never
+ * renders italic Greek, because the faux-slant of an upright face looks wrong.
+ * Use weight for emphasis: greekDisplay (SemiBold) for headline forms,
+ * greekBody (Regular) for sentence reading and translations.
  */
 export const POLYGLOT_FONTS = {
-  greekDisplay: Platform.select({
-    ios: "Cormorant Garamond",
-    android: "serif",
-    default: "'Cormorant Garamond', 'EB Garamond', Georgia, serif",
-  }),
-  // Body Greek (sentence rendering inside reader / review). Georgia has full
-  // polytonic coverage on iOS; system serif elsewhere.
-  greekBody: Platform.select({
-    ios: "Georgia",
-    android: "serif",
-    default: "Georgia, 'Noto Serif', serif",
-  }),
+  greekDisplay: "EBGaramond_600SemiBold",
+  greekBody: "EBGaramond_400Regular",
   uiSans: Platform.select({
     ios: "System",
     android: "sans-serif",

--- a/frontend/lib/polyglot-lookup-card.tsx
+++ b/frontend/lib/polyglot-lookup-card.tsx
@@ -213,7 +213,6 @@ const styles = StyleSheet.create({
     fontFamily: POLYGLOT_FONTS.greekBody,
     fontSize: POLYGLOT_TYPE.body,
     color: POLYGLOT_COLORS.textTertiary,
-    fontStyle: "italic",
   },
   posPill: {
     backgroundColor: POLYGLOT_COLORS.surfaceMuted,
@@ -249,7 +248,6 @@ const styles = StyleSheet.create({
     fontSize: POLYGLOT_TYPE.glossInline,
     color: POLYGLOT_COLORS.text,
     fontFamily: POLYGLOT_FONTS.greekDisplay,
-    fontStyle: "italic",
   },
   metaRow: {
     flexDirection: "row",
@@ -277,13 +275,11 @@ const styles = StyleSheet.create({
     fontFamily: POLYGLOT_FONTS.greekDisplay,
     fontSize: 16,
     color: POLYGLOT_COLORS.cognate,
-    fontStyle: "italic",
   },
   driftPeek: {
     flex: 1,
     fontSize: POLYGLOT_TYPE.bodySmall,
     color: POLYGLOT_COLORS.textSecondary,
-    fontStyle: "italic",
   },
   quoteBlock: {
     paddingHorizontal: 12,
@@ -297,7 +293,6 @@ const styles = StyleSheet.create({
   quoteText: {
     fontFamily: POLYGLOT_FONTS.greekDisplay,
     fontSize: 17,
-    fontStyle: "italic",
     color: POLYGLOT_COLORS.text,
     lineHeight: 22,
   },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@expo-google-fonts/amiri": "^0.4.1",
+        "@expo-google-fonts/eb-garamond": "^0.4.2",
         "@expo-google-fonts/noto-naskh-arabic": "^0.4.5",
         "@expo-google-fonts/noto-sans": "^0.4.2",
         "@expo-google-fonts/scheherazade-new": "^0.4.2",
@@ -1553,6 +1554,12 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@expo-google-fonts/amiri/-/amiri-0.4.1.tgz",
       "integrity": "sha512-JTZUZ4olyqGeXu5UBWVEerrbym/MD9U3wU8qzSg8z4qEtHFKAI3uPg2DuytfeRmJ6EppaHLYsYqpGerMOrpJeA==",
+      "license": "MIT AND OFL-1.1"
+    },
+    "node_modules/@expo-google-fonts/eb-garamond": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@expo-google-fonts/eb-garamond/-/eb-garamond-0.4.2.tgz",
+      "integrity": "sha512-tkw/RNj3sLpOfasAYF1wrh8XnKspHXmoNf6StJ4LDvFlRpDCXXtG8sxkyjab1ncnlgK8iRUC8FugmYMr55YCHw==",
       "license": "MIT AND OFL-1.1"
     },
     "node_modules/@expo-google-fonts/noto-naskh-arabic": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@expo-google-fonts/amiri": "^0.4.1",
+    "@expo-google-fonts/eb-garamond": "^0.4.2",
     "@expo-google-fonts/noto-naskh-arabic": "^0.4.5",
     "@expo-google-fonts/noto-sans": "^0.4.2",
     "@expo-google-fonts/scheherazade-new": "^0.4.2",


### PR DESCRIPTION
## Why

The polyglot sentence-review screen looked "ugly and hard to read." Root cause: the Greek display font was **never loaded**. `polyglot-design-tokens.ts` named `"Cormorant Garamond"`, but `_layout.tsx`'s single `useFonts` call only registered the Arabic faces — and no `@expo-google-fonts/cormorant-garamond` was installed. So Greek silently fell back to **Georgia** (web) / **system sans** (iOS). The design was tuned against a font the app didn't have.

## What changed

- **Load EB Garamond for real** — `@expo-google-fonts/eb-garamond` (400 + 600), registered in the app-wide `useFonts`. Styles reference the registered family names `EBGaramond_400Regular` / `EBGaramond_600SemiBold` — the same mechanism Alif already uses for Arabic. The broken `Platform.select` Greek entries are gone (the registered name is identical across iOS/Android/web).
- **Display vs body split** — `greekDisplay` → SemiBold (headline forms), `greekBody` → Regular (sentence reading + translations). With `@expo-google-fonts`, weight is a separately-registered family, not a `fontWeight` prop.
- **Sentence** now uses the regular reading face at 32/48 (was the display face at 30/46); translation at 21/29.
- **No italic anywhere** on the polyglot Greek surfaces (review screen, lookup card, lemma detail, stats). No italic face is loaded, so an italic style would only faux-slant the upright face.

## How it was chosen

Picked via design-explorer across 9 candidates (Gentium Book Plus, GFS Didot, GFS Neohellenic, Noto Serif, Literata, EB Garamond, Cardo, Cormorant, and a Georgia "current reality" baseline). The mockups `@import` the real font and include an Ancient-Greek polytonic + Latin strip, so coverage across all three target languages was visible — fixing the prior round's mockups, which named the font without loading it and secretly compared Georgia.

The reader (`polyglot.tsx`) keeps its own Georgia serif and is unchanged — it never used the broken token. It can get an EB Garamond pass later if desired.

tsc clean; polyglot frontend tests pass (38/38).