### PR TITLE
Polyglot: Latin-specific lemma-quality gate prompt (PROPN / homographs / non-reduction)

### DIFF
--- a/IDEAS.md
+++ b/IDEAS.md
@@ -26,11 +26,17 @@ cron `POLYGLOT_LANGUAGES=el la`.
 cron lane enabled.
 
 **Remaining follow-ups:**
-- **LatinCy quality-gate prompt**: add a Latin-specific warning to
-  `lemma_quality.py` about the sentence-initial→PROPN failure mode (every
-  sentence's first word is capitalized) and homograph flips (malum/malus),
-  mirroring the Greek homograph rule + Arabic feminine-ة CAMeL lesson. Also the
-  observed `miliario`↛`miliarium` non-reduction.
+- **[DONE 2026-05-25]** **LatinCy quality-gate prompt**: `lemma_quality.py`'s
+  gate prompt is now language-aware (`_LANG_PITFALLS` / `_LANG_CITATION_HINT`,
+  rendered by the extracted `_build_prompt`). The Latin block warns about the
+  sentence-initial→PROPN failure mode, homograph flips (malum/malus, bellum/
+  bellus, populus/populus), unreduced inflections (`miliario`↛`miliarium`), and
+  fused `-ne`/`-ve` enclitics; the Latin citation hint enforces the no-macron /
+  u-i / 1sg-nominative display policy (the generic "with diacritics" hint is
+  Greek-only now). Mirrors the Greek homograph rule + Arabic feminine-ة CAMeL
+  lesson: name the upstream lemmatizer's known systematic errors explicitly so
+  the gate hunts for them. Each language's block is isolated so Greek pitfalls
+  don't leak into Latin prompts (regression: `test_build_prompt_is_language_specific`).
 - **More reading texts**: only Eutropius Book I imported; add Books II–X, Nepos,
   or Einhard via `/api/texts/paste` (split into pages).
 - **DCC core** (optional): never needed — LLPSI chapter order is the frequency

--- a/polyglot/app/services/lemma_quality.py
+++ b/polyglot/app/services/lemma_quality.py
@@ -269,7 +269,7 @@ def verify_page_mappings(
     any_batch_failed = False
     for chunk_start in range(0, len(interesting), BATCH_SIZE):
         chunk = interesting[chunk_start:chunk_start + BATCH_SIZE]
-        verdicts = _call_claude(chunk, language_name=_LANG_DISPLAY[language_code])
+        verdicts = _call_claude(chunk, language_code)
         if verdicts is None:
             any_batch_failed = True
             log.warning("Page %d: batch %d returned no verdicts (LLM failure?)",
@@ -298,6 +298,56 @@ def verify_page_mappings(
 # ─── Internals ─────────────────────────────────────────────────────────────
 
 _LANG_DISPLAY = {"el": "Modern Greek", "grc": "Ancient Greek", "la": "Latin"}
+
+# Language-specific lemmatizer failure modes the gate must actively look for.
+# Mirrors Alif's CAMeL feminine-ة warning: when the upstream lemmatizer has a
+# known systematic error, name it explicitly so the LLM gate hunts for it
+# instead of rubber-stamping a morphologically-plausible-but-wrong lemma.
+# Keep each block to the failures the language's lemmatizer actually makes —
+# a Greek pitfall leaking into the Latin prompt is noise, and vice versa.
+_LANG_PITFALLS = {
+    "el": (
+        "- Homographs: e.g. χώρα (noun, country) vs χωρώ (verb, to fit) — pick by sentence role.\n"
+        "- All-caps headings often lack accents → the proposed lemma keeps the unaccented form. "
+        "Provide the standard accented citation form if you can identify it."
+    ),
+    "grc": (
+        "- Homographs: same surface, different lemma by sentence role — pick by syntax and meaning.\n"
+        "- Accent-stripped or all-caps forms → provide the standard citation form with accents "
+        "and breathing marks if you can identify it."
+    ),
+    "la": (
+        # LatinCy's documented failure modes (polyglot/CLAUDE.md § Latin).
+        "- Sentence-initial capitalization: every Latin sentence begins with a capital letter, "
+        "and LatinCy frequently mis-tags a capitalized sentence-initial COMMON word as a proper "
+        "noun (PROPN), leaving the inflected/capitalized surface as the lemma. If the first word "
+        "is an ordinary common word (verb, noun, adjective…), give its correct lower-case citation "
+        "form. Keep a proper-name lemma only for genuine names (people, places, peoples).\n"
+        "- Homographs differing by POS or declension: malum (noun, apple/evil) vs malus (adj, bad) "
+        "vs malus (noun, mast/apple-tree); bellum (noun, war) vs bellus (adj, pretty); populus "
+        "(people) vs populus (poplar). Pick by sentence role.\n"
+        "- Unreduced inflections: the lemmatizer sometimes leaves an inflected form as the lemma "
+        "(e.g. miliario instead of miliarium, or an ablative/dative left as-is). If the proposed "
+        "lemma is still inflected, give the citation form.\n"
+        "- Fused enclitics: -ne (question) and -ve (or) are sometimes left attached to the host "
+        "word (estne → sum). The lemma is the base word without the enclitic. (-que is usually "
+        "split correctly.)"
+    ),
+}
+
+# How `correct_lemma` should be spelled per language. Latin diverges: the
+# display policy is one convention — no macrons, u/i orthography, 1sg/nominative
+# citation form (polyglot/CLAUDE.md § Latin) — so the generic "with diacritics"
+# instruction (right for Greek) is actively wrong here.
+_LANG_CITATION_HINT = {
+    "el": "one word, with accents/diacritics",
+    "grc": "one word, with accents and breathing marks",
+    "la": (
+        "one word, standard dictionary citation form — no macrons, u not v, i not j, "
+        "verbs as 1st-person singular present (facio, not facere), nouns/adjectives as "
+        "nominative singular (consul, uita, bonus)"
+    ),
+}
 
 
 def _is_all_caps(surface: str) -> bool:
@@ -360,7 +410,38 @@ def _load_lemmas_for_words(db: Session, words: list[PageWord]) -> dict[int, Lemm
     return {l.lemma_id: l for l in db.query(Lemma).filter(Lemma.lemma_id.in_(ids)).all()}
 
 
-def _call_claude(chunk: list[TokenCheck], language_name: str) -> list[Verdict] | None:
+def _build_prompt(chunk: list[TokenCheck], language_code: str) -> str:
+    """Render the quality-gate prompt for one batch, with the failure-mode
+    warnings and citation-form convention specific to `language_code`."""
+    language_name = _LANG_DISPLAY.get(language_code, language_code)
+    citation_hint = _LANG_CITATION_HINT.get(language_code, "one word, with diacritics")
+    pitfalls = _LANG_PITFALLS.get(language_code, "")
+    items_block = "\n".join(
+        f"[{c.pageword_id}] sentence: «{c.sentence_context}»\n"
+        f"         surface: {c.surface}\n"
+        f"         proposed lemma: {c.proposed_lemma}"
+        + (f"  (gloss: {c.proposed_gloss})" if c.proposed_gloss else "")
+        for c in chunk
+    )
+    return f"""You are a {language_name} lemmatization quality gate. For each token below, the lemmatizer proposed a lemma. Check whether the proposed lemma is correct *in this sentence's context* (not just morphologically plausible).
+
+Rules:
+- verdict "ok": proposed lemma is the correct citation form for this surface in this sentence.
+- verdict "wrong": there's a clearly better citation form. Provide it in `correct_lemma` ({citation_hint}).
+- verdict "unclear": ambiguous or the surface isn't a real {language_name} word (typo, OCR garbage, foreign word, proper name where the lemma is fine as-is). Leave correct_lemma blank.
+
+Common pitfalls:
+{pitfalls}
+- Don't change a lemma just for style; only flag actual errors.
+
+Return one decision per token, keyed by the bracketed id. Skip nothing.
+
+Tokens:
+{items_block}
+"""
+
+
+def _call_claude(chunk: list[TokenCheck], language_code: str) -> list[Verdict] | None:
     """Single structured LLM call covering BATCH_SIZE tokens. Returns None on
     total LLM failure so callers can distinguish failure from empty-result."""
     schema = {
@@ -382,30 +463,7 @@ def _call_claude(chunk: list[TokenCheck], language_name: str) -> list[Verdict] |
         },
         "required": ["decisions"],
     }
-    items_block = "\n".join(
-        f"[{c.pageword_id}] sentence: «{c.sentence_context}»\n"
-        f"         surface: {c.surface}\n"
-        f"         proposed lemma: {c.proposed_lemma}"
-        + (f"  (gloss: {c.proposed_gloss})" if c.proposed_gloss else "")
-        for c in chunk
-    )
-    prompt = f"""You are a {language_name} lemmatization quality gate. For each token below, the lemmatizer proposed a lemma. Check whether the proposed lemma is correct *in this sentence's context* (not just morphologically plausible).
-
-Rules:
-- verdict "ok": proposed lemma is the correct citation form for this surface in this sentence.
-- verdict "wrong": there's a clearly better citation form. Provide it in `correct_lemma` (one word, with accents/diacritics).
-- verdict "unclear": ambiguous or the surface isn't a real {language_name} word (typo, OCR garbage, foreign word, proper name where the lemma is fine as-is). Leave correct_lemma blank.
-
-Common pitfalls:
-- Homographs: e.g. Modern Greek χώρα (noun, country) vs χωρώ (verb, to fit) — pick by sentence role.
-- All-caps headings often lack accents → proposed lemma keeps the unaccented form. Provide the standard accented citation form if you can identify it.
-- Don't change a lemma just for style; only flag actual errors.
-
-Return one decision per token, keyed by the bracketed id. Skip nothing.
-
-Tokens:
-{items_block}
-"""
+    prompt = _build_prompt(chunk, language_code)
     structured = call_structured_json(
         prompt=prompt,
         schema=schema,

--- a/polyglot/tests/test_lemma_quality.py
+++ b/polyglot/tests/test_lemma_quality.py
@@ -27,7 +27,7 @@ def test_apply_ok_verdict_stamps_verified(tmp_db, force_gate_enabled, monkeypatc
         monkeypatch.setattr(lemma_quality, "QUALITY_GATE_ENABLED", True)
 
         # Mock Claude → every token is OK
-        def fake_call(chunk, language_name):
+        def fake_call(chunk, language_code):
             return [Verdict(pageword_id=c.pageword_id, verdict="ok") for c in chunk]
         monkeypatch.setattr(lemma_quality, "_call_claude", fake_call)
 
@@ -54,7 +54,7 @@ def test_apply_wrong_verdict_creates_or_links_lemma(tmp_db, force_gate_enabled, 
         word.lemma_id = wrong.lemma_id
         db.commit()
 
-        def fake_call(chunk, language_name):
+        def fake_call(chunk, language_code):
             return [Verdict(pageword_id=c.pageword_id, verdict="wrong",
                             correct_lemma="χώρα", reason="noun, not verb")
                     for c in chunk]
@@ -127,7 +127,7 @@ def test_apply_unclear_verdict_marks_but_doesnt_change(tmp_db, force_gate_enable
         word = db.query(PageWord).filter(PageWord.page_id == page.id).first()
         original_lemma_id = word.lemma_id
 
-        def fake_call(chunk, language_name):
+        def fake_call(chunk, language_code):
             return [Verdict(pageword_id=c.pageword_id, verdict="unclear",
                             reason="OCR garbage")
                     for c in chunk]
@@ -152,7 +152,7 @@ def test_skips_function_words(tmp_db, force_gate_enabled, monkeypatch):
         page, _ = reading_intake.get_page_view(db, story.id, 1)
 
         calls = []
-        def fake_call(chunk, language_name):
+        def fake_call(chunk, language_code):
             calls.append(chunk)
             return [Verdict(pageword_id=c.pageword_id, verdict="ok") for c in chunk]
         monkeypatch.setattr(lemma_quality, "_call_claude", fake_call)
@@ -172,7 +172,7 @@ def test_skips_se_article_crasis_function_words(tmp_db, force_gate_enabled, monk
         page, _ = reading_intake.get_page_view(db, story.id, 1)
 
         calls = []
-        def fake_call(chunk, language_name):
+        def fake_call(chunk, language_code):
             calls.append(chunk)
             return [Verdict(pageword_id=c.pageword_id, verdict="ok") for c in chunk]
         monkeypatch.setattr(lemma_quality, "_call_claude", fake_call)
@@ -204,7 +204,7 @@ def test_skipped_when_already_verified(tmp_db, force_gate_enabled, monkeypatch):
         page, _ = reading_intake.get_page_view(db, story.id, 1)
 
         calls = []
-        def fake_call(chunk, language_name):
+        def fake_call(chunk, language_code):
             calls.append(chunk)
             return [Verdict(pageword_id=c.pageword_id, verdict="ok") for c in chunk]
         monkeypatch.setattr(lemma_quality, "_call_claude", fake_call)
@@ -228,7 +228,7 @@ def test_llm_failure_leaves_page_unverified(tmp_db, force_gate_enabled, monkeypa
         assert page.mappings_verified_at is None
         monkeypatch.setattr(lemma_quality, "QUALITY_GATE_ENABLED", True)
 
-        monkeypatch.setattr(lemma_quality, "_call_claude", lambda chunk, language_name: None)
+        monkeypatch.setattr(lemma_quality, "_call_claude", lambda chunk, language_code: None)
         monkeypatch.setenv("POLYGLOT_QG_SKIP_IDENTITY", "0")
 
         corrected = lemma_quality.verify_page_mappings(db, page, force=True)
@@ -252,9 +252,35 @@ def test_empty_llm_decisions_count_as_failure(monkeypatch):
             proposed_gloss="book",
             sentence_context="το βιβλίο",
         )
-    ], "Modern Greek")
+    ], "el")
 
     assert verdicts is None
+
+
+def test_build_prompt_is_language_specific():
+    """Each language's prompt must carry its own lemmatizer failure-mode
+    warnings and citation convention, and must NOT leak another language's."""
+    chunk = [TokenCheck(
+        pageword_id=1, surface="Malum", proposed_lemma="Malum",
+        proposed_gloss=None, sentence_context="Malum est arbor.",
+    )]
+
+    la = lemma_quality._build_prompt(chunk, "la")
+    assert "Latin lemmatization quality gate" in la
+    assert "proper noun" in la.lower()       # sentence-initial → PROPN warning
+    assert "malum" in la                      # homograph example
+    assert "miliarium" in la                  # non-reduction example
+    assert "-ne" in la                        # fused enclitic warning
+    assert "no macrons" in la                 # Latin citation convention
+    assert "χώρα" not in la                    # no Greek leakage
+    assert "with accents/diacritics" not in la
+
+    el = lemma_quality._build_prompt(chunk, "el")
+    assert "Modern Greek lemmatization quality gate" in el
+    assert "χώρα" in el                        # Greek homograph example
+    assert "with accents/diacritics" in el
+    assert "miliarium" not in el              # no Latin leakage
+    assert "no macrons" not in el
 
 
 def test_partial_batch_failure_leaves_page_unverified(tmp_db, force_gate_enabled, monkeypatch):
@@ -271,7 +297,7 @@ def test_partial_batch_failure_leaves_page_unverified(tmp_db, force_gate_enabled
 
         call_count = {"n": 0}
 
-        def fake_call(chunk, language_name):
+        def fake_call(chunk, language_code):
             call_count["n"] += 1
             if call_count["n"] == 1:
                 return [Verdict(pageword_id=c.pageword_id, verdict="ok") for c in chunk]
@@ -317,7 +343,7 @@ def test_all_caps_surface_bypasses_identity_skip(tmp_db, force_gate_enabled, mon
 
         chunks_seen = []
 
-        def fake_call(chunk, language_name):
+        def fake_call(chunk, language_code):
             chunks_seen.extend(chunk)
             return [Verdict(pageword_id=c.pageword_id, verdict="wrong",
                             correct_lemma="πολιτισμός", reason="add accent")
@@ -346,7 +372,7 @@ def test_heading_sentence_words_excluded_from_batch(tmp_db, force_gate_enabled, 
 
         chunks_seen = []
 
-        def fake_call(chunk, language_name):
+        def fake_call(chunk, language_code):
             chunks_seen.extend(chunk)
             return [Verdict(pageword_id=c.pageword_id, verdict="ok") for c in chunk]
 


### PR DESCRIPTION
## What

The per-page lemma quality gate (`polyglot/app/services/lemma_quality.py`) sent **every** language the same prompt, hardcoded with Modern Greek pitfalls (χώρα/χωρώ, all-caps accent loss). That guidance is actively *wrong* for Latin, whose lemmatizer (LatinCy) has a different set of systematic errors.

This makes the prompt language-aware: extract `_build_prompt(chunk, language_code)` and drive its pitfalls + citation convention from `_LANG_PITFALLS` / `_LANG_CITATION_HINT`.

## Why this shape

Mirrors Alif's CAMeL feminine-ة lesson: when an upstream lemmatizer has a *known systematic* error, name it explicitly in the gate prompt so the LLM hunts for it rather than rubber-stamping a morphologically-plausible-but-wrong lemma. LatinCy's failure modes are documented in `polyglot/CLAUDE.md § Latin`; this surfaces them to the gate:

- sentence-initial capital mis-tagged as PROPN (every Latin sentence starts capitalized)
- homograph flips by POS/declension (malum/malus, bellum/bellus, populus/populus)
- unreduced inflections (`miliario`↛`miliarium`, stray ablative/dative)
- fused `-ne`/`-ve` enclitics

The Latin citation hint also enforces the no-macron / u-i / 1sg-nominative **display policy**; the generic "with diacritics" hint is now Greek-only.

## Scope / safety

- Greek + Ancient-Greek prompt behavior is unchanged (el block kept to its original two pitfalls).
- `_call_claude` now takes `language_code` instead of the display name; the single production call site and all test mocks updated.
- Each language's warnings stay isolated — regression `test_build_prompt_is_language_specific` asserts no cross-leakage.
- Closes the deferred follow-up tracked in `IDEAS.md` (LatinCy quality-gate prompt).

All 17 `test_lemma_quality.py` tests pass.