### PR TITLE
Confusion picker UI fixes: tap-to-pick, keyboard avoidance, saved state

### DIFF
--- a/frontend/app/index.tsx
+++ b/frontend/app/index.tsx
@@ -9,6 +9,7 @@ import {
   Animated,
   Platform,
   AppState,
+  KeyboardAvoidingView,
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
@@ -2722,7 +2723,33 @@ export function ReviewScreen({ fixedMode }: { fixedMode: ReviewMode }) {
   const showSentenceInfo = item.sentence_id != null && !isPassageCard(item);
   const showStoryInfo = item.sentence_id != null && isPassageCard(item);
 
+  const pickedConfusionLemmaId =
+    lookupLemmaId != null && confusionCaptures[lookupLemmaId]?.capture_method === "suggested_pick"
+      ? confusionCaptures[lookupLemmaId].confused_with_lemma_id ?? null
+      : null;
+  const handlePickConfusion = (chosenLemmaId: number) => {
+    if (lookupLemmaId == null || !confusionData) return;
+    const candidateIds = [
+      ...(confusionData.similar_words ?? []).map((w) => w.lemma_id),
+      ...(confusionData.phonetic_similar ?? []).map((w) => w.lemma_id),
+    ];
+    setConfusionCaptures((prev) => ({
+      ...prev,
+      [lookupLemmaId]: {
+        failed_lemma_id: lookupLemmaId,
+        capture_method: "suggested_pick",
+        confused_with_lemma_id: chosenLemmaId,
+        candidates_shown: Array.from(new Set(candidateIds)),
+      },
+    }));
+  };
+
   return (
+    <KeyboardAvoidingView
+      style={{ flex: 1 }}
+      behavior={Platform.OS === "ios" ? "padding" : undefined}
+      keyboardVerticalOffset={Platform.OS === "ios" ? insets.top : 0}
+    >
     <View
       style={[styles.container, isListening && styles.listeningContainer, { paddingTop: Math.max(insets.top, 12) }]}
     >
@@ -2812,6 +2839,8 @@ export function ReviewScreen({ fixedMode }: { fixedMode: ReviewMode }) {
           hasNext={tappedCursor < tappedOrder.length - 1}
           surfaceTranslit={lookupSurfaceTranslit}
           confusionData={confusionData}
+          onPickConfusion={handlePickConfusion}
+          pickedConfusionLemmaId={pickedConfusionLemmaId}
         />
       )}
 
@@ -2875,6 +2904,7 @@ export function ReviewScreen({ fixedMode }: { fixedMode: ReviewMode }) {
         />
       )}
     </View>
+    </KeyboardAvoidingView>
   );
 }
 

--- a/frontend/lib/review/ConfusionPicker.tsx
+++ b/frontend/lib/review/ConfusionPicker.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useState } from "react";
 import { Pressable, StyleSheet, Text, TextInput, View } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
 import { colors, fontFamily } from "../theme";
 import { ConfusionAnalysis, ConfusionCaptureIn } from "../types";
 
@@ -11,12 +12,6 @@ interface ConfusionPickerProps {
   onClear: () => void;
 }
 
