### PR TITLE
Docs: Latin production deploy notes + Metro-cache deploy fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -228,10 +228,14 @@ ssh alif "cd /opt/alif && git pull && cd backend && .venv/bin/pip install -e . -
 ssh alif "cd /opt/alif/backend && .venv/bin/pip install -e . -q && systemctl restart alif-backend"
 
 # Deploy frontend (Expo dev server is a systemd service)
-ssh alif "cd /opt/alif && git pull && systemctl restart alif-expo"
+# NOTE: a bare `systemctl restart alif-expo` keeps Metro's transform cache and can
+# serve a STALE bundle (frontend code changes silently don't appear; symptom seen
+# 2026-05-25 — a screen showed the wrong language's data though source + backend
+# were correct). Clear the Metro cache too, then hard-reload the client:
+ssh alif "cd /opt/alif && git pull && rm -rf /tmp/metro-* /tmp/haste-map-* /opt/alif/frontend/node_modules/.cache /opt/alif/frontend/.expo && systemctl restart alif-expo"
 
 # Full deploy (both):
-ssh alif "cd /opt/alif && git pull && cd backend && .venv/bin/pip install -e . --no-deps -q && systemctl restart alif-backend && systemctl restart alif-expo"
+ssh alif "cd /opt/alif && git pull && cd backend && .venv/bin/pip install -e . --no-deps -q && systemctl restart alif-backend && rm -rf /tmp/metro-* /tmp/haste-map-* /opt/alif/frontend/node_modules/.cache /opt/alif/frontend/.expo && systemctl restart alif-expo"
 
 # Cron wrapper:
 # scripts/deploy.sh links /opt/alif-update-material.sh to deploy/alif-update-material.sh

--- a/IDEAS.md
+++ b/IDEAS.md
@@ -4,35 +4,40 @@
 
 ---
 
-## 🔵 [OPEN 2026-05-25] Polyglot: Latin as a second language (branch `sh/polyglot-latin`)
+## 🟢 [LIVE 2026-05-25] Polyglot: Latin as a second language (PR #140, deployed)
 
-Adding Latin alongside Modern Greek. Learner finished LLPSI Part 1 (Familia
-Romana); goal is to verify which of those ~1,800 words are still known (seed as
-assumed-known → confirm by collateral exposure), grow gradually with low daily
-effort, and read Eutropius. Full design + audits: `research/polyglot-latin-design-2026-05-25.md`.
+Latin alongside Modern Greek. Learner finished LLPSI Part 1 (Familia Romana);
+goal: verify which words are still known (seed as assumed-known → confirm by
+collateral exposure), grow gradually, read Eutropius. Full design + audits +
+production validation: `research/polyglot-latin-design-2026-05-25.md`.
 
-**Shipped on the branch:** language-scoped acquisition pacing aggregates (fixes a
-cross-language cap/recovery coupling found in the audit); LatinCy `la_core_web_lg`
-provider (simplemma fallback) behind the existing lemma-quality safety net;
-language-keyed philology eras (Latin Archaic→Neo-Latin); Latin generation
-function-words/scaffold (validator needed no change — lemmatizer-driven matching
-already handles Latin inflection); `scripts/import_latin_vocab.py` (DCC core +
-LLPSI assumed-known + Roma Aeterna learn-set); frontend `"la"` enablement.
+**Shipped + deployed to prod:** language-scoped acquisition pacing aggregates
+(fixed a cross-language cap/recovery coupling found in the audit); LatinCy
+`la_core_web_lg` provider (simplemma fallback) behind the lemma-quality safety
+net; unified macron-free / canonical display + citation-form canonicalization
+(facere→facio) at import; language-keyed philology eras; Latin generation
+function-words/scaffold (validator unchanged — lemmatizer-driven matching handles
+Latin inflection); `scripts/import_latin_vocab.py` + parsers; frontend `"la"`
+enablement; language-aware cron loop. **Seeded in prod:** 1,585 LLPSI
+assumed-known + 2,518 Roma Aeterna learn-frontier + Eutropius Book I (20 pages);
+cron `POLYGLOT_LANGUAGES=el la`.
 
