### PR TITLE
Fix + prevent frequency-core entries mapped to variant (inflected) lemmas

### DIFF
--- a/backend/app/services/frequency_core_intake.py
+++ b/backend/app/services/frequency_core_intake.py
@@ -113,6 +113,89 @@ def _map_entry_to_lemma(db: Session, entry: FrequencyCoreEntry, lemma_id: int) -
     return True
 
 
+def remap_variant_frequency_core_entries(db: Session, lemma_ids=None) -> dict:
+    """Re-point frequency-core entries that map to a *variant* lemma onto its
+    canonical, and exclude any that thereby duplicate the canonical's own entry.
+
+    Why this exists: an entry can become mis-mapped after it was created — variant
+    detection later links its lemma to a canonical (e.g. the inflected form نَزَّلنَا
+    → canonical نزل), so the entry lingers on the inflection and the stats card shows
+    "we sent down" as a top-1000 word. This is the invariant enforcer: NO active
+    frequency-core entry may point to a variant lemma. It is idempotent and is
+    called both at the variant-linking chokepoint (`mark_variants`) and as a cron
+    safety net (so direct `canonical_lemma_id =` assignments in scripts are healed
+    within a cycle too).
+
+    Pass `lemma_ids` to scope the entries acted on (the chokepoint passes the lemmas
+    it just marked); ownership/dedup is always computed against the full table.
+    """
+    redirect = {
+        lid: canon
+        for lid, canon in db.query(Lemma.lemma_id, Lemma.canonical_lemma_id)
+        .filter(Lemma.canonical_lemma_id.isnot(None))
+        .all()
+    }
+
+    def resolve(lid: int) -> int:
+        seen: set[int] = set()
+        while lid in redirect and lid not in seen:
+            seen.add(lid)
+            lid = redirect[lid]
+        return lid
+
+    q = db.query(FrequencyCoreEntry).filter(
+        FrequencyCoreEntry.excluded_reason.is_(None),
+        FrequencyCoreEntry.lemma_id.isnot(None),
+    )
+    if lemma_ids is not None:
+        ids = list(lemma_ids)
+        if not ids:
+            return {"remapped": 0, "excluded": 0}
+        q = q.filter(FrequencyCoreEntry.lemma_id.in_(ids))
+    targets = sorted(
+        (e for e in q.all() if resolve(e.lemma_id) != e.lemma_id),
+        key=lambda e: e.core_rank,
+    )
+    if not targets:
+        return {"remapped": 0, "excluded": 0}
+
+    all_active = (
+        db.query(FrequencyCoreEntry)
+        .filter(FrequencyCoreEntry.excluded_reason.is_(None), FrequencyCoreEntry.lemma_id.isnot(None))
+        .all()
+    )
+    by_canon: dict[int, list[FrequencyCoreEntry]] = {}
+    for e in all_active:
+        by_canon.setdefault(resolve(e.lemma_id), []).append(e)
+
+    now = datetime.now(timezone.utc)
+    remapped = excluded = 0
+    for e in targets:
+        canon = resolve(e.lemma_id)
+        owner_exists = any(
+            o.id != e.id and o.lemma_id == canon and o.excluded_reason is None
+            for o in by_canon.get(canon, [])
+        )
+        if owner_exists:
+            e.excluded_reason = "duplicate_variant_of_canonical"
+            e.gap_status = None
+            e.updated_at = now
+            excluded += 1
+        else:
+            canon_lemma = db.query(Lemma).filter(Lemma.lemma_id == canon).first()
+            if not canon_lemma:
+                continue
+            e.lemma_id = canon
+            e.lemma_key = f"lemma:{canon}"
+            e.display_form = canon_lemma.lemma_ar or e.display_form
+            e.gloss_en = canon_lemma.gloss_en
+            e.pos = canon_lemma.pos
+            e.gap_status = None
+            e.updated_at = now
+            remapped += 1
+    return {"remapped": remapped, "excluded": excluded}
+
+
 def _mark_needs_manual_review(entry: FrequencyCoreEntry, reason: str) -> None:
     flags = entry.source_flags_json if isinstance(entry.source_flags_json, dict) else {}
     flags = dict(flags)