-interface Candidate {
-  lemma_id: number;
-  lemma_ar: string;
-  gloss_en: string | null;
-}
-
 export function ConfusionPicker({
   failedLemmaId,
   confusionData,
@@ -24,72 +19,88 @@ export function ConfusionPicker({
   onSave,
   onClear,
 }: ConfusionPickerProps) {
-  const [expanded, setExpanded] = useState<boolean>(!!existing);
-  const [selectedLemmaId, setSelectedLemmaId] = useState<number | null>(
-    existing?.capture_method === "suggested_pick" ? existing.confused_with_lemma_id ?? null : null,
-  );
   const [freeText, setFreeText] = useState<string>(
     existing?.capture_method === "free_text" ? existing.confused_with_text ?? "" : "",
   );
+  const [typing, setTyping] = useState<boolean>(false);
 
-  const candidates: Candidate[] = useMemo(() => {
+  const candidateIds = useMemo(() => {
     const seen = new Set<number>();
-    const out: Candidate[] = [];
+    const out: number[] = [];
     for (const w of confusionData.similar_words ?? []) {
-      if (seen.has(w.lemma_id)) continue;
-      seen.add(w.lemma_id);
-      out.push({ lemma_id: w.lemma_id, lemma_ar: w.lemma_ar, gloss_en: w.gloss_en ?? null });
-      if (out.length >= 5) break;
+      if (!seen.has(w.lemma_id)) { seen.add(w.lemma_id); out.push(w.lemma_id); }
     }
     for (const w of confusionData.phonetic_similar ?? []) {
-      if (out.length >= 5) break;
-      if (seen.has(w.lemma_id)) continue;
-      seen.add(w.lemma_id);
-      out.push({ lemma_id: w.lemma_id, lemma_ar: w.lemma_ar, gloss_en: w.gloss_en ?? null });
+      if (!seen.has(w.lemma_id)) { seen.add(w.lemma_id); out.push(w.lemma_id); }
     }
     return out;
   }, [confusionData]);
 
-  const candidateIds = candidates.map((c) => c.lemma_id);
-
-  const handlePickChip = (lemmaId: number) => {
-    setFreeText("");
-    setSelectedLemmaId(lemmaId);
-    onSave({
-      failed_lemma_id: failedLemmaId,
-      capture_method: "suggested_pick",
-      confused_with_lemma_id: lemmaId,
-      candidates_shown: candidateIds,
-    });
-  };
+  const savedSummary = useMemo(() => {
+    if (!existing) return null;
+    if (existing.capture_method === "suggested_pick") {
+      const all = [...(confusionData.similar_words ?? []), ...(confusionData.phonetic_similar ?? [])];
+      const match = all.find((w) => w.lemma_id === existing.confused_with_lemma_id);
+      return {
+        kind: "lemma" as const,
+        arabic: match?.lemma_ar ?? `#${existing.confused_with_lemma_id}`,
+        gloss: match?.gloss_en ?? null,
+      };
+    }
+    return { kind: "text" as const, text: existing.confused_with_text ?? "" };
+  }, [existing, confusionData]);
 
   const handleSubmitText = () => {
     const text = freeText.trim();
     if (!text) return;
-    setSelectedLemmaId(null);
     onSave({
       failed_lemma_id: failedLemmaId,
       capture_method: "free_text",
       confused_with_text: text,
       candidates_shown: candidateIds,
     });
+    setTyping(false);
   };
 
-  const handleClear = () => {
-    setSelectedLemmaId(null);
+  const handleClearAll = () => {
     setFreeText("");
+    setTyping(false);
     onClear();
   };
 
-  if (!expanded) {
+  if (savedSummary) {
+    return (
+      <View style={styles.savedRow}>
+        <Ionicons name="checkmark-circle" size={16} color={colors.confused} />
+        <Text style={styles.savedLabel}>Will record: </Text>
+        {savedSummary.kind === "lemma" ? (
+          <>
+            <Text style={styles.savedArabic}>{savedSummary.arabic}</Text>
+            {savedSummary.gloss && (
+              <Text style={styles.savedGloss} numberOfLines={1}>
+                ({savedSummary.gloss})
+              </Text>
+            )}
+          </>
+        ) : (
+          <Text style={styles.savedText} numberOfLines={1}>"{savedSummary.text}"</Text>
+        )}
+        <Pressable onPress={handleClearAll} hitSlop={8} style={styles.clearLinkWrap}>
+          <Text style={styles.clearLink}>clear</Text>
+        </Pressable>
+      </View>
+    );
+  }
+
+  if (!typing) {
     return (
       <Pressable
-        onPress={() => setExpanded(true)}
+        onPress={() => setTyping(true)}
         style={({ pressed }) => [styles.collapsedLink, pressed && { opacity: 0.5 }]}
         accessibilityRole="button"
       >
         <Text style={styles.collapsedText}>
-          {existing ? "✓ confused with something — edit" : "Confused with another word?"}
+          Or type the word you thought it was ›
         </Text>
       </Pressable>
     );
@@ -97,70 +108,29 @@ export function ConfusionPicker({
 
   return (
     <View style={styles.container}>
-      <View style={styles.header}>
-        <Text style={styles.title}>What were you thinking of?</Text>
-        <Pressable onPress={() => setExpanded(false)} hitSlop={8}>
-          <Text style={styles.cancelLink}>Close</Text>
-        </Pressable>
-      </View>
-
-      {candidates.length > 0 && (
-        <View style={styles.chipsRow}>
-          {candidates.map((c) => {
-            const selected = selectedLemmaId === c.lemma_id;
-            return (
-              <Pressable
-                key={c.lemma_id}
-                onPress={() => handlePickChip(c.lemma_id)}
-                style={({ pressed }) => [
-                  styles.chip,
-                  selected && styles.chipSelected,
-                  pressed && { opacity: 0.7 },
-                  freeText.length > 0 && !selected && styles.chipDimmed,
-                ]}
-              >
-                <Text style={[styles.chipArabic, selected && styles.chipArabicSelected]}>
-                  {c.lemma_ar}
-                </Text>
-                {c.gloss_en && (
-                  <Text style={[styles.chipGloss, selected && styles.chipGlossSelected]} numberOfLines={1}>
-                    {c.gloss_en}
-                  </Text>
-                )}
-              </Pressable>
-            );
-          })}
-        </View>
-      )}
-
       <View style={styles.textRow}>
         <TextInput
           value={freeText}
-          onChangeText={(t) => {
-            setFreeText(t);
-            if (t.length > 0 && selectedLemmaId !== null) setSelectedLemmaId(null);
-          }}
+          onChangeText={setFreeText}
           onSubmitEditing={handleSubmitText}
-          placeholder="…or type in English"
+          placeholder="what word did you think it was?"
           placeholderTextColor={colors.textSecondary}
-          style={[
-            styles.textInput,
-            selectedLemmaId !== null && styles.textInputDimmed,
-          ]}
-          editable={selectedLemmaId === null}
+          style={styles.textInput}
+          autoFocus
+          returnKeyType="done"
+          blurOnSubmit
         />
-        {freeText.trim().length > 0 && (
-          <Pressable onPress={handleSubmitText} style={styles.saveButton}>
-            <Text style={styles.saveButtonText}>Save</Text>
-          </Pressable>
-        )}
-      </View>
-
-      {existing && (
-        <Pressable onPress={handleClear} style={styles.clearRow}>
-          <Text style={styles.clearText}>Clear selection</Text>
+        <Pressable
+          onPress={handleSubmitText}
+          disabled={freeText.trim().length === 0}
+          style={[styles.saveButton, freeText.trim().length === 0 && styles.saveButtonDisabled]}
+        >
+          <Text style={styles.saveButtonText}>Save</Text>
         </Pressable>
-      )}
+        <Pressable onPress={() => { setTyping(false); setFreeText(""); }} hitSlop={8}>
+          <Text style={styles.cancelLink}>cancel</Text>
+        </Pressable>
+      </View>
     </View>
   );
 }
@@ -170,6 +140,7 @@ const styles = StyleSheet.create({
     paddingVertical: 6,
     paddingHorizontal: 4,
     marginTop: 4,
+    alignSelf: "flex-start",
   },
   collapsedText: {
     color: colors.textSecondary,
@@ -178,70 +149,12 @@ const styles = StyleSheet.create({
     textDecorationLine: "underline",
   },
   container: {
-    marginTop: 8,
-    padding: 10,
+    marginTop: 6,
+    padding: 8,
     borderRadius: 8,
     backgroundColor: "rgba(243, 156, 18, 0.08)",
     borderWidth: 1,
     borderColor: "rgba(243, 156, 18, 0.25)",
-  },
-  header: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-    alignItems: "center",
-    marginBottom: 8,
-  },
-  title: {
-    color: colors.text,
-    fontSize: 13,
-    fontFamily: fontFamily.translitRegular,
-    fontWeight: "600" as const,
-  },
-  cancelLink: {
-    color: colors.textSecondary,
-    fontSize: 12,
-    fontFamily: fontFamily.translitRegular,
-  },
-  chipsRow: {
-    flexDirection: "row",
-    flexWrap: "wrap",
-    gap: 6,
-    marginBottom: 8,
-  },
-  chip: {
-    paddingVertical: 6,
-    paddingHorizontal: 10,
-    borderRadius: 14,
-    backgroundColor: colors.surface,
-    borderWidth: 1,
-    borderColor: colors.border,
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 6,
-  },
-  chipSelected: {
-    backgroundColor: colors.confused,
-    borderColor: colors.confused,
-  },
-  chipDimmed: {
-    opacity: 0.4,
-  },
-  chipArabic: {
-    color: colors.text,
-    fontSize: 16,
-    fontFamily: fontFamily.arabic,
-  },
-  chipArabicSelected: {
-    color: "#fff",
-  },
-  chipGloss: {
-    color: colors.textSecondary,
-    fontSize: 11,
-    fontFamily: fontFamily.translitRegular,
-    maxWidth: 110,
-  },
-  chipGlossSelected: {
-    color: "#fff",
   },
   textRow: {
     flexDirection: "row",
@@ -260,14 +173,14 @@ const styles = StyleSheet.create({
     fontFamily: fontFamily.translitRegular,
     backgroundColor: colors.surface,
   },
-  textInputDimmed: {
-    opacity: 0.4,
-  },
   saveButton: {
     paddingHorizontal: 12,
     paddingVertical: 7,
     backgroundColor: colors.confused,
     borderRadius: 6,
+  },
+  saveButtonDisabled: {
+    opacity: 0.4,
   },
   saveButtonText: {
     color: "#fff",
@@ -275,11 +188,52 @@ const styles = StyleSheet.create({
     fontFamily: fontFamily.translitRegular,
     fontWeight: "600" as const,
   },
-  clearRow: {
-    marginTop: 6,
-    alignSelf: "flex-end",
+  cancelLink: {
+    color: colors.textSecondary,
+    fontSize: 11,
+    fontFamily: fontFamily.translitRegular,
+    paddingHorizontal: 4,
   },
-  clearText: {
+  savedRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    marginTop: 6,
+    paddingVertical: 7,
+    paddingHorizontal: 10,
+    borderRadius: 8,
+    backgroundColor: "rgba(243, 156, 18, 0.12)",
+    borderWidth: 1,
+    borderColor: "rgba(243, 156, 18, 0.35)",
+  },
+  savedLabel: {
+    color: colors.text,
+    fontSize: 12,
+    fontFamily: fontFamily.translitRegular,
+    fontWeight: "600" as const,
+  },
+  savedArabic: {
+    color: colors.arabic,
+    fontFamily: fontFamily.arabic,
+    fontSize: 18,
+    writingDirection: "rtl",
+  },
+  savedGloss: {
+    color: colors.textSecondary,
+    fontSize: 12,
+    fontFamily: fontFamily.translitRegular,
+    flexShrink: 1,
+  },
+  savedText: {
+    color: colors.text,
+    fontSize: 13,
+    fontStyle: "italic",
+    flexShrink: 1,
+  },
+  clearLinkWrap: {
+    marginLeft: "auto",
+  },
+  clearLink: {
     color: colors.textSecondary,
     fontSize: 11,
     fontFamily: fontFamily.translitRegular,

--- a/frontend/lib/review/WordInfoCard.tsx
+++ b/frontend/lib/review/WordInfoCard.tsx
@@ -27,6 +27,8 @@ interface WordInfoCardProps {
   hasNext?: boolean;
   surfaceTranslit?: string | null;
   confusionData?: ConfusionAnalysis | null;
+  onPickConfusion?: (lemmaId: number) => void;
+  pickedConfusionLemmaId?: number | null;
 }
 
 function stemWord(w: string): string {
@@ -165,6 +167,8 @@ export default function WordInfoCard({
   hasNext = false,
   surfaceTranslit,
   confusionData,
+  onPickConfusion,
+  pickedConfusionLemmaId,
 }: WordInfoCardProps) {
   const hasFocus = !!surfaceForm && (markState !== null || !!result || loading);
   const showNav = hasPrev || hasNext;
@@ -246,7 +250,17 @@ export default function WordInfoCard({
         <GrammarParticleView info={particleInfo} />
       ) : (
         <ScrollView style={{ maxHeight: 200 }} showsVerticalScrollIndicator={true} nestedScrollEnabled>
-          <RevealedView result={result} surfaceForm={surfaceForm} onNavigateToDetail={onNavigateToDetail} onNavigateToPattern={onNavigateToPattern} onNavigateToRoot={onNavigateToRoot} surfaceTranslit={surfaceTranslit} confusionData={markState === "did_not_recognize" ? confusionData : null} />
+          <RevealedView
+            result={result}
+            surfaceForm={surfaceForm}
+            onNavigateToDetail={onNavigateToDetail}
+            onNavigateToPattern={onNavigateToPattern}
+            onNavigateToRoot={onNavigateToRoot}
+            surfaceTranslit={surfaceTranslit}
+            confusionData={markState === "did_not_recognize" ? confusionData : null}
+            onPickConfusion={markState === "did_not_recognize" ? onPickConfusion : undefined}
+            pickedConfusionLemmaId={markState === "did_not_recognize" ? pickedConfusionLemmaId ?? null : null}
+          />
         </ScrollView>
       )}
     </Animated.View>
@@ -286,6 +300,8 @@ function RevealedView({
   onNavigateToRoot,
   surfaceTranslit,
   confusionData,
+  onPickConfusion,
+  pickedConfusionLemmaId,
 }: {
   result: WordLookupResult | null;
   surfaceForm?: string | null;
@@ -294,6 +310,8 @@ function RevealedView({
   onNavigateToRoot?: (rootId: number) => void;
   surfaceTranslit?: string | null;
   confusionData?: ConfusionAnalysis | null;
+  onPickConfusion?: (lemmaId: number) => void;
+  pickedConfusionLemmaId?: number | null;
 }) {
   if (!result) return null;
 
@@ -392,6 +410,9 @@ function RevealedView({
           <View style={styles.confusionHeader}>
             <Ionicons name="eye-outline" size={14} color={colors.confused} />
             <Text style={styles.confusionTitle}>Easily confused</Text>
+            {onPickConfusion && (
+              <Text style={styles.pickHint}>tap one if that's what you thought</Text>
+            )}
           </View>
           {similarWords.slice(0, 6).map((sw) => {
             const diffSet = new Set(sw.diff_positions.map(d => d.pos));
@@ -400,29 +421,48 @@ function RevealedView({
               ? `has ${sw.diff_positions.slice(0, 2).map(d => d.similar).join(", ")} not ${sw.diff_positions.slice(0, 2).map(d => d.original).join(", ")}`
               : null;
             const hint = sw.match_reason ? `${sw.match_reason}${formHint}` : diffHint;
-            return (
-              <View key={sw.lemma_id} style={styles.confusionItem}>
-                <View style={styles.confusionItemRow}>
-                  <HighlightedArabic
-                    text={sw.lemma_ar}
-                    diffPositions={diffSet}
-                    highlightColor={colors.confused}
-                    fontSize={26}
-                  />
-                  <View style={styles.confusionTextCol}>
-                    <Text style={styles.confusionGloss} numberOfLines={1}>{sw.gloss_en ?? "?"}</Text>
-                    {hint && (
-                      <Text style={styles.confusionHint} numberOfLines={1}>
-                        {hint}
-                      </Text>
-                    )}
-                  </View>
-                  {sw.rasm_distance === 0 && (
-                    <View style={styles.dotsPill}>
-                      <Text style={styles.dotsPillText}>dots only</Text>
-                    </View>
+            const picked = pickedConfusionLemmaId === sw.lemma_id;
+            const itemContent = (
+              <View style={[styles.confusionItemRow, picked && styles.confusionItemRowPicked]}>
+                {picked && (
+                  <Ionicons name="checkmark-circle" size={18} color={colors.confused} />
+                )}
+                <HighlightedArabic
+                  text={sw.lemma_ar}
+                  diffPositions={diffSet}
+                  highlightColor={colors.confused}
+                  fontSize={26}
+                />
+                <View style={styles.confusionTextCol}>
+                  <Text style={styles.confusionGloss} numberOfLines={1}>{sw.gloss_en ?? "?"}</Text>
+                  {hint && (
+                    <Text style={styles.confusionHint} numberOfLines={1}>
+                      {hint}
+                    </Text>
                   )}
                 </View>
+                {sw.rasm_distance === 0 && (
+                  <View style={styles.dotsPill}>
+                    <Text style={styles.dotsPillText}>dots only</Text>
+                  </View>
+                )}
+              </View>
+            );
+            return onPickConfusion ? (
+              <Pressable
+                key={sw.lemma_id}
+                onPress={() => onPickConfusion(sw.lemma_id)}
+                style={({ pressed }) => [
+                  styles.confusionItem,
+                  picked && styles.confusionItemPicked,
+                  pressed && { opacity: 0.6 },
+                ]}
+              >
+                {itemContent}
+              </Pressable>
+            ) : (
+              <View key={sw.lemma_id} style={styles.confusionItem}>
+                {itemContent}
               </View>
             );
           })}
@@ -435,18 +475,38 @@ function RevealedView({
           <View style={styles.confusionHeader}>
             <Ionicons name="ear-outline" size={14} color="#8e44ad" />
             <Text style={[styles.confusionTitle, { color: "#8e44ad" }]}>Sounds similar</Text>
+            {onPickConfusion && (
+              <Text style={styles.pickHint}>tap one if that's what you thought</Text>
+            )}
           </View>
-          {phoneticSimilar.slice(0, 3).map((pw) => (
-            <View key={pw.lemma_id} style={styles.phoneticItem}>
-              <Text style={styles.phoneticAr}>{pw.lemma_ar}</Text>
-              <Text style={styles.confusionGloss} numberOfLines={1}>{pw.gloss_en ?? "?"}</Text>
-              {pw.confused_pairs.length > 0 && (
-                <View style={styles.phoneticPairsPill}>
-                  <Text style={styles.phoneticPairsText}>{pw.confused_pairs.join(" ")}</Text>
-                </View>
-              )}
-            </View>
-          ))}
+          {phoneticSimilar.slice(0, 3).map((pw) => {
+            const picked = pickedConfusionLemmaId === pw.lemma_id;
+            const itemContent = (
+              <View style={[styles.phoneticItem, picked && styles.phoneticItemPicked]}>
+                {picked && (
+                  <Ionicons name="checkmark-circle" size={18} color="#8e44ad" />
+                )}
+                <Text style={styles.phoneticAr}>{pw.lemma_ar}</Text>
+                <Text style={styles.confusionGloss} numberOfLines={1}>{pw.gloss_en ?? "?"}</Text>
+                {pw.confused_pairs.length > 0 && (
+                  <View style={styles.phoneticPairsPill}>
+                    <Text style={styles.phoneticPairsText}>{pw.confused_pairs.join(" ")}</Text>
+                  </View>
+                )}
+              </View>
+            );
+            return onPickConfusion ? (
+              <Pressable
+                key={pw.lemma_id}
+                onPress={() => onPickConfusion(pw.lemma_id)}
+                style={({ pressed }) => [pressed && { opacity: 0.6 }]}
+              >
+                {itemContent}
+              </Pressable>
+            ) : (
+              <View key={pw.lemma_id}>{itemContent}</View>
+            );
+          })}
         </View>
       )}
 
@@ -1011,10 +1071,27 @@ const styles = StyleSheet.create({
     borderBottomWidth: StyleSheet.hairlineWidth,
     borderBottomColor: "rgba(243, 156, 18, 0.12)",
   },
+  confusionItemPicked: {
+    backgroundColor: "rgba(243, 156, 18, 0.18)",
+    borderRadius: 8,
+    paddingHorizontal: 6,
+    paddingTop: 4,
+    paddingBottom: 4,
+    borderBottomWidth: 0,
+  },
   confusionItemRow: {
     flexDirection: "row",
     alignItems: "center",
     gap: 10,
+  },
+  confusionItemRowPicked: {
+    gap: 8,
+  },
+  pickHint: {
+    marginLeft: "auto",
+    color: colors.textSecondary,
+    fontSize: 10,
+    fontStyle: "italic",
   },
   confusionTextCol: {
     flex: 1,
@@ -1056,6 +1133,12 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "center",
     gap: 8,
+  },
+  phoneticItemPicked: {
+    backgroundColor: "rgba(142, 68, 173, 0.18)",
+    borderRadius: 8,
+    paddingHorizontal: 6,
+    paddingVertical: 4,
   },
   phoneticAr: {
     fontFamily: fontFamily.arabic,


### PR DESCRIPTION
## Summary

Fixes three problems with the confusion-capture picker shipped in #167:

- **Duplicate display** — the "Easily confused" yellow list inside `WordInfoCard` already showed the same lemmas the picker re-rendered as chips. Now the chips are gone; tapping a word in the yellow (or purple "Sounds similar") section is itself the pick action. Picked item gets a check-circle + tinted background.
- **Keyboard covered the input** — review container is now wrapped in `KeyboardAvoidingView` (iOS `padding`, `keyboardVerticalOffset={insets.top}`).
- **Unclear whether it saved** — picker becomes a tiny status banner showing "Will record: <Arabic + gloss>" or "Will record: \"text\"" with a clear link. Explicit "Will record" wording communicates that persistence happens at sentence submit (the captures are submitted with the rest of the review payload).

Backend (`ConfusionCapture` table, `sentence_review_service.submit_sentence_review`) is unchanged.

Verified in prod: 6 captures recorded today across both `suggested_pick` and `free_text` methods, all with `candidates_shown_json` populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)