### PR TITLE
Imported stories get a book-like intro tier (+195)

### DIFF
--- a/backend/app/services/word_selector.py
+++ b/backend/app/services/word_selector.py
@@ -49,7 +49,14 @@ DEFAULT_BATCH_SIZE = 3
 _TIER_BOOK_BASE = 200.0       # Active book words: 200 - page * 2.0
 _TIER_BOOK_PAGE_STEP = 2.0    # >1.5 gap ensures strict page ordering
 _TIER_TEXTBOOK_SCAN = 220.0   # OCR provenance: user's textbook, ahead of mid-core/backfill
-_TIER_STORY = 10.0            # Active imported stories (non-book)
+_TIER_STORY = 10.0            # Active generated/maintenance stories (auto-created)
+# Stories the user deliberately imported to *read* are active reading material,
+# like a book_ocr import. Ranked just below the truly-common core (top-1000 =
+# 210) and textbook course vocab (220), but above generic mid/low-frequency
+# words (freq_core rank 2000+), so a reader's genre vocabulary flows even when
+# corpus frequency under-counts it (e.g. fiction/intimate vocab ranking ~15k).
+# Off-switch is per-story status: mark too_difficult/skipped to stop the flow.
+_TIER_STORY_IMPORTED = 195.0
 _SOURCE_TIER_BONUS = {
     "textbook_scan": _TIER_TEXTBOOK_SCAN,
     "duolingo": 6.0,          # Curated beginner curriculum
@@ -156,7 +163,7 @@ def _active_story_lemma_ids(db: Session) -> dict[int, dict]:
     bonus reaches the actual introduction candidates.
     """
     rows = (
-        db.query(StoryWord.lemma_id, Story.id, Story.title_en, Story.title_ar)
+        db.query(StoryWord.lemma_id, Story.id, Story.title_en, Story.title_ar, Story.source)
         .join(Story, StoryWord.story_id == Story.id)
         .filter(
             Story.status == "active",
@@ -170,12 +177,17 @@ def _active_story_lemma_ids(db: Session) -> dict[int, dict]:
     canon_map = _resolve_to_canonical(db, raw_ids)
 
     result: dict[int, dict] = {}
-    for lemma_id, story_id, title_en, title_ar in rows:
+    for lemma_id, story_id, title_en, title_ar, source in rows:
         effective_id = canon_map.get(lemma_id, lemma_id)
-        if effective_id not in result:
+        # A word can appear in several active stories; an "imported" membership
+        # (deliberate reading material) wins the tier over a generated one.
+        if effective_id not in result or (
+            source == "imported" and result[effective_id].get("source") != "imported"
+        ):
             result[effective_id] = {
                 "title": title_en or title_ar or "Story",
                 "story_id": story_id,
+                "source": source,
             }
     return result
 
@@ -607,9 +619,15 @@ def select_next_words(
         priority_bonus = _SOURCE_TIER_BONUS.get(priority_source, 0.0)
         priority_tier = priority_source or "other"
 
-        if lemma.lemma_id in story_lemmas and _TIER_STORY > priority_bonus:
-            priority_bonus = _TIER_STORY
-            priority_tier = "active_story"
+        if lemma.lemma_id in story_lemmas:
+            story_tier = (
+                _TIER_STORY_IMPORTED
+                if story_lemmas[lemma.lemma_id].get("source") == "imported"
+                else _TIER_STORY
+            )
+            if story_tier > priority_bonus:
+                priority_bonus = story_tier
+                priority_tier = "active_story"
         if lemma.lemma_id in book_pages:
             page = book_pages[lemma.lemma_id]["page"]
             book_bonus = _TIER_BOOK_BASE - page * _TIER_BOOK_PAGE_STEP

--- a/backend/tests/test_word_selector.py
+++ b/backend/tests/test_word_selector.py
@@ -295,6 +295,60 @@ class TestSelectNextWords:
         assert result[0]["lemma_id"] == textbook.lemma_id
         assert result[0]["score_breakdown"]["priority_tier"] == "textbook_scan"
 
+    def _add_active_story(self, db, source, words):
+        """Create an active Story with StoryWords (word -> lemma_id)."""
+        from app.models import Story, StoryWord
+        story = Story(body_ar="نص", source=source, status="active",
+                      title_en=f"{source} story")
+        db.add(story)
+        db.flush()
+        for pos, (surface, lid) in enumerate(words):
+            db.add(StoryWord(
+                story_id=story.id, position=pos, surface_form=surface,
+                lemma_id=lid, is_function_word=False, is_known_at_creation=False,
+            ))
+        db.flush()
+        return story
+
+    def test_imported_story_word_flows_above_generic_frequency(self, db_session):
+        # A reader's genre vocabulary often ranks low in a formal corpus
+        # (e.g. fiction/intimate words). An imported story is deliberate reading
+        # material, so its words must outrank generic mid/low-frequency words.
+        imported_word = _create_lemma(db_session, "قبلة", "kiss", freq=15916)
+        generic = _create_lemma(db_session, "قول", "saying", freq=2500)
+        db_session.add(FrequencyCoreEntry(
+            core_rank=2500, lemma_id=generic.lemma_id,
+            lemma_key=f"lemma:{generic.lemma_id}", display_form=generic.lemma_ar,
+            score=70.0,
+        ))
+        self._add_active_story(db_session, "imported", [("قبلة", imported_word.lemma_id)])
+        db_session.commit()
+
+        result = select_next_words(db_session, count=2)
+        assert result[0]["lemma_id"] == imported_word.lemma_id
+        assert result[0]["score_breakdown"]["priority_tier"] == "active_story"
+        # Stays below the truly-common core and textbook (210 / 220).
+        assert result[0]["score_breakdown"]["priority_bonus"] == 195.0
+
+    def test_generated_story_word_stays_deprioritized(self, db_session):
+        # Auto-generated stories keep the weak +10 tier — they must not surface
+        # obscure vocab ahead of common words.
+        gen_word = _create_lemma(db_session, "دمنة", "ruin remains", freq=None)
+        common = _create_lemma(db_session, "بيت", "house", freq=50)
+        db_session.add(FrequencyCoreEntry(
+            core_rank=50, lemma_id=common.lemma_id,
+            lemma_key=f"lemma:{common.lemma_id}", display_form=common.lemma_ar,
+            score=100.0,
+        ))
+        self._add_active_story(db_session, "generated", [("دمنة", gen_word.lemma_id)])
+        db_session.commit()
+
+        result = select_next_words(db_session, count=2)
+        assert result[0]["lemma_id"] == common.lemma_id
+        gen = next(w for w in result if w["lemma_id"] == gen_word.lemma_id)
+        assert gen["score_breakdown"]["priority_tier"] == "active_story"
+        assert gen["score_breakdown"]["priority_bonus"] == 10.0
+
     def test_root_familiarity_boosts_score(self, db_session):
         root = _create_root(db_session, "ك.ت.ب")
         l1 = _create_lemma(db_session, "كتاب", "book", root, freq=100)

--- a/docs/scheduling-system.md
+++ b/docs/scheduling-system.md
@@ -1545,9 +1545,10 @@ Priority tiers (higher ALWAYS beats lower, freq/root/grammar are tiebreakers wit
   OCR textbook_scan          — +220.0 (learning provenance, not fake frequency)
   Frequency core top 1000    — +210.0
   Active book words          — 200.0 − page × 2.0 (deterministic page order)
+  Imported stories           — +195.0 (deliberate reading material; see below)
   Frequency core top 2000    — +170.0
   Frequency core top 5000    — +120.0
-  Active stories             — +10.0
+  Active stories (generated) — +10.0
   Duolingo                   — +6.0
   AVP A1                     — +4.0
   Wiktionary/other           — +0.0 (strictly by frequency)
@@ -1562,6 +1563,18 @@ Textbook OCR priority reads `user_lemma_knowledge.source` first, then
 textbook priority when the learner actually encountered it in scanned course
 material. This preserves the real frequency rank while making OCR words flow
 through introduction ahead of lower-priority backfill.
+
+Imported-story priority (`Story.source == "imported"`): a story the user
+deliberately imported to read is active reading material, like a `book_ocr`
+import, and gets +195 (between the truly-common core and generic mid/low
+frequency). Generated and maintenance-passage stories keep the weak +10
+`active_story` tier. This is intentional: corpus frequency lists are built from
+formal/news MSA and systematically under-count genre vocabulary (fiction,
+intimate, bodily, narrative words can rank ~15k+), so a reader's own imported
+text is a better usefulness signal than rank for those words. Off-switch is
+per-story status — mark a story `too_difficult`/`skipped` to stop its words
+flowing. Set in `word_selector.py` (`_TIER_STORY_IMPORTED`,
+`_active_story_lemma_ids` returns `source`).
 ```
 
 #### Frequency Score (40%)

--- a/research/experiment-log.md
+++ b/research/experiment-log.md
@@ -4,6 +4,22 @@ Running lab notebook for Alif's learning algorithm. Each entry documents what ch
 
 ---
 
+## 2026-06-02: Imported stories get a book-like intro tier (+195); fiction vocab now flows
+
+**Symptom.** Two imported stories the user is actively reading — #75 "A Night of Medical Betrayal" and #76 "A Night in the Private Hospital" — had ~98 fully-gated, unintroduced candidate words between them (#75: 37 eligible, #76: 61), yet **0 intros with source `story_import`/`active_story` in the last 21 days.** Every daily-cap slot went to textbook_scan, frequency_core, collateral, leech_reintro, quran, book, duolingo.
+
+**Audit (prod, 2026-06-02).** Textbook backlog is largely drained: 1,578 textbook_scan ULKs, 1,434 known (91%), only 37 encountered + 48 gated-pending eligible canonical lemmas remain (0 ungated). Textbook is still the top *flowing* source (121 intros/21d) at tier +220. The story words weren't flowing because `source='imported'` stories route through `_active_story_lemma_ids()` → the weak `_TIER_STORY = +10` `active_story` tier (not the `book_ocr` +200 page tier, which filters `Story.source == "book_ocr"` and also needs `page_number`, which imported StoryWords lack). At +10 they can't out-compete textbook (+220) / frequency-core for the cap-limited slots.
+
+**Why +10 existed (prior work, 2026-02-12 incident, experiment-log).** Imported stories historically carried obscure classical vocab (دِمْنَة "ruin remains", نواشر "forearm veins" from Kalila wa Dimna) that drowned out common words; the deliberate +10 tier suppressed that, and classical stories 3/4 were marked `too_difficult`. So a blind tier bump was rejected first.
+
+**Reframe.** Checked the frequency profile of the pending words: قُبْلة "kiss" ranks #15,916; قَضِيب #30,505; كُسّ #8,574; قَسْطَر/خُرْطُوم/بَوْل have *no* frequency data (45 of 61 in #76). These read as "obscure" only because the frequency lists are built from formal/news MSA, which systematically under-counts fiction/intimate/bodily/narrative vocabulary. For a reader of this genre those words are exactly the high-utility ones. **Quality is uniform** — every candidate passed the same `run_quality_gates()` regardless of pathway (hard invariant; `select_next_words` filters `gates_completed_at IS NULL`) — so the source tier is a *frequency/usefulness* signal, not a quality one. The honest fix: treat an imported story as a deliberate intent-to-read signal (like `book_ocr`), not as low-quality content.
+
+**Change (`word_selector.py` + `test_word_selector.py`).** New `_TIER_STORY_IMPORTED = 195.0`. `_active_story_lemma_ids()` now returns each candidate's `Story.source` (imported membership wins over generated when a word is in both). Scoring applies +195 when source is `imported`, else keeps +10. Placement: below truly-common core (top-1000 = 210) and textbook course vocab (220), above generic mid/low-frequency words (freq_core rank 2000+ = 170/120) — so a reader's genre vocabulary flows without displacing the most common words. Scoped to `source='imported'` only (2 active stories; the 56 maintenance passages and 4 generated stories are untouched). Off-switch is per-story status (`too_difficult`/`skipped`). Tests: `test_imported_story_word_flows_above_generic_frequency`, `test_generated_story_word_stays_deprioritized`.
+
+**Expected effect.** The ~98 pending words from #75/#76 begin flowing into daily intros (throttled by `DAILY_INTRO_CAP`/recovery budget; box-1 backlog is 32 < 60 so the low-tier gate is inactive), tagged `active_story` at priority_bonus 195, still behind textbook (+220) and top-1000 core. **Verify** after deploy: `select_next_words` top results include #75/#76 words at tier `active_story`/195; over the following days `acquisition_started_at` shows `story_import` intros > 0.
+
+---
+
 ## 2026-06-02: Quran import — dagger-alef (U+0670) collapse mis-lemmatized خَٰلِدُونَ → Khaldūn
 
 **Symptom.** An intro card showed خَلِدُونَ ("abiding forever", *khalidūna*) — a malformed headword: no medial alif, transliteration `khalidūna`, etymology claiming a "fuʿlūn" pattern and citing Ibn Khaldūn (ابن خلدون). Lemma `#2887`, `source='quran'`, freq-core rank #1729, in active acquisition.


### PR DESCRIPTION
## Problem

Two imported stories the user is actively reading — #75 *A Night of Medical Betrayal* and #76 *A Night in the Private Hospital* — had **~98 fully-gated, unintroduced candidate words** between them (37 + 61), yet produced **0 intros** in the last 21 days. Every daily-cap slot went to textbook_scan, frequency_core, collateral, leech_reintro, quran, book, duolingo.

## Root cause

`source='imported'` stories route through `_active_story_lemma_ids()` → the weak `_TIER_STORY = +10` `active_story` tier, not the `book_ocr` +200 page tier (which filters `Story.source == "book_ocr"` and needs `page_number`, absent on imported StoryWords). At +10 they can't out-compete textbook (+220) / frequency-core for the cap-limited slots.

The +10 tier was a deliberate guard (2026-02-12) against obscure classical vocab (Kalila wa Dimna: دِمْنَة, نواشر) drowning out common words. But the pending words here rank low *only* because frequency lists are built from formal/news MSA, which under-counts fiction/intimate/narrative vocabulary — قُبْلة "kiss" ranks #15,916; 45 of 61 in #76 have no frequency data at all. For a reader of this genre those are the high-utility words.

Quality is uniform across all import pathways (every candidate passes `run_quality_gates()`; `select_next_words` filters `gates_completed_at IS NULL`), so the source tier is a **usefulness** signal, not a quality one. An imported story is a valid intent-to-read signal — like a `book_ocr` import.

## Change

- New `_TIER_STORY_IMPORTED = 195.0`: below truly-common core (top-1000 = 210) and textbook course vocab (220), above generic mid/low-frequency words (rank 2000+ = 170/120).
- `_active_story_lemma_ids()` returns each candidate's `Story.source`; imported membership wins over generated when a word is in both.
- Scoring applies +195 only for `source='imported'`; generated/maintenance stories keep +10.
- Off-switch is per-story status (`too_difficult`/`skipped`).

Scoped to the 2 active imported stories; the 56 maintenance passages and 4 generated stories are untouched.

## Verification

`select_next_words` top results now include #75/#76 words at tier `active_story` / priority_bonus 195, still behind textbook and top-1000 core. Two new tests cover imported-flows-above-generic and generated-stays-deprioritized. `test_word_selector.py` + `test_sentence_selector.py`: 137 passed.