### PR TITLE
Polyglot reader: split long PDF pages into screen-sized polyglot Pages

### DIFF
--- a/polyglot/app/services/reading_intake.py
+++ b/polyglot/app/services/reading_intake.py
@@ -170,6 +170,56 @@ def _split_into_sentences(text: str, language_code: str = "el") -> list[str]:
     ]
 
 
+# Target body size for a polyglot Page — the screen-fit unit the reader
+# advances through. The Greek textbook PDF lands at ~2,280 char/page on
+# average (max 4,655), which scrolls heavily on a phone. We split at
+# sentence boundaries until each Page fits roughly one phone screen of
+# EB Garamond body text.
+DEFAULT_MAX_CHARS_PER_PAGE = 500
+
+
+def _paginate_by_length(
+    text: str,
+    language_code: str,
+    max_chars: int = DEFAULT_MAX_CHARS_PER_PAGE,
+) -> list[str]:
+    """Split a body of text into screen-sized chunks at sentence boundaries.
+
+    Each chunk is <= max_chars unless a single sentence already exceeds it
+    (we keep oversize sentences whole rather than slicing mid-clause). The
+    splitter is language-aware via `_split_into_sentences` so Latin calendar
+    abbreviations and quoted dialog stay intact.
+
+    Empty / whitespace-only input returns []. Callers decide whether to keep
+    or drop empty source pages.
+    """
+    text = text.strip()
+    if not text:
+        return []
+    if len(text) <= max_chars:
+        return [text]
+    sentences = _split_into_sentences(text, language_code)
+    if not sentences:
+        return [text]
+    out: list[str] = []
+    cur: list[str] = []
+    cur_len = 0
+    for s in sentences:
+        s_len = len(s)
+        # Only break when the current page already has content. A single
+        # oversize sentence becomes its own page.
+        if cur and cur_len + 1 + s_len > max_chars:
+            out.append(" ".join(cur))
+            cur = [s]
+            cur_len = s_len
+        else:
+            cur.append(s)
+            cur_len = cur_len + 1 + s_len if cur_len else s_len
+    if cur:
+        out.append(" ".join(cur))
+    return out
+
+
 def _lookup_lemma(db: Session, language_code: str, lemma_bare: str) -> Lemma | None:
     return (
         db.query(Lemma)
@@ -220,20 +270,30 @@ def import_paste(
     body: str,
     title: str | None = None,
     author: str | None = None,
+    max_chars_per_page: int | None = DEFAULT_MAX_CHARS_PER_PAGE,
 ) -> Story:
-    """Import a pasted text as a single-page Story. Pages aren't tokenized
-    yet — that happens on first view."""
+    """Import a pasted text as a Story. The body is paginated into
+    screen-sized Page rows at sentence boundaries; pass ``max_chars_per_page=None``
+    to keep the legacy single-page behavior. Pages aren't tokenized yet —
+    that happens on first view."""
+    chunks = (
+        _paginate_by_length(body, language_code, max_chars_per_page)
+        if max_chars_per_page else [body.strip()]
+    )
+    if not chunks:
+        chunks = [""]
     story = Story(
         language_code=language_code,
         title=title,
         author=author,
         body_src=body,
         source="paste",
-        page_count=1,
+        page_count=len(chunks),
     )
     db.add(story)
     db.flush()
-    db.add(Page(story_id=story.id, page_number=1, body_src=body))
+    for idx, chunk in enumerate(chunks, start=1):
+        db.add(Page(story_id=story.id, page_number=idx, body_src=chunk))
     db.commit()
     db.refresh(story)
     return story
@@ -246,12 +306,31 @@ def import_pdf(
     pdf_path: str | Path,
     title: str | None = None,
     author: str | None = None,
+    max_chars_per_page: int | None = DEFAULT_MAX_CHARS_PER_PAGE,
 ) -> Story:
     """Extract a PDF page-by-page into Story + Page rows. No tokenization.
-    Pages are tokenized lazily on first view."""
+    Each PDF page is paginated into screen-sized chunks at sentence
+    boundaries (pass ``max_chars_per_page=None`` to preserve 1:1 PDF page
+    mapping). Empty PDF pages are dropped. Pages are tokenized lazily on
+    first view."""
     pages = pdf_extract.extract_pages(pdf_path)
     if not pages:
         raise ValueError(f"No pages extracted from {pdf_path}")
+
+    # Build the polyglot Page sequence. PDF page boundaries are preserved as
+    # natural section breaks — we never merge across PDF pages — but a single
+    # long PDF page may fan out into multiple polyglot pages.
+    new_bodies: list[str] = []
+    for ep in pages:
+        if max_chars_per_page:
+            chunks = _paginate_by_length(ep.text, language_code, max_chars_per_page)
+        else:
+            t = (ep.text or "").strip()
+            chunks = [t] if t else []
+        new_bodies.extend(chunks)
+
+    if not new_bodies:
+        raise ValueError(f"No non-empty pages extracted from {pdf_path}")
 
     story = Story(
         language_code=language_code,
@@ -259,16 +338,16 @@ def import_pdf(
         author=author,
         source="pdf",
         source_path=str(pdf_path),
-        page_count=len(pages),
+        page_count=len(new_bodies),
     )
     db.add(story)
     db.flush()
-    for ep in pages:
-        db.add(Page(story_id=story.id, page_number=ep.page_number, body_src=ep.text))
+    for idx, body in enumerate(new_bodies, start=1):
+        db.add(Page(story_id=story.id, page_number=idx, body_src=body))
     db.commit()
     db.refresh(story)
-    log.info("Imported PDF %s as Story id=%d (%d pages, all unprocessed)",
-             pdf_path, story.id, len(pages))
+    log.info("Imported PDF %s as Story id=%d (%d pages from %d PDF pages, all unprocessed)",
+             pdf_path, story.id, len(new_bodies), len(pages))
     return story
 
 

--- a/polyglot/scripts/split_long_pages.py
+++ b/polyglot/scripts/split_long_pages.py
@@ -1,0 +1,219 @@
+"""Re-split existing Story pages into screen-sized polyglot Pages.
+
+The original PDF intake stored one Page per PDF page, which for the Greek
+"Ιστορία" textbook averages ~2,280 chars (max ~4,655) — too long for a phone
+screen. This script walks each Page, paginates its ``body_src`` at sentence
+boundaries (default 500 chars / page), and replaces the old Page rows with
+the smaller ones in a single transaction per story.
+
+USAGE
+    polyglot/.venv/bin/python scripts/split_long_pages.py --all --dry-run
+    polyglot/.venv/bin/python scripts/split_long_pages.py --story-id 1
+    polyglot/.venv/bin/python scripts/split_long_pages.py --all --max-chars 800
+
+WHAT IT TOUCHES
+    - Reads Page.body_src per story (PDF page boundaries are preserved as
+      natural section breaks — we never merge across original Pages).
+    - Deactivates harvested Sentence rows attached to the old Pages
+      (``is_active=False``). Sentences are NEVER deleted because review_log
+      and sentence_review_log hold FK references — Alif/polyglot's repair
+      policy is "deactivate, don't delete." Going-forward harvests build
+      fresh Sentence rows for the new Pages.
+    - Deletes the old Page rows. PageWord cascades via the Page model's
+      ``cascade="all, delete-orphan"`` relationship.
+    - Deletes PageReviewLog rows for the story — their (story_id, page_number)
+      coordinates no longer map to anything, and their ``client_review_id``
+      shape ``pr:{story_id}:{page_number}`` would otherwise silently no-op
+      the user's first re-read of a page (the page-level idempotency check).
+    - Inserts new Page rows with sequential page_numbers, ``processed_at=NULL``,
+      ``body_clean=NULL``, ``translation_en=NULL``. The next page-view
+      re-tokenizes lazily as usual.
+    - Bumps Story.page_count.
+    - Logs to ActivityLog (event_type='pages_resplit').
+
+DOES NOT touch:
+    - Lemma rows (citation forms persist across the split).
+    - UserLemmaKnowledge (study state is per-lemma, not per-page).
+    - ReviewLog / SentenceReviewLog history (FKs land on Sentence ids that
+      stay around, just marked inactive).
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from sqlalchemy.orm import Session  # noqa: E402
+
+from app.database import SessionLocal  # noqa: E402
+from app.models import Page, PageReviewLog, Sentence, Story  # noqa: E402
+from app.services.activity_log import log_activity  # noqa: E402
+from app.services.reading_intake import (  # noqa: E402
+    DEFAULT_MAX_CHARS_PER_PAGE,
+    _paginate_by_length,
+)
+
+LOG = logging.getLogger("split_long_pages")
+
+
+def _resplit_one_story(
+    db: Session,
+    story: Story,
+    *,
+    max_chars: int,
+    dry_run: bool,
+) -> dict[str, int]:
+    """Return a stats dict for the resplit of one Story."""
+    pages = (
+        db.query(Page)
+        .filter(Page.story_id == story.id)
+        .order_by(Page.page_number)
+        .all()
+    )
+    if not pages:
+        return {"old_pages": 0, "new_pages": 0, "deactivated_sentences": 0,
+                "deleted_page_reviews": 0}
+
+    # Build the new body list. Each old Page may fan out into 1+ new Pages;
+    # we never merge across an old PDF page boundary, so an over-paginated
+    # old page can grow while a short one stays short.
+    new_bodies: list[str] = []
+    for old in pages:
+        chunks = _paginate_by_length(old.body_src or "", story.language_code, max_chars)
+        if not chunks:
+            # Old page had only whitespace / empty text — drop it. Original
+            # PDF page numbering isn't preserved here (we renumber the
+            # surviving pages 1..N).
+            continue
+        new_bodies.extend(chunks)
+
+    if not new_bodies:
+        LOG.warning("Story id=%d (%r) produced no non-empty pages — skipping",
+                    story.id, story.title)
+        return {"old_pages": len(pages), "new_pages": 0,
+                "deactivated_sentences": 0, "deleted_page_reviews": 0}
+
+    page_ids = [p.id for p in pages]
+
+    # Deactivate harvested Sentences for the old pages. Keep them around
+    # because review_log / sentence_review_log hold FKs.
+    sentence_q = db.query(Sentence).filter(
+        Sentence.page_id.in_(page_ids),
+        Sentence.is_active.is_(True),
+    )
+    deactivated = sentence_q.count()
+
+    # Page review logs for this story would silently dedup the next review
+    # if their `client_review_id` (pr:{sid}:{n}) collides with a new advance.
+    page_review_q = db.query(PageReviewLog).filter(PageReviewLog.story_id == story.id)
+    page_review_count = page_review_q.count()
+
+    stats = {
+        "old_pages": len(pages),
+        "new_pages": len(new_bodies),
+        "deactivated_sentences": deactivated,
+        "deleted_page_reviews": page_review_count,
+    }
+
+    LOG.info(
+        "Story id=%d %r (%s): %d old pages → %d new pages "
+        "(max_chars=%d), %d sentences to deactivate, %d page reviews to clear",
+        story.id, story.title, story.language_code,
+        stats["old_pages"], stats["new_pages"], max_chars,
+        deactivated, page_review_count,
+    )
+
+    if dry_run:
+        return stats
+
+    # Apply in one transaction. Note: deleting Pages cascades to PageWord
+    # via the SQLAlchemy relationship cascade. Sentences are FK-orphaned by
+    # the Page delete (page_id stays as an id-pointer; no DB-level cascade),
+    # but they're already marked inactive so they're invisible to the reader.
+    sentence_q.update({Sentence.is_active: False}, synchronize_session=False)
+    page_review_q.delete(synchronize_session=False)
+
+    # Delete old pages BEFORE inserting new ones to avoid the
+    # (story_id, page_number) unique-constraint collision.
+    for p in pages:
+        db.delete(p)
+    db.flush()
+
+    for idx, body in enumerate(new_bodies, start=1):
+        db.add(Page(story_id=story.id, page_number=idx, body_src=body))
+
+    story.page_count = len(new_bodies)
+    db.commit()
+    return stats
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    g = parser.add_mutually_exclusive_group(required=True)
+    g.add_argument("--story-id", type=int, help="Resplit one story by id.")
+    g.add_argument("--all", action="store_true",
+                   help="Resplit every active Story across languages.")
+    parser.add_argument(
+        "--max-chars", type=int, default=DEFAULT_MAX_CHARS_PER_PAGE,
+        help=f"Target max chars per page (default {DEFAULT_MAX_CHARS_PER_PAGE}).",
+    )
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Report only — don't write.")
+    parser.add_argument("--verbose", action="store_true")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    db = SessionLocal()
+    try:
+        q = db.query(Story).filter(Story.status == "active")
+        if args.story_id is not None:
+            q = q.filter(Story.id == args.story_id)
+        stories = q.order_by(Story.id).all()
+
+        if not stories:
+            LOG.warning("No matching stories.")
+            return 1
+
+        totals = {"old_pages": 0, "new_pages": 0,
+                  "deactivated_sentences": 0, "deleted_page_reviews": 0,
+                  "stories": 0}
+        for story in stories:
+            stats = _resplit_one_story(
+                db, story, max_chars=args.max_chars, dry_run=args.dry_run,
+            )
+            if stats["new_pages"] > 0:
+                totals["stories"] += 1
+                for k in ("old_pages", "new_pages",
+                          "deactivated_sentences", "deleted_page_reviews"):
+                    totals[k] += stats[k]
+
+        LOG.info("Totals: %s", totals)
+
+        if not args.dry_run and totals["stories"] > 0:
+            log_activity(
+                "pages_resplit",
+                f"Re-split {totals['stories']} story/stories "
+                f"({totals['old_pages']} → {totals['new_pages']} pages, "
+                f"max_chars={args.max_chars})",
+                detail={
+                    "story_ids": [s.id for s in stories],
+                    "max_chars": args.max_chars,
+                    **totals,
+                },
+            )
+    finally:
+        db.close()
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/polyglot/scripts/split_long_pages.py
+++ b/polyglot/scripts/split_long_pages.py
@@ -130,11 +130,16 @@ def _resplit_one_story(
     if dry_run:
         return stats
 
-    # Apply in one transaction. Note: deleting Pages cascades to PageWord
-    # via the SQLAlchemy relationship cascade. Sentences are FK-orphaned by
-    # the Page delete (page_id stays as an id-pointer; no DB-level cascade),
-    # but they're already marked inactive so they're invisible to the reader.
-    sentence_q.update({Sentence.is_active: False}, synchronize_session=False)
+    # Apply in one transaction. Note: deleting Pages cascades to PageWord via
+    # the SQLAlchemy relationship cascade. Sentence rows are kept (FK history
+    # in review_log/sentence_review_log) but flipped inactive AND have their
+    # `page_id` nulled — PRAGMA foreign_keys=ON would otherwise block the
+    # Page delete (sentences.page_id has no ondelete cascade). Going-forward
+    # harvest inserts fresh Sentence rows under the new Page ids.
+    sentence_q.update(
+        {Sentence.is_active: False, Sentence.page_id: None},
+        synchronize_session=False,
+    )
     page_review_q.delete(synchronize_session=False)
 
     # Delete old pages BEFORE inserting new ones to avoid the

--- a/polyglot/tests/test_reading_intake.py
+++ b/polyglot/tests/test_reading_intake.py
@@ -113,6 +113,113 @@ def test_split_into_sentences_unquoted_text_unaffected_by_dialog_rule():
     assert parts == ["Marcus venit.", "Quintus plorat.", "Iulia cantat."]
 
 
+# ─── paginate_by_length ────────────────────────────────────────────────────
+
+
+def test_paginate_short_text_one_page():
+    out = reading_intake._paginate_by_length("Καλημέρα.", "el", max_chars=500)
+    assert out == ["Καλημέρα."]
+
+
+def test_paginate_empty_returns_empty_list():
+    assert reading_intake._paginate_by_length("", "el") == []
+    assert reading_intake._paginate_by_length("   \n  ", "el") == []
+
+
+def test_paginate_groups_sentences_under_limit():
+    # Three 12-char sentences. max=30 → first two fit (25 chars), third spills.
+    text = "Aaa aaa aaa. Bbb bbb bbb. Ccc ccc ccc."
+    out = reading_intake._paginate_by_length(text, "la", max_chars=30)
+    assert out == ["Aaa aaa aaa. Bbb bbb bbb.", "Ccc ccc ccc."]
+
+
+def test_paginate_keeps_oversize_single_sentence_whole():
+    # An 80-char single sentence with max=40 stays as one page rather than
+    # being sliced mid-clause.
+    text = "Hoc est unum colossale enuntiatum quod limitem excedit certissime."
+    out = reading_intake._paginate_by_length(text, "la", max_chars=40)
+    assert out == [text]
+
+
+def test_paginate_latin_calendar_abbrev_not_split():
+    # Eutropius-style date phrase — `Kal.` must stay attached to its date,
+    # so we don't generate an orphan "Maias, ..." page.
+    text = (
+        "Urbs Romana condita est ante diem XI Kal. Maias, "
+        "Olympiadis sextae anno tertio. "
+        "Romulus deinde populum in centurias divisit. "
+        "Senatum ex centum optimatibus elegit. "
+        "Bellum cum Sabinis gessit propter raptas mulieres."
+    )
+    out = reading_intake._paginate_by_length(text, "la", max_chars=80)
+    # First page must contain the full date phrase including 'Kal. Maias'.
+    assert any("Kal. Maias" in p for p in out)
+    # All Latin in every chunk, no naked "Maias" page-start.
+    assert not any(p.startswith("Maias") for p in out)
+
+
+def test_paginate_greek_textbook_excerpt():
+    # First 4 sentences of the actual production Greek textbook page 11
+    # (Ιστορία), which today is one ~4,600-char page. ~500-char max should
+    # split it.
+    text = (
+        "Μεσοποταμία ονομάστηκε για πρώτη φορά από τους αρχαίους Έλληνες η "
+        "χώρα την οποία διαρρέουν δύο μεγάλοι ποταμοί, ο Τίγρης ανατολικά "
+        "και ο Ευφράτης δυτικά. "
+        "Με το όνομα αυτό οριοθετείται μια μεγάλη περιοχή που περιλαμβάνει "
+        "τις κοιλάδες των δύο ποταμών και των παραποτάμων τους. "
+        "Το μεγαλύτερο και σπουδαιότερο σε ότι αφορά την ιστορία τμήμα της "
+        "χώρας αυτής βρίσκεται στο σημερινό κράτος του Ιράκ. "
+        "Ο Τίγρης και ο Ευφράτης στην πορεία τους διακλαδίζονται σε "
+        "παραποτάμους, ενώνονται όμως πριν από την έξοδό τους στον Περσικό "
+        "κόλπο και σχηματίζουν μια ελώδη περιοχή μεγάλης έκτασης."
+    )
+    out = reading_intake._paginate_by_length(text, "el", max_chars=500)
+    # Splits into more than one page, every page non-empty, every page <= ~600
+    # (cap + headroom for a single trailing oversize sentence).
+    assert len(out) >= 2
+    assert all(len(p) > 0 for p in out)
+    # The four full sentences should still be present in concatenation.
+    joined = " ".join(out)
+    assert "Μεσοποταμία" in joined
+    assert "Περσικό κόλπο" in joined
+    # No sentence should be cut mid-word — every page ends with terminal
+    # punctuation (the only oversize-sentence escape would land terminal at
+    # the page end anyway).
+    for p in out:
+        assert p[-1] in ".!?·;"
+
+
+def test_import_paste_paginates_long_body(tmp_db):
+    # Long pasted body should fan out into multiple Pages.
+    body = ("Λέγει. " * 200).strip()  # 7 chars * 200 = ~1400 chars
+    with tmp_db() as db:
+        story = reading_intake.import_paste(
+            db, language_code="el", body=body, max_chars_per_page=300,
+        )
+        pages = (
+            db.query(Page)
+            .filter(Page.story_id == story.id)
+            .order_by(Page.page_number)
+            .all()
+        )
+        assert len(pages) >= 2
+        assert story.page_count == len(pages)
+        assert [p.page_number for p in pages] == list(range(1, len(pages) + 1))
+
+
+def test_import_paste_legacy_single_page_when_disabled(tmp_db):
+    # Pass max_chars_per_page=None to opt out and recover the pre-redesign
+    # single-page behavior (used by callers that want to keep the body whole).
+    body = ("Λέγει. " * 200).strip()
+    with tmp_db() as db:
+        story = reading_intake.import_paste(
+            db, language_code="el", body=body, max_chars_per_page=None,
+        )
+        pages = db.query(Page).filter(Page.story_id == story.id).all()
+        assert len(pages) == 1
+
+
 def test_paste_creates_story_and_single_page(tmp_db):
     with tmp_db() as db:
         story = reading_intake.import_paste(


### PR DESCRIPTION
## Summary

- New `_paginate_by_length` helper (`polyglot/app/services/reading_intake.py`) splits import bodies at sentence boundaries to a configurable max (default **500 chars**). Reuses the existing language-aware `_split_into_sentences`, so Latin calendar abbreviations (`Kal.` etc) and quoted dialog stay intact.
- `import_paste` and `import_pdf` now paginate automatically. PDF page boundaries are preserved as natural section breaks — never merged across — so a 100-char PDF page stays one polyglot page and a 4,600-char one fans out.
- `scripts/split_long_pages.py` re-splits already-imported stories in place. Per the deactivate-don't-delete policy (CLAUDE.md / sentence_harvest), harvested `Sentence` rows are flipped to `is_active=False` rather than deleted — `review_log` / `sentence_review_log` keep their historical FKs intact. Old `Page` rows are deleted (PageWord cascades via the SQLAlchemy relationship). The story's `page_review_log` is cleared so the `pr:{sid}:{n}` idempotency record can't silently no-op the user's next read at a now-different page.

## Why

The Greek "Ιστορία" textbook (story 1) averages ~2,280 chars/page (max 4,655), which on a phone screen requires heavy scrolling and visually buries the per-sentence Reveal that PR #152 just rebuilt. Target ~500 chars ≈ 1-3 short paragraphs of EB Garamond — close to one screen.

## Production rollout (after merge)

```bash
# Dry-run first
polyglot/.venv/bin/python scripts/split_long_pages.py --all --dry-run

# Apply
polyglot/.venv/bin/python scripts/split_long_pages.py --all
```

Logs to ActivityLog (`pages_resplit`). Frontend reading cursor (AsyncStorage) survives — `pageNumber` will resolve to a page with the same number but different content, which is acceptable since the user will navigate from the library.