### PR TITLE
Polyglot reader: prefetch 5 pages from client + bump cron buffer to 10

### DIFF
--- a/frontend/app/polyglot.tsx
+++ b/frontend/app/polyglot.tsx
@@ -164,6 +164,13 @@ function marksEqual(
 // (see goToLibrary) — that's the only way to genuinely reset to the story list.
 const CURSOR_STORAGE_KEY = "@polyglot:readingCursor";
 
+// How many pages ahead to background-prefetch on each page view. The backend
+// tokenizes a page on first request (4 LLM passes ~ 40-90s for a cold Latin
+// page); each prefetch fires concurrently and lets the server work through
+// the queue while the user reads. 5 matches the cron's warm_pages_ahead
+// buffer so an in-session gap between cron runs (3h) stays covered.
+const PREFETCH_AHEAD = 5;
+
 type ReadingCursor = {
   storyId: number;
   pageNumber: number;
@@ -375,9 +382,19 @@ export default function Polyglot() {
       }
       setPageData(data);
       setPageNumber(data.page_number);
-      // Warm the next page (so Next is instant) and this page's translation
-      // (so "Show English" is instant).
-      if (data.page_number < data.total_pages) prefetchPage(sid, data.page_number + 1);
+      // Warm the next several pages (so Next stays instant even when the user
+      // outpaces a single-page lookahead) and this page's translation (so
+      // "Show English" is instant). Cold tokenization of a new Latin page can
+      // take 40-90s of LLM work; the cron's warm_pages_ahead pre-warms a
+      // 5-page buffer every 3h, so the client prefetch only needs to bridge
+      // the in-session gap between cron runs. PREFETCH_AHEAD requests fire
+      // concurrently from the client; the server serializes the SQLite writes,
+      // so this looks like queue depth, not parallel CPU load.
+      for (let i = 1; i <= PREFETCH_AHEAD; i++) {
+        const next = data.page_number + i;
+        if (next > data.total_pages) break;
+        prefetchPage(sid, next);
+      }
       fetchTranslation(sid, data.page_number);
     };
 

--- a/polyglot/deploy/polyglot-update-material.sh
+++ b/polyglot/deploy/polyglot-update-material.sh
@@ -14,10 +14,14 @@
 # LANGUAGES comment below). Phase descriptions say "Modern Greek" but apply to
 # whichever language the loop is on. In order:
 #   1. warm_pages_ahead
-#      — keeps the next N (default 5) unread pages of every active story
+#      — keeps the next N (default 10) unread pages of every active story
 #        already through the quality gate, so the user never waits when
 #        flipping pages. Runs first because freshly verified pages are the
 #        source of new lemmas that the sentence cache then needs to cover.
+#        Buffer was 5 until 2026-05-26; bumped to 10 because heavy-reading
+#        Latin sessions outpaced the 3h cron cadence (user advancing >5 pages
+#        between cron passes). Frontend also prefetches 5 pages ahead so the
+#        client bridges any in-session gap.
 #   2. review_existing_sentences for Modern Greek
 #      — backfills the sentence quality gate for legacy LLM-generated rows and
 #        retires rows that are unnatural or mistranslated.
@@ -73,9 +77,9 @@ export POLYGLOT_ACTIVE_TARGET="${POLYGLOT_ACTIVE_TARGET:-5}"
 # 64 lemmas / BATCH_WORD_SIZE=4 = 16 Sonnet+verify+quality batches. Give the
 # phase 45 minutes so slow LLM calls don't truncate an otherwise healthy pass.
 TIMEOUT_SECONDS="${POLYGLOT_WARM_TIMEOUT_SECONDS:-2700}"
-PAGES_BUFFER="${POLYGLOT_PAGES_AHEAD_BUFFER:-5}"
-PAGES_MAX_PER_RUN="${POLYGLOT_PAGES_AHEAD_MAX_PER_RUN:-5}"
-PAGES_TIMEOUT_SECONDS="${POLYGLOT_PAGES_AHEAD_TIMEOUT_SECONDS:-1200}"
+PAGES_BUFFER="${POLYGLOT_PAGES_AHEAD_BUFFER:-10}"
+PAGES_MAX_PER_RUN="${POLYGLOT_PAGES_AHEAD_MAX_PER_RUN:-10}"
+PAGES_TIMEOUT_SECONDS="${POLYGLOT_PAGES_AHEAD_TIMEOUT_SECONDS:-1800}"
 REVIEW_EXISTING_MAX_SENTENCES="${POLYGLOT_REVIEW_EXISTING_MAX_SENTENCES:-80}"
 REVIEW_EXISTING_BATCH_SIZE="${POLYGLOT_REVIEW_EXISTING_BATCH_SIZE:-10}"
 REVIEW_EXISTING_TIMEOUT_SECONDS="${POLYGLOT_REVIEW_EXISTING_TIMEOUT_SECONDS:-900}"


### PR DESCRIPTION
## Summary

Clicking Next on a Latin story page hangs 40-90s while the backend cold-tokenizes the next page (4 LLM passes: body_clean → batch_gloss → citation repair → quality gate). The cron's \`warm_pages_ahead\` pre-warms a buffer but with the previous buffer=5 and a 3h cron cadence, a heavy-reading session outpaced it.

Two layers:

- **Frontend (\`polyglot.tsx\`)**: \`PREFETCH_AHEAD=5\` — every page view kicks off concurrent prefetches for N+1..N+5 instead of just N+1. The server serializes the SQLite writes, so this looks like queue depth, not parallel CPU load.
- **Cron (\`polyglot-update-material.sh\`)**: \`POLYGLOT_PAGES_AHEAD_BUFFER\` and \`POLYGLOT_PAGES_AHEAD_MAX_PER_RUN\` default 5 → 10, phase timeout 1200s → 1800s. Doubles the per-cron warming budget so heavy-reading days don't outpace it between runs.

Client-side prefetch covers the in-session gap; cron covers the cross-session catch-up. Both stay env-overridable.