-**Follow-ups (not yet done):**
-- **Seed the data**: drop DCC/LLPSI/Roma Aeterna files in `polyglot/data/vocab/`
-  (see its README) and run the importer. LLPSI is copyright (local-only).
-- **Eutropius reading text**: import the DCC-annotated Breviarium via paste/PDF
-  intake (`language_code='la'`) as the first reading material.
+**[DONE]** seed data · Eutropius reading text · deploy + LatinCy model install ·
+cron lane enabled.
+
+**Remaining follow-ups:**
 - **LatinCy quality-gate prompt**: add a Latin-specific warning to
   `lemma_quality.py` about the sentence-initial→PROPN failure mode (every
   sentence's first word is capitalized) and homograph flips (malum/malus),
-  mirroring the Greek homograph rule + Arabic feminine-ة CAMeL lesson.
-- **Deploy**: `pip install -e ".[la]"` pulls the LatinCy model (~0.5 GB) on the
-  server; add a Latin cron lane (warm-cache/translate/enrich) once vocab is seeded.
+  mirroring the Greek homograph rule + Arabic feminine-ة CAMeL lesson. Also the
+  observed `miliario`↛`miliarium` non-reduction.
+- **More reading texts**: only Eutropius Book I imported; add Books II–X, Nepos,
+  or Einhard via `/api/texts/paste` (split into pages).
+- **DCC core** (optional): never needed — LLPSI chapter order is the frequency
+  backbone. Drop `data/vocab/dcc_core.tsv` + re-run the importer if wanted.
 - **Leech sweeps** (`check_and_manage_leeches`, `check_leech_reintroductions`)
-  are global across languages — per-lemma-correct but could be language-scoped
-  for a per-language cron. Low priority.
+  are global across languages — per-lemma-correct but could be language-scoped.
+  Low priority.
 
 ## 🧹 [TRIAGE 2026-05-22] Five abandoned 2026-03-21 experiment PRs — evaluated against production data
 

--- a/polyglot/CLAUDE.md
+++ b/polyglot/CLAUDE.md
@@ -163,8 +163,33 @@ polyglot/deploy/deploy-polyglot.sh
 
 The script pushes `main` if needed, pulls `origin/main` in `/opt/alif`, links
 `/opt/polyglot-update-material.sh` to the repo copy under
-`/opt/alif/polyglot/deploy/`, reinstalls `polyglot-backend`, restarts
-`polyglot-backend`, and health-checks port `3002`.
+`/opt/alif/polyglot/deploy/`, reinstalls `polyglot-backend` (with `--no-deps`),
+restarts `polyglot-backend`, and health-checks port `3002`.
+
+**`deploy-polyglot.sh` does NOT install dependencies or extras** (`--no-deps`).
+New runtime deps / per-language NLP models must be installed separately, e.g.
+the Latin model: `ssh alif "cd /opt/alif/polyglot && .venv/bin/pip install spacy
+'https://huggingface.co/latincy/la_core_web_lg/resolve/main/la_core_web_lg-3.9.0-py3-none-any.whl'"`
+(~0.5 GB; use `nohup` + a log — `pip -q` can go quiet long enough to trip the
+SSH idle drop). Confirm with `GET /api/languages` → `provider_available:true`.
+
+### Frontend deploy — clear the Metro cache
+`systemctl restart alif-expo` restarts Metro but **keeps its transform cache**, so
+frontend code changes can keep serving a stale bundle (symptom: a screen shows
+the wrong language's data even though the source + backend are correct). After
+pulling frontend changes:
+`ssh alif "rm -rf /tmp/metro-* /tmp/haste-map-* /opt/alif/frontend/node_modules/.cache /opt/alif/frontend/.expo; systemctl restart alif-expo"`,
+then hard-reload the client. (Backend restarts don't have this issue.)
+
+### Seeding Latin on the server (one-time, done 2026-05-25)
+Data files are gitignored, so scp them to `data/vocab/` then run the importer
+(it canonicalizes through LatinCy, so install the model first). Set
+`DATABASE_URL` explicitly to avoid the `.env`-ordering trap that once hit
+`alif.db`. Enable the cron lane with a crontab env line `POLYGLOT_LANGUAGES=el la`
+(the wrapper loops languages sequentially — never add a parallel Latin cron, see
+the wrapper's lock comment). Reading texts are imported via `POST /api/texts/paste`
+(`language_code='la'`); split long texts into pages so the read-flow has
+boundaries (see `import_eutropius_pages.py` approach).
 
 ## Code style — same as Alif
 

--- a/polyglot/data/vocab/README.md
+++ b/polyglot/data/vocab/README.md
@@ -59,6 +59,27 @@ Phases run independently and are idempotent:
   acquisition. That is the "which words do I already know?" mechanism.
 
 Function words (per `lemma_quality.FUNCTION_WORD_SETS['la']`) are created as
-mappable lemmas but never enrolled as scaffold targets.
+mappable lemmas but never enrolled as scaffold targets. The importer
+canonicalizes citation forms through LatinCy (infinitive `facere` → lemma
+`facio`) so seeded lemmas match reading-time lemmatization — install the LatinCy
+model first (`pip install -e ".[la]"`) or pass `--no-canonicalize`.
+
+## Regenerate the TSVs from source
+
+These were produced by committed parsers (run them if you re-download the source):
+
+```bash
+.venv/bin/python scripts/parse_llpsi_pdf.py \
+    --pdf ~/Downloads/Lingua-Latina-Vocabulary.pdf --out data/vocab/llpsi_fr.tsv
+.venv/bin/python scripts/parse_roma_aeterna_apkg.py \
+    --apkg ~/Downloads/Lingua_Latina_II_-_Roma_Aeterna_Latin_to_English.apkg \
+    --out data/vocab/roma_aeterna.tsv
+```
+
+Reading texts (e.g. `eutropius_book1.txt`) are imported via `POST /api/texts/paste`
+(`language_code='la'`); split long texts into one page per section.
+
+**Production was seeded from these on 2026-05-25** (1,585 LLPSI assumed-known,
+2,518 Roma Aeterna learn-frontier, Eutropius Book I).
 
 This directory's source files are gitignored; only this README is tracked.

--- a/polyglot/deploy/polyglot-update-material.sh
+++ b/polyglot/deploy/polyglot-update-material.sh
@@ -8,8 +8,12 @@
 #
 #     45 */3 * * * /opt/polyglot-update-material.sh >> /var/log/polyglot-update-material.log 2>&1
 #
-# One pass per run, in order:
-#   1. warm_pages_ahead for Modern Greek (primary)
+# One pass per run: the 5 phases below run for EACH language in
+# POLYGLOT_LANGUAGES (default "el"; "el la" adds Latin), sequentially — one
+# language fully before the next, in this single process (lock-safe; see the
+# LANGUAGES comment below). Phase descriptions say "Modern Greek" but apply to
+# whichever language the loop is on. In order:
+#   1. warm_pages_ahead
 #      — keeps the next N (default 5) unread pages of every active story
 #        already through the quality gate, so the user never waits when
 #        flipping pages. Runs first because freshly verified pages are the

--- a/research/polyglot-latin-design-2026-05-25.md
+++ b/research/polyglot-latin-design-2026-05-25.md
@@ -141,16 +141,29 @@ fallback. Remaining Latin-specific seams: lemmatizer wiring (done), philology er
 taxonomy (Greek-hardcoded), generation function-word/scaffold lists, the vocab
 importer, and the frontend `"ar"|"el"` → `+"la"` generalization.
 
-## 5. Implementation status
+## 5. Implementation status — LIVE in production (2026-05-25, PR #140)
 
-- [x] Cross-language pacing leakage fixed + tested (commit 1).
-- [x] LatinCy wired into `la.py` (primary + simplemma fallback, normalization,
-      enclitics-to-gate), fast + slow tests green (commit 2).
-- [ ] Philology era taxonomy language-keyed (Latin eras).
-- [ ] Latin generation seams (function words, scaffold, validator, gate prompt).
-- [ ] Latin vocab importer (DCC + LLPSI + RA).
-- [ ] Eutropius reading-text import.
-- [ ] Frontend Latin enablement.
+- [x] Cross-language pacing leakage fixed + tested.
+- [x] LatinCy wired into `la.py` (primary + simplemma fallback, normalization).
+- [x] Philology era taxonomy language-keyed (Latin eras).
+- [x] Latin generation seams (function words, scaffold; validator unchanged).
+- [x] Latin vocab importer (LLPSI + Roma Aeterna; DCC optional/unused) + parsers.
+- [x] Unified macron-free display + citation-form canonicalization.
+- [x] Frontend Latin enablement; language-aware cron loop.
+- [x] **Deployed**: PR #140 merged → server on `main`; LatinCy model installed;
+      seeded 1,585 LLPSI assumed-known + 2,518 Roma Aeterna learn-frontier;
+      Eutropius Book I (20 pages) imported + page-1 verified; cron
+      `POLYGLOT_LANGUAGES=el la`; frontend live (Metro cache cleared).
+- [ ] Remaining (see IDEAS.md): Latin `lemma_quality` gate-prompt note
+      (sentence-initial→PROPN, homographs, `miliario` non-reduction); more
+      reading texts; optional per-language leech scoping.
+
+**Deploy gotcha learned:** `systemctl restart alif-expo` keeps Metro's transform
+cache → stale frontend bundle (the Latin Stats screen showed Greek's 145 acquiring
+from a cached pre-fix bundle, though the backend correctly returned 0). Clear
+`/tmp/metro-* /tmp/haste-map-* frontend/node_modules/.cache frontend/.expo` then
+restart + hard-reload. Also: `deploy-polyglot.sh` uses `pip install --no-deps`, so
+the LatinCy model is installed separately.
 
 ## Display + canonicalization policy (decided 2026-05-25, with real data)
 


### PR DESCRIPTION
Post-deploy documentation for the Latin launch (PR #140, live in prod). Docs only.

- polyglot/CLAUDE.md: LatinCy model install (deploy script is --no-deps), server seeding, POLYGLOT_LANGUAGES cron env, frontend Metro-cache-clear.
- CLAUDE.md (root): frontend deploy clears the Metro cache (a bare restart serves a stale bundle — Latin Stats showed Greek's count from a cached pre-fix bundle).
- IDEAS.md: Latin marked LIVE; follow-ups updated.
- cron wrapper header: per-language loop documented.
- research design doc: deployed status + prod seed counts + Metro gotcha.
- data/vocab/README: parser regeneration commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)