--- a/backend/app/services/variant_detection.py
+++ b/backend/app/services/variant_detection.py
@@ -246,6 +246,7 @@ def mark_variants(
     we don't set A.canonical = B.
     """
     count = 0
+    marked_ids: list[int] = []
     for var_id, canon_id, _vtype, _details in variants:
         lemma = db.query(Lemma).filter(Lemma.lemma_id == var_id).first()
         if lemma and lemma.canonical_lemma_id is None:
@@ -259,6 +260,18 @@ def mark_variants(
                 continue
             lemma.canonical_lemma_id = canon_id
             count += 1
+            marked_ids.append(var_id)
+    # Heal any frequency-core entries that were mapped to these now-variant lemmas
+    # so they never linger on an inflected form (invariant: no active FCE entry
+    # points to a variant). Best-effort — must not block variant marking.
+    if marked_ids:
+        try:
+            from app.services.frequency_core_intake import (
+                remap_variant_frequency_core_entries,
+            )
+            remap_variant_frequency_core_entries(db, lemma_ids=marked_ids)
+        except Exception:
+            logger.exception("FCE variant remap after mark_variants failed")
     return count
 
 

--- a/backend/scripts/update_material.py
+++ b/backend/scripts/update_material.py
@@ -1361,6 +1361,22 @@ def step_pregenerate_candidates(db: Session, dry_run: bool, count: int, model: s
     except Exception as exc:
         print(f"  Frequency-core intake failed: {exc}")
 
+    # Safety net: heal any frequency-core entries that drifted onto a variant
+    # lemma (e.g. an inflected form whose canonical was linked after mapping).
+    # Idempotent; covers paths that set canonical_lemma_id directly.
+    try:
+        from app.services.frequency_core_intake import remap_variant_frequency_core_entries
+        if not dry_run:
+            remap = remap_variant_frequency_core_entries(db)
+            if remap.get("remapped") or remap.get("excluded"):
+                db.commit()
+                print(
+                    "  Frequency-core variant remap: "
+                    f"remapped={remap['remapped']}, excluded_dupes={remap['excluded']}"
+                )
+    except Exception as exc:
+        print(f"  Frequency-core variant remap failed: {exc}")
+
     candidates = select_next_words(db, count=count)
     if not candidates:
         print("  No candidates available.")

--- a/backend/tests/test_frequency_core_variant_remap.py
+++ b/backend/tests/test_frequency_core_variant_remap.py
@@ -1,0 +1,53 @@
+"""Invariant: no active frequency_core_entry may point to a *variant* lemma.
+Variant detection links inflected forms (نَزَّلنَا) to a canonical (نزل) after the
+entry was mapped; remap_variant_frequency_core_entries heals that — re-pointing to
+the canonical, or excluding the entry when it duplicates the canonical's own."""
+from app.models import FrequencyCoreEntry, Lemma
+from app.services.frequency_core_intake import remap_variant_frequency_core_entries
+
+
+def _lemma(db, lemma_id, ar, canonical=None):
+    db.add(Lemma(lemma_id=lemma_id, lemma_ar=ar, lemma_ar_bare=ar, gloss_en=f"g{lemma_id}",
+                 pos="verb", canonical_lemma_id=canonical))
+    db.flush()
+
+
+def _fce(db, rank, lemma_id, display):
+    db.add(FrequencyCoreEntry(core_rank=rank, lemma_id=lemma_id, lemma_key=f"lemma:{lemma_id}",
+                              display_form=display, score=1.0))
+    db.flush()
+
+
+def _resolves_to_variant(db):
+    redirect = {lid: c for lid, c in db.query(Lemma.lemma_id, Lemma.canonical_lemma_id)
+                .filter(Lemma.canonical_lemma_id.isnot(None)).all()}
+    bad = []
+    for e in db.query(FrequencyCoreEntry).filter(FrequencyCoreEntry.excluded_reason.is_(None),
+                                                 FrequencyCoreEntry.lemma_id.isnot(None)).all():
+        if e.lemma_id in redirect:
+            bad.append(e.core_rank)
+    return bad
+
+
+def test_variant_entry_repointed_or_deduped(db_session):
+    # Canonical 100 (نزل) has NO entry; variant 101 (نزّلنا) carries the entry -> RE-POINT.
+    _lemma(db_session, 100, "نزل")
+    _lemma(db_session, 101, "نزّلنا", canonical=100)
+    _fce(db_session, 527, 101, "نَزَّلنَا")
+    # Canonical 200 (حبّ) HAS its own entry; variant 201 (تحبّ) also has one -> EXCLUDE the variant.
+    _lemma(db_session, 200, "حبّ"); _fce(db_session, 50, 200, "حبّ")
+    _lemma(db_session, 201, "تحبّ", canonical=200); _fce(db_session, 124, 201, "تُحِبُّ")
+    db_session.commit()
+
+    res = remap_variant_frequency_core_entries(db_session)
+    assert res["remapped"] == 1 and res["excluded"] == 1
+
+    repointed = db_session.query(FrequencyCoreEntry).filter_by(core_rank=527).first()
+    assert repointed.lemma_id == 100 and repointed.display_form == "نزل"
+
+    deduped = db_session.query(FrequencyCoreEntry).filter_by(core_rank=124).first()
+    assert deduped.excluded_reason == "duplicate_variant_of_canonical"
+
+    # Invariant holds, and the op is idempotent.
+    assert _resolves_to_variant(db_session) == []
+    assert remap_variant_frequency_core_entries(db_session) == {"remapped": 0, "excluded": 0}


### PR DESCRIPTION
Follow-up to the stats-honesty work, prompted by 'we sent down' (نَزَّلنَا) appearing as a top-1000 frequency word.

**Bug:** 30 `frequency_core_entries` point at inflected-form *variant* lemmas instead of their canonical (e.g. نَزَّلنَا → lemma 2878, canonical نزل; تُحِبُّ → حبّ; نَدْرُسُ → درس). 9 are in the top-1000, all 30 by top-3000, and **10 are outright duplicates** of the canonical's own entry. Root cause: variant detection links a lemma to its canonical *after* the frequency entry was mapped, stranding the entry on the inflection.

**Fix + invariant (so it can't recur):**
- `remap_variant_frequency_core_entries()` — idempotent: re-points each entry to its canonical, or excludes it (`duplicate_variant_of_canonical`) when the canonical already owns an entry. Enforces: *no active FCE entry points to a variant lemma*.
- Wired at the **chokepoint** (`mark_variants`, heals immediately) **and** the **cron** (`update_material` step C, safety net for the many scripts that set `canonical_lemma_id` directly).
- Regression test covers re-point, dedupe, the invariant, and idempotency.

The one-off heal of the existing 30 is run on prod after deploy.