### PR TITLE
Polyglot stats: count today's exposure-confirmed words, not just graduations

### DIFF
--- a/frontend/app/polyglot-stats.tsx
+++ b/frontend/app/polyglot-stats.tsx
@@ -143,7 +143,8 @@ export default function PolyglotStats() {
           <PanelTitle label="Today" />
           <KV label="reviews" value={num(td.reviews)} unit="evt" />
           <KV label="sentences" value={num(td.sentence_reviews)} />
-          <KV label="verified" value={`+${num(td.graduated)}`} unit="wd" valueColor={C.verified} />
+          <KV label="confirmed" labelHint="read" value={`+${num(td.confirmed)}`} unit="wd" valueColor={C.verified} />
+          <KV label="graduated" labelHint="recall" value={`+${num(td.graduated)}`} unit="wd" valueColor={C.verified} />
           <KV label="new gaps" value={`+${num(td.marked_unknown)}`} unit="wd" valueColor={C.warning} last />
         </Panel>
       </View>

--- a/frontend/lib/polyglot-api.ts
+++ b/frontend/lib/polyglot-api.ts
@@ -273,6 +273,7 @@ export type LanguageStats = {
     pages_read: number;
     new_lemmas: number;
     graduated: number;
+    confirmed: number;
     graduated_words: { lemma: string; gloss: string | null }[];
     marked_unknown: number;
     streak: number;

--- a/polyglot/app/routers/stats.py
+++ b/polyglot/app/routers/stats.py
@@ -347,6 +347,15 @@ def get_stats(language_code: str, db: Session = Depends(get_db)) -> dict[str, An
         )
         .scalar() or 0
     )
+    confirmed_today = (
+        db.query(func.count(UserLemmaKnowledge.id))
+        .join(Lemma, Lemma.lemma_id == UserLemmaKnowledge.lemma_id)
+        .filter(
+            Lemma.language_code == language_code,
+            UserLemmaKnowledge.confirmed_at >= today_start,
+        )
+        .scalar() or 0
+    )
     unknown_marked_today = (
         db.query(func.count(UserLemmaKnowledge.id))
         .join(Lemma, Lemma.lemma_id == UserLemmaKnowledge.lemma_id)
@@ -402,6 +411,7 @@ def get_stats(language_code: str, db: Session = Depends(get_db)) -> dict[str, An
         "pages_read": int(pages_read_today),
         "new_lemmas": int(new_lemmas_today),
         "graduated": int(graduated_today),
+        "confirmed": int(confirmed_today),
         "graduated_words": graduated_words_today,
         "marked_unknown": int(unknown_marked_today),
         "streak": streak,

--- a/polyglot/tests/test_stats_router.py
+++ b/polyglot/tests/test_stats_router.py
@@ -210,6 +210,14 @@ def test_stats_overall_and_promoted_words(tmp_db):
                 lemma_id=gap.lemma_id, knowledge_state="acquiring",
                 first_failed_at=now, times_seen=1,
             ))
+            # Assumed-known scaffold exposure-confirmed today (no FSRS card)
+            scaffold = Lemma(language_code="el", lemma_form="terra", lemma_bare="terra",
+                             gloss_en="earth", source="test")
+            db.add(scaffold); db.flush()
+            db.add(UserLemmaKnowledge(
+                lemma_id=scaffold.lemma_id, knowledge_state="known",
+                confirmed_at=now, clean_exposures=1,
+            ))
             db.commit()
 
         body = client.get("/api/stats?language_code=el").json()
@@ -225,6 +233,8 @@ def test_stats_overall_and_promoted_words(tmp_db):
         promoted = body["today"]["graduated_words"]
         assert {"lemma": "rex", "gloss": "king"} in promoted
         assert body["today"]["graduated"] == 1
+        # exposure-confirmed scaffold counts toward today.confirmed, not graduated
+        assert body["today"]["confirmed"] == 1
 
         # history carries per-day graduations + gaps
         assert all("graduated" in d and "gaps_found" in d for d in body["history_14d"])


### PR DESCRIPTION
## Problem

After a 135-sentence Latin reading day, the stats screen's **Today → verified +N** line showed **+8**, but the DB shows **82** Latin words got `confirmed_at` stamped today (assumed-known → verified-by-reading). The `+8` was the count of words that fully *graduated* through the Leitner ladder into FSRS — a much rarer event — so the daily figure understated real verified-pool growth by ~10x and didn't reconcile with the **Verified words** hero (`exposure_confirmed + fsrs_known`).

Root cause: `frontend/app/polyglot-stats.tsx` wired the Today "verified" line to `today.graduated` (`graduated_at`), with no field for daily exposure-confirmations.

## Change

- `routers/stats.py`: add `today.confirmed` — count of ULK rows with `confirmed_at >= today_start`, language-scoped via the `Lemma` join (same pattern as `today.graduated`).
- `polyglot-stats.tsx`: split the single `verified` line into **confirmed (read)** + **graduated (recall)**, mirroring the hero's `read · recall` breakdown.
- `polyglot-api.ts`: add `today.confirmed: number`.
- `test_stats_router.py`: assert an exposure-confirmed scaffold counts toward `today.confirmed` and not `today.graduated`.

The two counts are distinct event classes (read-confirmation vs ladder-graduation) shown as separate lines, so there's no double-count.