### PR TITLE
Polyglot cron: 3x sentence-generation throughput (warm cache 16→48 lemmas/run)

### DIFF
--- a/polyglot/deploy/polyglot-update-material.sh
+++ b/polyglot/deploy/polyglot-update-material.sh
@@ -44,9 +44,17 @@ VENV="${POLYGLOT_PYTHON:-$WORKDIR/.venv/bin/python3}"
 PYTHONPATH_VALUE="${PYTHONPATH:-/opt/limbic}"
 
 LANGUAGE="${POLYGLOT_WARM_LANGUAGE:-el}"
-MAX_LEMMAS="${POLYGLOT_WARM_MAX_LEMMAS:-16}"
+# 2026-05-22: bumped 16→48. With the picker now strictly preferring generated
+# sentences over book fallbacks, the engaged-vocabulary pool (~2.1k active
+# lemmas) had only ~98 LLM sentences — 1,890 active lemmas had zero generated
+# coverage. At 16 lemmas/run × 8 runs/day the backlog cleared too slowly. 48 ×
+# 8 = ~384 lemma-attempts/day (×SENTENCES_PER_TARGET), clearing the backlog in
+# days while comfortably keeping up with new acquiring words (≤30/day cap).
+MAX_LEMMAS="${POLYGLOT_WARM_MAX_LEMMAS:-48}"
 SENTENCES_PER_TARGET="${POLYGLOT_WARM_SENTENCES_PER_TARGET:-2}"
-TIMEOUT_SECONDS="${POLYGLOT_WARM_TIMEOUT_SECONDS:-1200}"
+# 1200→1800: 48 lemmas / BATCH_WORD_SIZE=4 = 12 Sonnet+Haiku batches; at up to
+# ~2 min/batch worst case that's ~24 min, so give the phase 30 min of headroom.
+TIMEOUT_SECONDS="${POLYGLOT_WARM_TIMEOUT_SECONDS:-1800}"
 PAGES_BUFFER="${POLYGLOT_PAGES_AHEAD_BUFFER:-5}"
 PAGES_MAX_PER_RUN="${POLYGLOT_PAGES_AHEAD_MAX_PER_RUN:-5}"
 PAGES_TIMEOUT_SECONDS="${POLYGLOT_PAGES_AHEAD_TIMEOUT_SECONDS:-1200}"


### PR DESCRIPTION
Follow-up to #133. The strict generated-over-book picker tier made thin LLM coverage visible: prod has ~2,153 active-study lemmas but only **98 generated sentences** — **1,890 active lemmas have zero LLM coverage** (62 of 117 currently-acquiring words among them). At 16 lemmas/run × 8 cron runs/day the backlog cleared too slowly, so most due words showed (now-translated) book fallbacks instead of the preferred novel generated context.

Bumps in `deploy/polyglot-update-material.sh`:
- `POLYGLOT_WARM_MAX_LEMMAS` 16 → 48
- `POLYGLOT_WARM_TIMEOUT_SECONDS` 1200 → 1800 (12 Sonnet+Haiku batches at ~2 min worst case)

~384 lemma-attempts/day clears the backlog in days and stays ahead of the ≤30/day new-acquiring cap. Both stay env-overridable. A larger one-time catch-up generation run is being kicked separately.