### PR TITLE
Stats honesty: exclude function words + resolve variants in frequency-core gaps

### DIFF
--- a/backend/app/routers/stats.py
+++ b/backend/app/routers/stats.py
@@ -740,6 +740,63 @@ def _compute_frequency_core_progress(db: Session) -> FrequencyCoreProgress | Non
         .all()
     )
 
+    # Honesty pass (2026-06-03): the raw entries include function words (e.g. ال)
+    # and variant/compound forms whose canonical is already known (e.g. اليوم →
+    # يوم). Both used to surface as "missing"/"need intro" gaps, overstating the
+    # remaining work. Drop function words entirely (frequency coverage is a
+    # content-word metric) and resolve each entry to its canonical lemma so a
+    # known canonical counts the variant as learned.
+    from types import SimpleNamespace
+    from app.services.sentence_validator import _is_function_word, strip_diacritics
+
+    func_ids = _get_func_word_ids(db)
+    entry_lemma_ids = {r.lemma_id for r in rows if r.lemma_id is not None}
+    redirect: dict[int, int] = {}
+    if entry_lemma_ids:
+        for lid, canon in (
+            db.query(Lemma.lemma_id, Lemma.canonical_lemma_id)
+            .filter(Lemma.lemma_id.in_(entry_lemma_ids))
+            .all()
+        ):
+            if canon:
+                redirect[lid] = canon
+    need_ids = entry_lemma_ids | set(redirect.values())
+    ulk_state: dict[int, tuple] = {}
+    if need_ids:
+        for u in (
+            db.query(
+                UserLemmaKnowledge.lemma_id,
+                UserLemmaKnowledge.knowledge_state,
+                UserLemmaKnowledge.introduced_at,
+            )
+            .filter(UserLemmaKnowledge.lemma_id.in_(need_ids))
+            .all()
+        ):
+            ulk_state[u.lemma_id] = (u.knowledge_state, u.introduced_at)
+
+    def _is_func_row(r) -> bool:
+        if r.lemma_id is not None:
+            return redirect.get(r.lemma_id, r.lemma_id) in func_ids or r.lemma_id in func_ids
+        return _is_function_word(strip_diacritics(r.display_form or ""))
+
+    norm_rows = []
+    for r in rows:
+        if _is_func_row(r):
+            continue
+        canon = redirect.get(r.lemma_id, r.lemma_id) if r.lemma_id is not None else None
+        state, introduced_at = ulk_state.get(canon, ulk_state.get(r.lemma_id, (None, None)))
+        norm_rows.append(SimpleNamespace(
+            core_rank=r.core_rank,
+            lemma_id=r.lemma_id,
+            display_form=r.display_form,
+            gloss_en=r.gloss_en,
+            confidence_tier=r.confidence_tier,
+            gap_status=r.gap_status,
+            knowledge_state=state,
+            introduced_at=introduced_at,
+        ))
+    rows = norm_rows
+
     learned_states = {"known", "learning", "acquiring"}
     pipeline_states = learned_states | {"lapsed", "encountered"}
     introduced_states = learned_states | {"lapsed", "suspended"}

--- a/backend/tests/test_stats_frequency_honesty.py
+++ b/backend/tests/test_stats_frequency_honesty.py
@@ -1,0 +1,54 @@
+"""Frequency-core stats must not report function words or already-known variant
+forms as 'missing'/'gap' — only genuinely uncovered content words (Part D)."""
+from datetime import datetime, timezone
+
+from app.models import FrequencyCoreEntry, Lemma, UserLemmaKnowledge
+from app.routers.stats import _compute_frequency_core_progress, _func_word_ids_cache
+import app.routers.stats as stats_mod
+
+
+def _lemma(db, lemma_id, ar, canonical=None):
+    db.add(Lemma(lemma_id=lemma_id, lemma_ar=ar, lemma_ar_bare=ar, gloss_en=ar,
+                 pos="noun", canonical_lemma_id=canonical))
+    db.flush()
+
+
+def _known(db, lemma_id):
+    db.add(UserLemmaKnowledge(lemma_id=lemma_id, knowledge_state="known", source="study",
+                              introduced_at=datetime.now(timezone.utc),
+                              fsrs_card_json={"due": datetime.now(timezone.utc).isoformat()}))
+    db.flush()
+
+
+def _fce(db, rank, lemma_id, display):
+    db.add(FrequencyCoreEntry(core_rank=rank, lemma_id=lemma_id, lemma_key=f"k{rank}",
+                              display_form=display, score=1.0))
+    db.flush()
+
+
+def test_frequency_gaps_exclude_function_words_and_known_variants(db_session, monkeypatch):
+    # Reset the module-level function-word cache so it rebuilds against this DB.
+    monkeypatch.setattr(stats_mod, "_func_word_ids_cache", None)
+
+    _lemma(db_session, 1, "مِن")           # function word (preposition "from")
+    _lemma(db_session, 2, "كتاب"); _known(db_session, 2)   # known content word
+    _lemma(db_session, 3, "يوم"); _known(db_session, 3)    # known canonical
+    _lemma(db_session, 4, "اليوم", canonical=3)            # variant of known canonical, no ULK
+    _lemma(db_session, 5, "جديد")          # content word, NOT introduced -> a real gap
+    _fce(db_session, 1, 1, "مِن")
+    _fce(db_session, 2, 2, "كتاب")
+    _fce(db_session, 3, 4, "اليوم")        # entry points at the variant lemma
+    _fce(db_session, 5, 5, "جديد")
+    db_session.commit()
+
+    prog = _compute_frequency_core_progress(db_session)
+    assert prog is not None
+    gap_forms = {g.display_form for g in prog.next_gaps}
+
+    assert "جديد" in gap_forms                 # genuine uncovered content word IS a gap
+    assert "مِن" not in gap_forms               # function word excluded
+    assert "اليوم" not in gap_forms             # variant of a known canonical = covered
+
+    band = next(b for b in prog.bands if b.top_n == 100)
+    assert band.total_count == 3                # function word dropped from denominator
+    assert band.learned_count == 2              # كتاب + اليوم(→يوم known)


### PR DESCRIPTION
Part D of the 2026-06-03 growth+maintenance program.

`_compute_frequency_core_progress` (the High-Frequency Core card on the stats screen) reported **function words** (e.g. مِن) and **variant/compound forms whose canonical is already known** (e.g. اليوم → يوم) as `missing` / `need intro` gaps — overstating the remaining work toward the 2500/3000 frequency goal.

- Drop function words entirely from bands + gaps (frequency coverage is a content-word metric).
- Resolve each entry to its canonical lemma, so a known canonical counts the variant as learned.
- Suspended leeches were already excluded.

Net: `next_gaps`, `unmapped_count` ('missing'), `not_introduced_count` ('need intro'), and band coverage% now reflect genuine content-word coverage. New test `test_stats_frequency_honesty.py`.