### PR TITLE
Root showcase Phase 7: trust_palette_mappings narrow exception

### DIFF
--- a/backend/app/services/material_generator.py
+++ b/backend/app/services/material_generator.py
@@ -1267,6 +1267,8 @@ def validate_multi_target_sentence(
     result,
     lemma_lookup: dict[str, int],
     target_bares: dict[str, int],
+    *,
+    trust_palette_mappings: bool = False,
 ) -> list | None:
     """LLM-only validation phase. No DB writes, no session dirty state.
 
@@ -1278,6 +1280,17 @@ def validate_multi_target_sentence(
     the session has no dirty state when calling — otherwise the query-driven
     autoflush will acquire the SQLite write lock and hold it for the duration
     of the LLM calls (verify ~15-25s, disambig ~5-10s).
+
+    trust_palette_mappings: when True, verifier corrections targeting positions
+    flagged is_target=True (i.e. the bare form matches one of the caller's
+    target_bares — a verified palette match) are dropped before being passed to
+    apply_corrections. The semantics: palette mappings come from a deterministic
+    spec (the caller asked the LLM to use lemma[X] for surface Y, and the bare
+    confirms the match), not from inference. The verifier's objections at these
+    positions are bypassed because we have ground truth. Scaffold-position
+    corrections are preserved — the verifier's general gate still applies there.
+    Currently used only by root_showcase.py, where same-root crowded sentences
+    confuse the verifier into rejecting correctly-mapped palette lemmas.
     """
     from app.services.sentence_validator import (
         map_tokens_to_lemmas,
@@ -1354,6 +1367,23 @@ def validate_multi_target_sentence(
     if corrections is None:
         logger.warning("Mapping verification unavailable for multi-target sentence, discarding")
         return None
+    if corrections and trust_palette_mappings:
+        # Drop corrections at palette positions: the bare form matched a
+        # caller-supplied target — that's ground truth, not inference. Leaves
+        # scaffold-position corrections intact so apply_corrections's general
+        # gate still fires there (and same_lemma rejection on scaffold still
+        # works as designed — see apply_corrections docstring).
+        palette_positions = {m.position for m in mappings if m.is_target}
+        before = len(corrections)
+        corrections = [
+            c for c in corrections if c.get("position") not in palette_positions
+        ]
+        dropped = before - len(corrections)
+        if dropped:
+            logger.info(
+                f"trust_palette_mappings: dropped {dropped} verifier "
+                f"correction(s) at palette positions for: {result.arabic[:60]}"
+            )
     if corrections:
         failed = apply_corrections(
             corrections, mappings, db, arabic_text=result.arabic,

--- a/backend/app/services/root_showcase.py
+++ b/backend/app/services/root_showcase.py
@@ -257,8 +257,13 @@ def generate_and_store_showcases_for_root(
             transliteration=res.transliteration,
             primary_target_lemma_id=primary_lemma_id,
         )
+        # trust_palette_mappings=True: palette positions are deterministic
+        # spec (we asked LLM to use lemma[X] for surface Y, mapper confirmed
+        # the bare match). Verifier objections at palette positions are
+        # bypassed; scaffold-position corrections still apply normally.
         mappings = validate_multi_target_sentence(
             db, adapted, lemma_lookup, target_bares,
+            trust_palette_mappings=True,
         )
         if mappings is None:
             rejected.append(f"validation_failed: {res.arabic[:40]}")

--- a/backend/tests/test_root_showcase.py
+++ b/backend/tests/test_root_showcase.py
@@ -219,7 +219,7 @@ def test_generate_requires_three_palette_lemmas_per_sentence(db_session):
         # second returns None (validation failed)
         from app.services.sentence_validator import TokenMapping
 
-        def fake_validate(db, result, lemma_lookup, target_bares):
+        def fake_validate(db, result, lemma_lookup, target_bares, **kwargs):
             if "كَتَبَ" in result.arabic and "كاتِب" in result.arabic:
                 ms = []
                 for i, (sf, lid) in enumerate([
@@ -321,3 +321,83 @@ def test_palette_due_ranking_orders_by_acquisition_then_fsrs(db_session):
     targeted = {l_due_soon.lemma_id, l_overdue.lemma_id, l_no_due.lemma_id}
     most_due = min(targeted, key=lambda lid: ranks.get(lid, _DUE_RANK_DEFAULT))
     assert most_due == l_overdue.lemma_id
+
+
+def _stub_validate_multi_target(*, trust_palette_mappings: bool):
+    """Drive material_generator.validate_multi_target_sentence with everything
+    inside mocked. Returns the corrections list that reached apply_corrections.
+
+    The function imports its dependencies inside (sentence_validator helpers),
+    so we patch at the sentence_validator module, not material_generator.
+    """
+    from unittest.mock import MagicMock
+    from app.services import material_generator
+    from app.services.sentence_validator import TokenMapping
+
+    mappings = [
+        TokenMapping(position=0, surface_form="كَتَبَ", lemma_id=101,
+                     is_target=True, is_function_word=False),
+        TokenMapping(position=1, surface_form="فِي", lemma_id=200,
+                     is_target=False, is_function_word=False),
+        TokenMapping(position=2, surface_form="كَاتِب", lemma_id=102,
+                     is_target=True, is_function_word=False),
+    ]
+    fake_corrections = [
+        {"position": 0, "correct_lemma_ar": "X", "correct_gloss": "x", "correct_pos": "verb"},
+        {"position": 1, "correct_lemma_ar": "Y", "correct_gloss": "y", "correct_pos": "prep"},
+        {"position": 2, "correct_lemma_ar": "Z", "correct_gloss": "z", "correct_pos": "noun"},
+    ]
+
+    received_corrections: list[dict] = []
+    def fake_apply(corrections, mappings, db, **kwargs):
+        received_corrections.extend(corrections)
+        return []
+
+    db_mock = MagicMock()
+    db_mock.query.return_value.filter.return_value.all.return_value = []
+
+    result = MagicMock()
+    result.arabic = "كَتَبَ في كَاتِب"
+    result.english = "wrote in writer"
+    result.transliteration = ""
+    result.primary_target_lemma_id = 101
+
+    with patch("app.services.sentence_validator.tokenize_display",
+               return_value=["كَتَبَ", "في", "كَاتِب"]), \
+         patch("app.services.sentence_validator.map_tokens_to_lemmas",
+               return_value=mappings), \
+         patch("app.services.sentence_validator.verify_and_correct_mappings_llm",
+               return_value=fake_corrections), \
+         patch("app.services.sentence_validator.apply_corrections",
+               side_effect=fake_apply):
+        material_generator.validate_multi_target_sentence(
+            db_mock, result,
+            lemma_lookup={"كتب": 101, "كاتب": 102, "في": 200},
+            target_bares={"كتب": 101, "كاتب": 102},
+            trust_palette_mappings=trust_palette_mappings,
+        )
+
+    return received_corrections
+
+
+def test_trust_palette_mappings_drops_palette_position_corrections():
+    """When trust_palette_mappings=True, verifier corrections targeting
+    is_target=True positions are dropped before apply_corrections sees them.
+    Scaffold-position corrections (is_target=False) are preserved — the
+    verifier's general gate still applies to them."""
+    received = _stub_validate_multi_target(trust_palette_mappings=True)
+    # Only the scaffold-position correction (position 1) reaches apply_corrections
+    positions = [c["position"] for c in received]
+    assert positions == [1], (
+        f"Expected only scaffold position 1 to reach apply_corrections, got {positions}"
+    )
+
+
+def test_trust_palette_mappings_default_false_preserves_existing_behavior():
+    """Default trust_palette_mappings=False — all corrections pass through.
+    Regression guard so regular multi-target generation behavior is unchanged."""
+    received = _stub_validate_multi_target(trust_palette_mappings=False)
+    positions = [c["position"] for c in received]
+    assert positions == [0, 1, 2], (
+        f"Expected all 3 corrections to reach apply_corrections, got {positions}"
+    )

--- a/research/experiment-log.md
+++ b/research/experiment-log.md
@@ -4,6 +4,33 @@ Running lab notebook for Alif's learning algorithm. Each entry documents what ch
 
 ---
 
+## 2026-05-28: Root-showcase Phase 7 — `trust_palette_mappings` narrow exception to same_lemma rejection
+
+**Context.** Bootstrap run of root-showcase on prod yielded only 2/30 sentences (ج.م.ع #47934, س.ع.د #47935). 8/10 roots produced zero showcases. Inspecting the failure log: most rejections were `apply_corrections` returning `same_lemma` — meaning the verifier flagged a palette-position mapping as wrong, but the corrector couldn't find the "correct" lemma in the DB.
+
+Investigation: the textbook_scan import created inflected verb forms as standalone canonical lemmas (e.g. `يَكْتُبُونَ` is its own lemma #1558, `أَكْتُبُ` is #1682) **without ever creating or linking to the Form-I canonical base** (`كَتَبَ` for ك.ت.ب doesn't exist in the DB at all). When the showcase used `يَكْتُبُونَ`, the mapper correctly mapped it to #1558, but the verifier — which knows MSA morphology — suggested "the canonical lemma should be كَتَبَ." That isn't in the DB → `same_lemma` rejection → sentence discarded. Root cause is data quality (Phase 8 will address); root-showcase Phase 7 sidesteps it for now.
+
+**Change.** New `trust_palette_mappings: bool = False` kwarg to `validate_multi_target_sentence`. When True, verifier corrections targeting `is_target=True` positions are filtered out **before** they reach `apply_corrections`. Scaffold-position corrections still pass through unchanged.
+
+Why this is safe (and not a weakening of the sacred `apply_corrections` `same_lemma` gate that CLAUDE.md repeatedly warns against touching):
+
+- **Palette positions are deterministic spec, not inference.** The showcase prompt explicitly tells the LLM "use lemma X for surface Y." When the mapper confirms `bare(surface) == target_bares[bare]`, the mapping is ground truth — there's no ambiguity for the verifier to be opinionated about.
+- **The gate isn't weakened — it's bypassed for a narrow class** of mappings where the original concern (verifier rejecting because the right lemma isn't in DB) is by construction inapplicable.
+- **`apply_corrections` itself is untouched.** The DO-NOT-WEAKEN guard block is preserved. The filter happens upstream, in the multi-target shim that already wraps `apply_corrections`.
+- **Scaffold-position rejections still fire.** If a non-palette word (e.g. `بِمَعْلُومَاتٍ`) trips the verifier, the existing rejection logic still discards the sentence. Only palette positions get the bypass.
+- **The flag defaults to False.** Regular multi-target generation behavior is unchanged. Only `root_showcase.py` opts in.
+
+**Expected behaviour.** Of the 8 roots that produced zero showcases in the bootstrap, ~6 had failure reasons dominated by palette-position verifier rejections (يَكْتُبُونَ, أَكْتُبُ for ك.ت.ب; نَدْرُسُ, أَدْرُسُ for د.ر.س; similar for ع.ل.م, ب.ن.ي, أ.خ.ر, ط.ي.ر). After Phase 7 deploys, the cron Step G2b refresh should yield ≥1 showcase per palette-heavy depleted root within 1-2 cron passes. ق.ب.ل and د.و.ر also rejected — those had a mix of palette and scaffold issues — yield improvement uncertain.
+
+**Verification.** Two new tests in `test_root_showcase.py`:
+- `test_trust_palette_mappings_drops_palette_position_corrections`: with `trust_palette_mappings=True`, 3 verifier corrections at positions {palette, scaffold, palette} → only the scaffold one reaches `apply_corrections`.
+- `test_trust_palette_mappings_default_false_preserves_existing_behavior`: with default False, all 3 corrections pass through (regression guard so regular multi-target gen is unaffected).
+10/10 in `test_root_showcase.py` and 183/183 in related modules green.
+
+**Followups.** Phase 8 (textbook_scan inflected verb cleanup) addresses the underlying data-shape issue — ~47 standalone inflected verbs across 47 roots should be linked to canonical Form-I bases (created if missing). Once done, the verifier objections that motivate Phase 7 go away, and other places in the codebase that touch these lemmas also benefit. Phase 7 stays — it's cheap insurance and the principle (trust deterministic spec over LLM inference) is general.
+
+---
+
 ## 2026-05-28: Root-showcase Phase 6 — make showcases actually appear + safe new-lemma handling
 
 **Context.** PR #170 landed the root-showcase generator (sentences packing 3+ derivations of one Arabic root, e.g. *يَكْتُبُونَ … وَكَاتَبَ … مَكْتُوبٌ* for ك.ت.ب). Each surface form earns its own lemma review credit via the foundational "every word" rule, so one showcase yields N hits instead of 1. But two issues surfaced when reasoning about the rollout:


### PR DESCRIPTION
## Summary

Bootstrap of root-showcase on prod yielded only **2/30** because verifier kept rejecting palette-position mappings. Investigation: textbook_scan import created inflected verb forms as standalone canonical lemmas (`يَكْتُبُونَ` is #1558, `أَكْتُبُ` is #1682) without ever creating or linking to the Form-I canonical base (`كَتَبَ` doesn't exist in DB). The verifier knows MSA morphology, proposes the missing canonical, `apply_corrections` returns `same_lemma`, sentence discarded.

This PR sidesteps that for showcases via a narrow, principled exception. The underlying data quality issue is Phase 8 (separate PR).

## What changed

New `trust_palette_mappings: bool = False` kwarg on `validate_multi_target_sentence`. When True, verifier corrections at `is_target=True` positions are filtered out **before** `apply_corrections` sees them. Scaffold-position corrections still pass through.

Why this isn't a weakening of the sacred `same_lemma` gate (per `CLAUDE.md feedback_dont_weaken_same_lemma_gate`):

- **Palette positions are deterministic spec, not inference.** The showcase prompt tells the LLM "use lemma X for surface Y", and the mapper confirms via `bare(surface) == target_bares[bare]`. There's no ambiguity for the verifier's objection to resolve — its rejection just disagrees with our explicit instructions.
- **The gate itself is untouched.** `apply_corrections` is unchanged. Its DO-NOT-WEAKEN guard block is preserved verbatim. The filter happens upstream in the multi-target shim.
- **Scaffold rejections still fire.** Non-palette words (e.g. `بِمَعْلُومَاتٍ`) trip the verifier as before. Only palette positions get the bypass.
- **Default False.** Regular multi-target generation behavior is unchanged. Only `root_showcase.py` opts in.

## Expected impact

Of the 8 roots that produced zero showcases in the bootstrap (ق.ب.ل, ك.ت.ب, ع.ل.م, ب.ن.ي, د.ر.س, أ.خ.ر, ط.ي.ر, د.و.ر), ~6 had failure reasons dominated by palette-position verifier rejections. After this deploys + cron Step G2b runs, expecting ≥1 showcase per palette-heavy depleted root within 1-2 cron passes.

## Tests

- `test_trust_palette_mappings_drops_palette_position_corrections`: 3 corrections at {palette, scaffold, palette} → only scaffold reaches `apply_corrections`
- `test_trust_palette_mappings_default_false_preserves_existing_behavior`: regression guard, all 3 pass through with default
- 10/10 in test_root_showcase.py, 183/183 in related modules (material_generator + sentence_generator + sentence_selector + acquisition)