### PR TITLE
Polyglot reader: quote-aware sentence splitter + opening-quote leading space

### DIFF
--- a/frontend/lib/__tests__/polyglot-render-helpers.test.ts
+++ b/frontend/lib/__tests__/polyglot-render-helpers.test.ts
@@ -57,6 +57,35 @@ describe("renderTokens — punctuation spacing", () => {
     expect(joined([tok("«"), tok("έπος"), tok("»"), tok("του")]))
       .toBe("«έπος» του");
   });
+
+  it("curly opening quote gets a leading space after a colon (dialog start)", () => {
+    // The 2026-05-26 LLPSI page-3 typography bug: `respondet:"Quia` rendered
+    // as one mashed run because the opening quote inherited isPunct=true from
+    // the tokenizer and `attaches` swallowed its leading space.
+    expect(joined([
+      tok("respondet"),
+      tok(":"),
+      tok("“", { is_punctuation: true }),
+      tok("Quia"),
+      tok("plorat"),
+      tok(".", { is_punctuation: true }),
+      tok("”", { is_punctuation: true }),
+    ])).toBe("respondet: “Quia plorat.”");
+  });
+
+  it("metalinguistic quote in mid-sentence keeps spaces on both sides", () => {
+    // `verbum "Marcus" videt` was rendering as `verbum"Marcus"videt` — both
+    // the opening AND closing quotes were tokenized as punctuation and the
+    // surrounding word boundaries were collapsed.
+    expect(joined([
+      tok("verbum"),
+      tok("“", { is_punctuation: true }),
+      tok("Marcus"),
+      tok("”", { is_punctuation: true }),
+      tok("videt"),
+    ])).toBe("verbum “Marcus” videt");
+  });
+
 });
 
 describe("renderTokens — soft-hyphen joining", () => {

--- a/frontend/lib/polyglot-render-helpers.ts
+++ b/frontend/lib/polyglot-render-helpers.ts
@@ -143,7 +143,14 @@ export function renderTokens(tokens: readonly TokenView[]): RenderedSpan[] {
     }
 
     const isPunct = t.is_punctuation;
-    const attaches = ATTACHING_PUNCT.has(surface) || isPunct;
+    // Opening punctuation (`"`, `(`, `«`, …) keeps its leading space — it
+    // bonds to the *next* word via `previousWasOpening` below, not to the
+    // previous one. Without this guard, `respondet:` + `"` would render as
+    // `respondet:"` and the whole dialog reads as one mashed run-on. Closing
+    // and attaching punctuation (`.`, `,`, `:`, `)`, `»`, …) keep the no-space
+    // attach to the previous word as before.
+    const attaches =
+      ATTACHING_PUNCT.has(surface) || (isPunct && !OPENING_PUNCT.has(surface));
     const leadingSpace =
       out.length === 0 || attaches || previousWasOpening || previousHadDroppedHyphen
         ? ""

--- a/polyglot/app/services/reading_intake.py
+++ b/polyglot/app/services/reading_intake.py
@@ -76,6 +76,65 @@ _LATIN_NON_BOUNDARY_ABBREVS: tuple[str, ...] = (
 )
 
 
+# Sentinels used to hide terminal punctuation from the splitter when that
+# punctuation is *inside* a dialog quote. All control chars; safe to inject
+# because `body_clean.normalize_pdf_artifacts` already strips them from source.
+_QUOTE_INNER_PROTECT = str.maketrans({
+    ".": "\x01", "!": "\x02", "?": "\x03", ";": "\x04", "·": "\x05",
+})
+_QUOTE_INNER_RESTORE = str.maketrans({
+    "\x00": ".",  # _LATIN_NON_BOUNDARY_ABBREVS
+    "\x01": ".", "\x02": "!", "\x03": "?", "\x04": ";", "\x05": "·",
+})
+_QUOTE_INNER_TERMINAL_SET = "\x01\x02\x03\x04\x05"
+# A close-quote that ended on a real terminal is itself an outer-sentence
+# boundary in dialog-attribution prose (`...?" Marcus respondet:`). We mark
+# such closes with this sentinel and add it to the splitter's lookbehind set
+# so the cut lands AFTER the close-quote rather than after the next clause.
+_DIALOG_CLOSE_BOUNDARY = "\x06"
+
+# Quote pairs we recognize for dialog protection. Curly first because LLPSI
+# and most modern Latin/Greek editions use them; ASCII as fallback; guillemets
+# for French- or German-style typesetting. Apostrophes (' / ') intentionally
+# excluded — they collide with possessives and contractions.
+_QUOTE_PAIRS: tuple[tuple[str, str], ...] = (
+    ("“", "”"),  # " "
+    ('"', '"'),
+    ("«", "»"),  # « »
+)
+
+
+def _protect_quoted_dialog(text: str) -> str:
+    """Hide sentence-terminal punctuation inside paired quotes so the cheap
+    regex splitter doesn't cut mid-dialog. When the quoted content itself
+    ended on a terminal (the quote held a complete utterance), append a
+    `_DIALOG_CLOSE_BOUNDARY` sentinel after the close-quote so the splitter
+    treats the dialog close as the outer sentence boundary instead of cutting
+    after the next narration clause.
+
+    `interrogat: "Cur eum verberas? Cur puer probus non es?" Marcus respondet:`
+    correctly splits between the close-quote and `Marcus`; the bare metalinguistic
+    `"Marcus"` mention (no internal terminal) is left as-is so the surrounding
+    sentence isn't split at the closing quote.
+    """
+    protected = text
+    for open_q, close_q in _QUOTE_PAIRS:
+        pattern = re.compile(
+            re.escape(open_q) + r"([^" + re.escape(close_q) + r"]*?)" + re.escape(close_q)
+        )
+
+        def _replace(m: re.Match, oq: str = open_q, cq: str = close_q) -> str:
+            inner_protected = m.group(1).translate(_QUOTE_INNER_PROTECT)
+            ends_on_terminal = bool(
+                re.search(r"[" + _QUOTE_INNER_TERMINAL_SET + r"]\s*$", inner_protected)
+            )
+            tail = _DIALOG_CLOSE_BOUNDARY if ends_on_terminal else ""
+            return oq + inner_protected + cq + tail
+
+        protected = pattern.sub(_replace, protected)
+    return protected
+
+
 def _split_into_sentences(text: str, language_code: str = "el") -> list[str]:
     """Cheap splitter: ·;.!?\\n plus Greek question mark ;. Keeps delimiters
     out — we only need sentence_index for grouping in the UI.
@@ -85,13 +144,30 @@ def _split_into_sentences(text: str, language_code: str = "el") -> list[str]:
     "." for a NUL sentinel before splitting, then restore it on each part so
     the visible text is unchanged. NUL is safe as a sentinel because Page text
     has already been normalized by `body_clean.normalize_pdf_artifacts`,
-    which strips control characters."""
+    which strips control characters.
+
+    Quote-aware: inside paired curly / ASCII / guillemet quotes, terminal
+    punctuation is sentinelized so a quoted question like "Cur eum verberas?"
+    isn't cut mid-dialog. When a closing quote ended on a terminal (the quote
+    held a complete utterance), the close itself becomes the outer-sentence
+    boundary — so `"...?" Marcus respondet:` splits between the close-quote
+    and the new clause, not after the verb of speech. Bare metalinguistic
+    `"Marcus"` mentions (no inner terminal) don't trigger the close-boundary
+    so the surrounding sentence stays whole.
+    """
     protected = text
     if language_code == "la":
         for ab in _LATIN_NON_BOUNDARY_ABBREVS:
             protected = protected.replace(ab, ab.replace(".", "\x00"))
-    parts = re.split(r"(?<=[.!?·;\n])\s+", protected.strip())
-    return [p.replace("\x00", ".") for p in parts if p.strip()]
+    protected = _protect_quoted_dialog(protected)
+    parts = re.split(
+        r"(?<=[.!?·;\n" + _DIALOG_CLOSE_BOUNDARY + r"])\s+",
+        protected.strip(),
+    )
+    return [
+        p.translate(_QUOTE_INNER_RESTORE).replace(_DIALOG_CLOSE_BOUNDARY, "")
+        for p in parts if p.strip()
+    ]
 
 
 def _lookup_lemma(db: Session, language_code: str, lemma_bare: str) -> Lemma | None:

--- a/polyglot/scripts/resync_page_sentence_indices.py
+++ b/polyglot/scripts/resync_page_sentence_indices.py
@@ -1,0 +1,259 @@
+"""Re-bucket PageWord.sentence_index using the current sentence splitter.
+
+When the splitter changes (e.g. quote-aware dialog rule landed 2026-05-26
+after the Reveal misalignment incident), pages previously processed under
+the old rules keep their stale ``PageWord.sentence_index`` until they're
+re-tokenized. A full ``process_page(force=True)`` would do it, but at the
+cost of re-running body_clean + quality gate per page — wasteful when the
+*only* thing that changed is sentence bucketing.
+
+This script reuses the existing ``body_clean`` and the deterministic
+tokenizer to recompute sentence indices and updates PageWord rows in place.
+Lemma assignments, gloss work, citation repair, and quality-gate verdicts
+are all preserved. After the in-place update, ``harvest_page_sentences``
+runs with the drift detector from PR #160 — it sees the new sentence
+grouping and refreshes ``Sentence`` rows (nulling ``translation_en`` for
+rows whose text changed so the next reveal re-translates).
+
+USAGE
+    polyglot/.venv/bin/python scripts/resync_page_sentence_indices.py \\
+        --languages la el grc --dry-run
+    polyglot/.venv/bin/python scripts/resync_page_sentence_indices.py \\
+        --languages la el grc --translate
+
+NOTES
+    - Skips pages without verified mappings (harvest precondition).
+    - Skips pages whose retokenization produces a different token count
+      (defensive — the tokenizer should be deterministic, but if a provider
+      version drifted we don't want to corrupt PageWord.position alignment).
+    - Idempotent: re-running once the indices are correct is a no-op.
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from app.database import SessionLocal  # noqa: E402
+from app.models import Page, PageWord, Story  # noqa: E402
+from app.services import body_clean as body_clean_svc  # noqa: E402
+from app.services.activity_log import log_activity  # noqa: E402
+from app.services.languages import get_provider  # noqa: E402
+from app.services.reading_intake import _split_into_sentences  # noqa: E402
+from app.services.sentence_harvest import harvest_page_sentences  # noqa: E402
+
+LOG = logging.getLogger("resync_page_sentence_indices")
+
+
+def _new_sentence_index_per_position(page: Page, language_code: str) -> list[int]:
+    """Re-tokenize the page from body_clean and return a list of
+    ``sentence_index`` values aligned with PageWord.position order."""
+    raw_source = page.body_clean if (page.body_clean and page.body_clean.strip()) else page.body_src
+    source_text = body_clean_svc.normalize_pdf_artifacts(raw_source or "", collapse_whitespace=True)
+    sentences = _split_into_sentences(source_text, language_code)
+    provider = get_provider(language_code)
+    out: list[int] = []
+    for s_idx, sentence in enumerate(sentences):
+        for _ in provider.tokenize(sentence):
+            out.append(s_idx)
+    return out
+
+
+def _resync_page(db, page: Page, language_code: str) -> dict:
+    stats = {"changed": False, "skipped": None, "harvested": 0}
+    pws = (
+        db.query(PageWord)
+        .filter(PageWord.page_id == page.id)
+        .order_by(PageWord.position)
+        .all()
+    )
+    if not pws:
+        stats["skipped"] = "no_page_words"
+        return stats
+
+    try:
+        new_sidx = _new_sentence_index_per_position(page, language_code)
+    except Exception as e:
+        LOG.warning("tokenize failed for page %d: %s", page.id, e)
+        stats["skipped"] = f"tokenize_error: {e}"
+        return stats
+
+    if len(new_sidx) != len(pws):
+        LOG.warning(
+            "Token-count drift on page %d (%s): %d new vs %d existing — "
+            "skipping to avoid PageWord misalignment",
+            page.id, page.story.title, len(new_sidx), len(pws),
+        )
+        stats["skipped"] = f"token_count_drift:{len(new_sidx)}/{len(pws)}"
+        return stats
+
+    if all(pw.sentence_index == ns for pw, ns in zip(pws, new_sidx)):
+        return stats
+
+    for pw, ns in zip(pws, new_sidx):
+        if pw.sentence_index != ns:
+            pw.sentence_index = ns
+    db.commit()
+    stats["changed"] = True
+
+    refreshed = harvest_page_sentences(db, page, force=True)
+    stats["harvested"] = refreshed
+    return stats
+
+
+def _fill_translations(db, language_code: str, batch_size: int = 12) -> int:
+    """Reused from resync_stale_page_sentences — same lazy-fill semantics."""
+    from app.models import Sentence
+    from app.services.material_generator import translate_sentences_batch
+
+    pending = (
+        db.query(Sentence)
+        .filter(
+            Sentence.language_code == language_code,
+            Sentence.is_active == True,  # noqa: E712
+            Sentence.source == "textbook",
+            Sentence.page_id.isnot(None),
+            Sentence.translation_en.is_(None),
+        )
+        .all()
+    )
+    if not pending:
+        return 0
+    LOG.info("[%s] translating %d sentences", language_code, len(pending))
+    filled = 0
+    for start in range(0, len(pending), batch_size):
+        chunk = pending[start:start + batch_size]
+        items = [{"id": s.id, "text": s.text} for s in chunk if s.text]
+        if not items:
+            continue
+        translations = translate_sentences_batch(language_code, items)
+        if not translations:
+            continue
+        for sid, english in translations.items():
+            (
+                db.query(Sentence)
+                .filter(Sentence.id == sid)
+                .update({"translation_en": english})
+            )
+            filled += 1
+        db.commit()
+    return filled
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--languages", nargs="+", default=["la", "el", "grc"])
+    ap.add_argument("--story-id", type=int, default=None)
+    ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument("--translate", action="store_true")
+    ap.add_argument("--log-level", default="INFO")
+    args = ap.parse_args(argv)
+
+    logging.basicConfig(
+        level=getattr(logging, args.log_level.upper(), logging.INFO),
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    db = SessionLocal()
+    summary: dict = {
+        "languages": args.languages,
+        "stories_scanned": 0,
+        "pages_scanned": 0,
+        "pages_changed": 0,
+        "pages_skipped": 0,
+        "sentences_refreshed": 0,
+        "translations_filled": 0,
+        "per_story": [],
+    }
+    try:
+        story_q = db.query(Story).filter(Story.language_code.in_(args.languages))
+        if args.story_id is not None:
+            story_q = story_q.filter(Story.id == args.story_id)
+        stories = story_q.order_by(Story.id).all()
+
+        for story in stories:
+            summary["stories_scanned"] += 1
+            pages = (
+                db.query(Page)
+                .filter(Page.story_id == story.id)
+                .filter(Page.mappings_verified_at.isnot(None))
+                .order_by(Page.page_number)
+                .all()
+            )
+            story_changed = 0
+            for page in pages:
+                summary["pages_scanned"] += 1
+                if args.dry_run:
+                    try:
+                        new_sidx = _new_sentence_index_per_position(page, story.language_code)
+                    except Exception:
+                        continue
+                    pws = (
+                        db.query(PageWord)
+                        .filter(PageWord.page_id == page.id)
+                        .order_by(PageWord.position)
+                        .all()
+                    )
+                    if (
+                        pws
+                        and len(new_sidx) == len(pws)
+                        and any(pw.sentence_index != ns for pw, ns in zip(pws, new_sidx))
+                    ):
+                        LOG.info(
+                            "WOULD CHANGE story=%d (%s) page=%d page_id=%d",
+                            story.id, story.title or "(no title)", page.page_number, page.id,
+                        )
+                        story_changed += 1
+                        summary["pages_changed"] += 1
+                    continue
+
+                stats = _resync_page(db, page, story.language_code)
+                if stats["changed"]:
+                    story_changed += 1
+                    summary["pages_changed"] += 1
+                    summary["sentences_refreshed"] += stats["harvested"]
+                    LOG.info(
+                        "CHANGED story=%d page=%d page_id=%d  refreshed %d sentences",
+                        story.id, page.page_number, page.id, stats["harvested"],
+                    )
+                elif stats["skipped"]:
+                    summary["pages_skipped"] += 1
+
+            if story_changed:
+                summary["per_story"].append({
+                    "story_id": story.id,
+                    "language_code": story.language_code,
+                    "title": story.title,
+                    "pages_changed": story_changed,
+                })
+
+        if not args.dry_run and args.translate:
+            for lang in args.languages:
+                filled = _fill_translations(db, lang)
+                LOG.info("[%s] filled %d translation_en rows", lang, filled)
+                summary["translations_filled"] += filled
+
+        if not args.dry_run and summary["pages_changed"]:
+            log_activity(
+                db,
+                event_type="page_sentence_index_resync",
+                summary=(
+                    f"Re-bucketed PageWord.sentence_index across "
+                    f"{summary['pages_changed']} pages "
+                    f"({summary['stories_scanned']} stories scanned)"
+                ),
+                detail=summary,
+            )
+    finally:
+        db.close()
+
+    LOG.info("DONE: %s", summary)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/polyglot/tests/test_reading_intake.py
+++ b/polyglot/tests/test_reading_intake.py
@@ -61,6 +61,58 @@ def test_split_into_sentences_greek_unaffected_by_latin_protection():
     assert parts == ["Λέει Kal.", "Επιστρέφει."]
 
 
+def test_split_into_sentences_protects_terminals_inside_curly_quotes():
+    # LLPSI page 3 actual prose: a quoted question with two `?` inside should
+    # be one outer sentence (with the embedded dialog) — not three. The 2026-05-26
+    # Reveal bug split this at every interior terminal and `;`.
+    text = (
+        "Aemilia venit irata et Marcum interrogat: "
+        "“Cur eum verberas? Cur puer probus non es?” "
+        "Marcus respondet: “Quia Quintus me videt et ridet; "
+        "neque laetus sum.” Iulia, quae hic est, cantat;"
+    )
+    parts = reading_intake._split_into_sentences(text, language_code="la")
+    assert parts == [
+        "Aemilia venit irata et Marcum interrogat: "
+        "“Cur eum verberas? Cur puer probus non es?”",
+        "Marcus respondet: “Quia Quintus me videt et ridet; "
+        "neque laetus sum.”",
+        "Iulia, quae hic est, cantat;",
+    ]
+
+
+def test_split_into_sentences_metalinguistic_quote_does_not_split():
+    # `verbum "Marcus" videt` — the bare mention has no inner terminal, so
+    # the closing quote must NOT introduce a sentence break.
+    text = "Iulius in pagina verbum “Marcus” videt et interrogat."
+    parts = reading_intake._split_into_sentences(text, language_code="la")
+    assert parts == [
+        "Iulius in pagina verbum “Marcus” videt et interrogat."
+    ]
+
+
+def test_split_into_sentences_handles_ascii_and_guillemet_quotes():
+    # Same dialog-attribution rule for ASCII "..." (older PDFs / pasted text)
+    # and «...» (German/French editions).
+    ascii_text = 'Dixit: "Quid agis?" Respondit: "Bene."'
+    assert reading_intake._split_into_sentences(ascii_text, language_code="la") == [
+        'Dixit: "Quid agis?"',
+        'Respondit: "Bene."',
+    ]
+    guill = "Dixit: «Quid agis?» Respondit: «Bene.»"
+    assert reading_intake._split_into_sentences(guill, language_code="la") == [
+        "Dixit: «Quid agis?»",
+        "Respondit: «Bene.»",
+    ]
+
+
+def test_split_into_sentences_unquoted_text_unaffected_by_dialog_rule():
+    # The dialog rule must not regress plain prose — no quotes anywhere.
+    text = "Marcus venit. Quintus plorat. Iulia cantat."
+    parts = reading_intake._split_into_sentences(text, language_code="la")
+    assert parts == ["Marcus venit.", "Quintus plorat.", "Iulia cantat."]
+
+
 def test_paste_creates_story_and_single_page(tmp_db):
     with tmp_db() as db:
         story = reading_intake.import_paste(


### PR DESCRIPTION
## Summary
- Splitter now skips terminal punctuation inside paired quotes (curly, ASCII, guillemet) and recognises the closing quote of a complete utterance as the outer-sentence boundary. Bare metalinguistic mentions like \`\"Marcus\"\` (no inner terminal) don't split. Closes the LLPSI page-3 misslicing visible after PR #160 fixed the alignment bug.
- Frontend renderer no longer treats opening punctuation (\`\"\`, \`\(\`, \`«\`, \`\"\`, \`“\`) as attaching to the previous token — the opening quote keeps its leading space and bonds to the next word via the existing \`previousWasOpening\` flag.
- One-shot prod fix: \`polyglot/scripts/resync_page_sentence_indices.py --languages la el grc [--translate]\` re-buckets \`PageWord.sentence_index\` per the new splitter, then leans on PR #160's drift-aware harvest to refresh \`Sentence\` rows. No body_clean re-run, no quality-gate re-run, no LLM cost beyond the optional \`--translate\` pass.

## Production incident
LLPSI Familia Romana — Coverage Reader, page 3 dialog: \`Aemilia ... interrogat: "Cur eum verberas? Cur puer probus non es?" Marcus respondet: "Quia Quintus me videt et ridet; neque laetus sum."\` was rendering as five fragments because the inner \`?\` and \`;\` triggered breaks. The opening curly quotes also rendered glued to colons (\`respondet:"Quia\`).

## Tests
- 4 new splitter tests (\`tests/test_reading_intake.py\`) including the exact LLPSI prose.
- 2 new frontend render-helper tests (\`frontend/lib/__tests__/polyglot-render-helpers.test.ts\`).
- Full polyglot fast suite: 406 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)