### PR TITLE
Polyglot picker: no textbook fallback for acquiring lemmas

### DIFF
--- a/polyglot/app/services/sentence_selector.py
+++ b/polyglot/app/services/sentence_selector.py
@@ -106,6 +106,14 @@ RECENT_SENTENCE_PENALTY = 0.25
 # material catches up, but they should not dominate a review session. Keep the
 # cap deliberately small: a short session may still show one fallback; normal
 # sessions show at most two.
+#
+# **Hard rule (user feedback 2026-05-26):** textbook sentences are NEVER
+# served for `acquiring` (Box 1/2/3) lemmas, regardless of this cap. Book
+# prose is syntactically and lexically beyond early-learning comprehensibility
+# — using it to practice a just-tapped-red word ruins the experience. Acquiring
+# lemmas wait for an LLM sentence or get skipped from the session. The cap
+# below still gates textbook fallbacks for FSRS-carded lemmas where the word
+# is already well-learned.
 TEXTBOOK_FALLBACK_SOURCES = frozenset({"textbook"})
 TEXTBOOK_FALLBACK_MAX_PER_SESSION = 2
 
@@ -806,13 +814,16 @@ def build_session(
     textbook_fallback_limit = _textbook_fallback_limit(limit)
     textbook_fallback_count = 0
 
-    def _pick_for_session(lemma_id: int) -> Optional[SentencePayload]:
+    def _pick_for_session(
+        lemma_id: int, *, allow_textbook: bool
+    ) -> Optional[SentencePayload]:
         nonlocal textbook_fallback_count
-        exclude_sources = (
-            set(TEXTBOOK_FALLBACK_SOURCES)
-            if textbook_fallback_count >= textbook_fallback_limit
-            else None
-        )
+        # Acquiring lemmas never get textbook fallbacks (see TEXTBOOK_FALLBACK_
+        # SOURCES docstring). FSRS-carded lemmas can, up to the session cap.
+        if not allow_textbook or textbook_fallback_count >= textbook_fallback_limit:
+            exclude_sources: Optional[set[str]] = set(TEXTBOOK_FALLBACK_SOURCES)
+        else:
+            exclude_sources = None
         payload = pick_sentence_for_lemma(
             db,
             lemma_id=lemma_id,
@@ -828,7 +839,9 @@ def build_session(
     for ulk, lemma in acquiring:
         if len(selected) >= limit:
             break
-        payload = _pick_for_session(lemma.lemma_id)
+        # Acquiring = no textbook fallback. Skip the lemma if no LLM sentence
+        # exists yet; the warm cache will eventually catch up.
+        payload = _pick_for_session(lemma.lemma_id, allow_textbook=False)
         if payload is None:
             skipped_due.append(SkippedDueLemma(
                 lemma_id=lemma.lemma_id,
@@ -845,7 +858,7 @@ def build_session(
     for ulk, lemma, _due in fsrs:
         if len(selected) >= limit:
             break
-        payload = _pick_for_session(lemma.lemma_id)
+        payload = _pick_for_session(lemma.lemma_id, allow_textbook=True)
         if payload is None:
             skipped_due.append(SkippedDueLemma(
                 lemma_id=lemma.lemma_id,

--- a/polyglot/tests/test_sentence_selector.py
+++ b/polyglot/tests/test_sentence_selector.py
@@ -542,8 +542,11 @@ def test_session_picks_one_sentence_per_due_lemma(tmp_db):
         b = _seed_lemma(db, form="κόσμος")
         _seed_acquiring(db, a.lemma_id, box=1)
         _seed_acquiring(db, b.lemma_id, box=1)
-        sa = _seed_sentence(db, lemma_surfaces=[(a.lemma_id, "λόγος")], text="A")
-        sb = _seed_sentence(db, lemma_surfaces=[(b.lemma_id, "κόσμος")], text="B")
+        # Use source="llm": acquiring lemmas no longer accept textbook
+        # fallback (2026-05-26), and this test is about per-lemma picking,
+        # not source policy.
+        sa = _seed_sentence(db, lemma_surfaces=[(a.lemma_id, "λόγος")], text="A", source="llm")
+        sb = _seed_sentence(db, lemma_surfaces=[(b.lemma_id, "κόσμος")], text="B", source="llm")
         db.commit()
         bundle = build_session(db, language_code="el", limit=10)
         assert len(bundle.sentences) == 2
@@ -557,7 +560,7 @@ def test_session_skips_lemmas_without_eligible_sentences(tmp_db):
         b = _seed_lemma(db, form="κόσμος")  # no sentence → skipped
         _seed_acquiring(db, a.lemma_id)
         _seed_acquiring(db, b.lemma_id)
-        sa = _seed_sentence(db, lemma_surfaces=[(a.lemma_id, "λόγος")], text="A")
+        sa = _seed_sentence(db, lemma_surfaces=[(a.lemma_id, "λόγος")], text="A", source="llm")
         db.commit()
         bundle = build_session(db, language_code="el", limit=10)
         assert len(bundle.sentences) == 1
@@ -589,6 +592,7 @@ def test_session_dedupes_sentences(tmp_db):
             db,
             lemma_surfaces=[(a.lemma_id, "λόγος"), (b.lemma_id, "κόσμος")],
             text="λόγος κόσμος",
+            source="llm",
         )
         db.commit()
         bundle = build_session(db, language_code="el", limit=10)
@@ -636,10 +640,12 @@ def test_session_skips_recently_shown_sentence_instead_of_repeating(tmp_db):
 
 
 def test_session_caps_textbook_fallbacks(tmp_db):
+    """Textbook fallback applies only to FSRS-carded lemmas (2026-05-26).
+    Cap caps how many of those a single session serves."""
     with tmp_db() as db:
         for i in range(5):
             lemma = _seed_lemma(db, form=f"λ{i}", bare=f"λ{i}")
-            _seed_acquiring(db, lemma.lemma_id, box=1, due_offset_s=-60 - i)
+            _seed_known(db, lemma.lemma_id, state="learning")
             _seed_sentence(
                 db,
                 lemma_surfaces=[(lemma.lemma_id, f"λ{i}")],
@@ -655,10 +661,12 @@ def test_session_caps_textbook_fallbacks(tmp_db):
 
 
 def test_session_textbook_cap_does_not_block_generated_material(tmp_db):
+    """Generated (LLM) sentences for FSRS-due lemmas are served beyond the
+    textbook cap; the cap only counts textbook fallbacks."""
     with tmp_db() as db:
         for i in range(3):
             lemma = _seed_lemma(db, form=f"β{i}", bare=f"β{i}")
-            _seed_acquiring(db, lemma.lemma_id, box=1, due_offset_s=-60 - i)
+            _seed_known(db, lemma.lemma_id, state="learning")
             _seed_sentence(
                 db,
                 lemma_surfaces=[(lemma.lemma_id, f"β{i}")],
@@ -666,7 +674,7 @@ def test_session_textbook_cap_does_not_block_generated_material(tmp_db):
                 source="textbook",
             )
         generated = _seed_lemma(db, form="λόγος")
-        _seed_acquiring(db, generated.lemma_id, box=1, due_offset_s=-100)
+        _seed_known(db, generated.lemma_id, state="learning")
         llm = _seed_sentence(
             db,
             lemma_surfaces=[(generated.lemma_id, "λόγος")],
@@ -740,7 +748,10 @@ def test_endpoint_session_returns_bundle(tmp_db):
     with tmp_db() as db:
         a = _seed_lemma(db, form="λόγος")
         _seed_acquiring(db, a.lemma_id, box=1)
-        _seed_sentence(db, lemma_surfaces=[(a.lemma_id, "λόγος")])
+        # source="llm" because acquiring lemmas no longer accept textbook
+        # fallback (2026-05-26). The endpoint test asserts the bundle shape,
+        # not the source policy.
+        _seed_sentence(db, lemma_surfaces=[(a.lemma_id, "λόγος")], source="llm")
         db.commit()
 
     client = _http_client(tmp_db)
@@ -963,3 +974,99 @@ def test_recently_shown_sentence_penalty_prefers_fresher_generated_context(tmp_d
         assert result.llm_candidate_count == 2
         assert result.selected_recently_shown is False
         assert db.query(Sentence).filter_by(id=recent_best_scaffold.id).one()
+
+
+# ─── 2026-05-26 user feedback: no textbook fallback for acquiring lemmas ─────
+#
+# Book sentences are too complex for early learning. The picker must serve
+# them only for FSRS-carded lemmas, never for `acquiring` rows — even if no
+# LLM material exists yet, skipping the lemma is preferable. See
+# feedback_no_book_sentences_for_acquiring.md.
+
+
+def test_acquiring_lemma_never_gets_textbook_fallback(tmp_db):
+    """Acquiring lemma with ONLY a textbook sentence available → skipped, not served."""
+    with tmp_db() as db:
+        target = _seed_lemma(db, form="λόγος")
+        _seed_acquiring(db, target.lemma_id, box=1)
+        _seed_sentence(
+            db,
+            lemma_surfaces=[(target.lemma_id, "λόγος")],
+            text="ο λόγος (textbook)",
+            source="textbook",
+        )
+        db.commit()
+        bundle = build_session(db, language_code="el", limit=10)
+        assert len(bundle.sentences) == 0
+        # The lemma should be in skipped_due, not silently dropped.
+        assert any(
+            s.lemma_id == target.lemma_id and s.queue == "acquisition"
+            for s in bundle.skipped_due_lemmas
+        )
+
+
+def test_fsrs_lemma_still_gets_textbook_fallback(tmp_db):
+    """FSRS-carded lemma with only a textbook sentence available → served
+    (subject to the global TEXTBOOK_FALLBACK_MAX_PER_SESSION cap)."""
+    with tmp_db() as db:
+        target = _seed_lemma(db, form="λόγος")
+        _seed_known(db, target.lemma_id, state="learning")
+        sent = _seed_sentence(
+            db,
+            lemma_surfaces=[(target.lemma_id, "λόγος")],
+            text="ο λόγος (textbook)",
+            source="textbook",
+        )
+        db.commit()
+        bundle = build_session(db, language_code="el", limit=10)
+        assert len(bundle.sentences) == 1
+        assert bundle.sentences[0].sentence_id == sent.id
+
+
+def test_mixed_session_acquiring_skipped_fsrs_served(tmp_db):
+    """In one session, an acquiring lemma with only textbook source is skipped
+    while an FSRS-due lemma with the same textbook-only constraint is served."""
+    with tmp_db() as db:
+        acquiring_target = _seed_lemma(db, form="λόγος")
+        fsrs_target = _seed_lemma(db, form="κόσμος")
+        _seed_acquiring(db, acquiring_target.lemma_id, box=1)
+        _seed_known(db, fsrs_target.lemma_id, state="learning")
+        _seed_sentence(
+            db,
+            lemma_surfaces=[(acquiring_target.lemma_id, "λόγος")],
+            text="acq textbook",
+            source="textbook",
+        )
+        fsrs_sent = _seed_sentence(
+            db,
+            lemma_surfaces=[(fsrs_target.lemma_id, "κόσμος")],
+            text="fsrs textbook",
+            source="textbook",
+        )
+        db.commit()
+        bundle = build_session(db, language_code="el", limit=10)
+        served_ids = {s.sentence_id for s in bundle.sentences}
+        assert served_ids == {fsrs_sent.id}
+        # The acquiring lemma should land in skipped_due.
+        assert any(
+            s.lemma_id == acquiring_target.lemma_id and s.queue == "acquisition"
+            for s in bundle.skipped_due_lemmas
+        )
+
+
+def test_acquiring_lemma_with_llm_sentence_still_works(tmp_db):
+    """Sanity: acquiring with an LLM-source sentence available IS served,
+    so the fix doesn't accidentally starve the normal acquisition flow."""
+    with tmp_db() as db:
+        target = _seed_lemma(db, form="λόγος")
+        _seed_acquiring(db, target.lemma_id, box=1)
+        sent = _seed_sentence(
+            db,
+            lemma_surfaces=[(target.lemma_id, "λόγος")],
+            text="ο λόγος (llm)",
+            source="llm",
+        )
+        db.commit()
+        bundle = build_session(db, language_code="el", limit=10)
+        assert len(bundle.sentences) == 1
+        assert bundle.sentences[0].sentence_id == sent.id


### PR DESCRIPTION
User feedback 2026-05-26 (after first Latin review session): book
sentences are too complex for early learning and shouldn't be served
for words still in acquisition. The user has stated this multiple
times; the missing rule has now been recorded in memory.

## Change

`sentence_selector.build_session` now passes `allow_textbook=False`
when picking sentences for `acquiring` lemmas, regardless of the
existing `TEXTBOOK_FALLBACK_MAX_PER_SESSION` cap. If no LLM sentence is
available, the acquiring lemma lands in `skipped_due_lemmas` and waits
for `warm_sentence_cache` — better to show nothing than show a
too-hard sentence.

FSRS-carded lemmas (`learning` / `known` / `lapsed`) still accept
textbook fallback up to the existing cap.

## Regression coverage

Four new tests:

- `test_acquiring_lemma_never_gets_textbook_fallback` — only textbook
  available → 0 sentences served, lemma in skipped_due.
- `test_fsrs_lemma_still_gets_textbook_fallback` — FSRS-carded with
  textbook-only → served (no regression on the existing fallback).
- `test_mixed_session_acquiring_skipped_fsrs_served` — mixed session,
  acquiring skipped + FSRS served from the same source policy.
- `test_acquiring_lemma_with_llm_sentence_still_works` — sanity that
  the normal acquisition flow isn't starved.

Six pre-existing tests were updated: generic `build_session` tests now
use `source="llm"` (they weren't actually testing source policy); the
textbook-cap tests switched to FSRS-due lemmas (the only place
textbook fallback now applies). All 38 selector tests + the full 336-
test polyglot suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)