### PR TITLE
Frontend: fix REPLACE-not-handled crash on language switch + strip picker subtitles

### DIFF
--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -308,14 +308,17 @@ function LayoutInner({ online }: { online: boolean }) {
                   style={styles.pickerRow}
                   onPress={() => {
                     setPickerOpen(false);
-                    if (opt.code !== language) {
-                      setLanguage(opt.code);
-                      router.replace(homePathFor(opt.code) as any);
-                    }
+                    // Only flip the language. The language-sync effect above
+                    // performs the navigation on the next render, after the
+                    // target tab's href has switched from null to active and the
+                    // route is registered. Calling router.replace synchronously
+                    // here raced that href flip — the destination tab (e.g.
+                    // polyglot-review) was still href:null, so expo-router emitted
+                    // a raw REPLACE no navigator could handle.
+                    if (opt.code !== language) setLanguage(opt.code);
                   }}
                 >
                   <Text style={styles.pickerNative}>{opt.native}</Text>
-                  <Text style={styles.pickerName}>{opt.name}</Text>
                   {active ? (
                     <Ionicons name="checkmark" size={18} color={colors.accent} />
                   ) : (
@@ -337,10 +340,10 @@ function LayoutInner({ online }: { online: boolean }) {
   );
 }
 
-const LANGUAGE_OPTIONS: { code: AppLanguage; native: string; name: string }[] = [
-  { code: "ar", native: "العربية", name: "Arabic" },
-  { code: "el", native: "Ελληνικά", name: "Greek" },
-  { code: "la", native: "Lingua Latina", name: "Latin" },
+const LANGUAGE_OPTIONS: { code: AppLanguage; native: string }[] = [
+  { code: "ar", native: "العربية" },
+  { code: "el", native: "Ελληνικά" },
+  { code: "la", native: "Lingua Latina" },
 ];
 
 const styles = StyleSheet.create({
@@ -410,11 +413,6 @@ const styles = StyleSheet.create({
     color: colors.text,
     fontSize: 18,
     fontWeight: "700",
-    minWidth: 78,
-  },
-  pickerName: {
-    color: colors.textSecondary,
-    fontSize: 13,
     flex: 1,
   },
   pickerCheckSpacer: {

--- a/frontend/app/languages.tsx
+++ b/frontend/app/languages.tsx
@@ -12,6 +12,7 @@
  * tab-bar visibility updates automatically because _layout.tsx subscribes to
  * the language context.
  */
+import { useEffect, useRef } from "react";
 import { View, Text, Pressable, StyleSheet, ScrollView } from "react-native";
 import { useRouter } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
@@ -51,10 +52,26 @@ export default function Languages() {
   const router = useRouter();
   const { language, setLanguage } = useLanguage();
 
+  // Navigate only after the language flip has re-rendered _layout's <Tabs>: by
+  // then the destination tab's href has switched from null to active and the
+  // route is registered. Replacing synchronously inside pick() raced that flip
+  // and produced "REPLACE … not handled by any navigator". /languages is a
+  // "shared" route, so _layout's own language-sync redirect skips it — hence
+  // this local deferral.
+  const pendingPath = useRef<string | null>(null);
+  useEffect(() => {
+    if (pendingPath.current) {
+      const path = pendingPath.current;
+      pendingPath.current = null;
+      router.replace(path as any);
+    }
+  }, [language, router]);
+
   const pick = (opt: LanguageOption) => {
+    if (opt.code === language) return;
+    // Replace (not push) so the back stack doesn't bounce between languages.
+    pendingPath.current = opt.primaryPath;
     setLanguage(opt.code);
-    // Replace so the back stack doesn't bounce the user between languages
-    router.replace(opt.primaryPath as any);
   };
 
   return (


### PR DESCRIPTION
## Problem
Switching language via the globe popover threw a dev-only console error and failed to navigate:

> The action 'REPLACE' with payload {"name":"polyglot-review"} was not handled by any navigator. Do you have a route named 'polyglot-review'?

## Cause
The popover handler called `setLanguage(opt.code)` then **synchronously** `router.replace(homePathFor(opt.code))`. Tabs are shown/hidden via `href` (`href: null` = unregistered). At the instant `replace` fires, React hasn't re-rendered with the new language, so the destination tab (e.g. `polyglot-review`) is still `href: null` and unregistered — expo-router emits a raw `REPLACE` no navigator can handle. This is the same race the cold-start comment in `_layout.tsx` already documents.

## Fix
- **Popover (`_layout.tsx`)**: only flip the language; the existing language-sync `useEffect` performs the navigation on the next render, after the `href` flip registers the target tab (the proven cold-start path).
- **`/languages` fallback screen**: it's a `"shared"` route the layout effect deliberately skips, so it gets a local deferred navigation — stash the target in a ref, navigate from an effect keyed on `language`.
- **Picker UI**: removed the English subtitle (`Arabic`/`Greek`/`Latin`) from picker rows per request; only the bold native script remains. Native text is now `flex: 1` so the active checkmark stays right-aligned.

## Verification
- `tsc --noEmit` passes
- `jest` language-isolation manifest tests pass (7/7)