### PR TITLE
Stats: collapse completed frequency tiers + finer frontier bands

### DIFF
--- a/backend/app/routers/stats.py
+++ b/backend/app/routers/stats.py
@@ -809,7 +809,9 @@ def _compute_frequency_core_progress(db: Session) -> FrequencyCoreProgress | Non
         break
 
     bands: list[FrequencyCoreBand] = []
-    for top_n in (100, 250, 500, 1000, 2000, 5000):
+    # Denser at the frontier (2000-3000) so the active learning zone isn't hidden
+    # by the old 2000->5000 jump; the frontend collapses completed leading tiers.
+    for top_n in (100, 250, 500, 1000, 1500, 2000, 2500, 3000, 4000, 5000):
         band_rows = [r for r in rows if r.core_rank <= top_n]
         if not band_rows:
             continue

--- a/frontend/app/stats.tsx
+++ b/frontend/app/stats.tsx
@@ -510,7 +510,19 @@ function FrequencyCoreCard({ data }: { data: FrequencyCoreProgress }) {
   const focusBand =
     sortedBands.find((b) => b.coverage_pct < 95) ??
     sortedBands[sortedBands.length - 1];
-  const visibleBands = sortedBands;
+  // Collapse completed leading tiers into one "✓" summary; show the frontier
+  // tier onward in full per-band detail. A tier is complete when nothing is left
+  // to do in it (no words needing intro and none missing).
+  const bandComplete = (b: (typeof sortedBands)[number]) =>
+    b.not_introduced_count === 0 && b.unmapped_count === 0 && b.coverage_pct >= 99.5;
+  const frontierIdx = sortedBands.findIndex((b) => !bandComplete(b));
+  const completedSummary =
+    frontierIdx === -1
+      ? sortedBands[sortedBands.length - 1]
+      : frontierIdx > 0
+      ? sortedBands[frontierIdx - 1]
+      : null;
+  const detailBands = frontierIdx === -1 ? [] : sortedBands.slice(frontierIdx);
   const gaps = data.next_gaps.slice(0, 6);
 
   if (!focusBand) return null;
@@ -553,7 +565,22 @@ function FrequencyCoreCard({ data }: { data: FrequencyCoreProgress }) {
       </View>
 
       <View style={styles.freqCoreBands}>
-        {visibleBands.map((band) => {
+        {completedSummary && (
+          <View style={styles.freqCoreBand}>
+            <View style={styles.freqCoreBandTop}>
+              <Text style={[styles.freqCoreBandLabel, { color: colors.good }]}>
+                ✓ Top {completedSummary.top_n.toLocaleString()} complete
+              </Text>
+              <Text style={styles.freqCoreBandCount}>
+                {completedSummary.learned_count.toLocaleString()} learned
+              </Text>
+            </View>
+            <View style={styles.freqCoreTrack}>
+              <View style={[styles.freqCoreLearnedFill, { width: "100%" }]} />
+            </View>
+          </View>
+        )}
+        {detailBands.map((band) => {
           const learnedPct = Math.min(band.coverage_pct, 100);
           const introducedPct = Math.min((band.introduced_count / Math.max(band.total_count, 1)) * 100, 100);
           const missingPct = Math.min((band.unmapped_count / Math.max(band.total_count, 1)) * 100, 100);


### PR DESCRIPTION
Implements the adaptive frequency-core display.

- **Backend:** denser bands at the frontier — `100, 250, 500, 1000, 1500, 2000, 2500, 3000, 4000, 5000` (was `…1000, 2000, 5000`), so the active 2000-3000 zone is visible instead of buried in a 2000→5000 lump.
- **Frontend:** collapse all completed leading tiers into a single `✓ Top N complete` row; render the frontier tier onward in full per-band detail. Detail follows where the work is.