### PR TITLE
Add /api/discover: vocabulary discovery from external Arabic text (Dragoman integration)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,7 +7,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.database import engine, Base
-from app.routers import words, review, analyze, stats, import_data, sentences, tts, learn, grammar, stories, chat, ocr, flags, activity, settings, books, patterns, roots, podcast, polyglot_proxy
+from app.routers import words, review, analyze, stats, import_data, sentences, tts, learn, grammar, stories, chat, ocr, flags, activity, settings, books, patterns, roots, podcast, polyglot_proxy, discover
 
 
 @asynccontextmanager
@@ -112,6 +112,7 @@ app.include_router(podcast.router)
 # the deliberate constraints — this module is pure HTTP passthrough, no
 # code coupling to polyglot.
 app.include_router(polyglot_proxy.router)
+app.include_router(discover.router)
 
 # Serve voice samples for comparison testing
 from pathlib import Path as _Path

--- a/backend/app/routers/discover.py
+++ b/backend/app/routers/discover.py
@@ -4,47 +4,65 @@ Two jobs:
   POST /api/discover/words  — given a block of Arabic text, return the highest-value
        lemmas that are NOT yet in Alif's pool, ranked by MSA frequency, each glossed.
   POST /api/discover/add[-batch] — create the chosen lemma(s), introduce them into the
-       acquisition pipeline, and (in the background) run the quality gates + generate
-       review material. Fast write up front; the LLM-heavy gating never holds the
-       write lock (own session in a BackgroundTask).
+       acquisition pipeline immediately (explicit user adds bypass the daily intro cap),
+       and (in the background) run the quality gates + generate review material. Fast
+       write up front; the LLM-heavy gating never holds the write lock (own session in
+       a BackgroundTask).
 
 This is the Dragoman → Alif integration: a reader sees an Arabic essay in the magazine,
 Dragoman asks this endpoint which words are worth learning, and renders "add to Alif"
 buttons that POST back here.
+
+Word identity goes through the production-hardened lookup path
+(`build_comprehensive_lemma_lookup` + `lookup_lemma`): clitic stripping, CAMeL
+disambiguation, collision handling, and variant→canonical resolution — the same path
+the corpus importer uses. We never hand-roll tokenize+normalize+classify here (that
+surface-only shortcut leaks clitic-attached and variant forms — 2026-06-03 lesson).
 """
 import logging
 import re
 
-from fastapi import APIRouter, BackgroundTasks, Depends
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from app.database import SessionLocal, get_db
 from app.models import Lemma
 from app.services.interaction_logger import log_interaction
-from app.services.llm import generate_completion
 from app.services.lemma_quality import (
     _load_rank_map,
     _normalize,
     assign_frequency_rank,
     run_quality_gates,
 )
+from app.services.llm import generate_completion
 from app.services.material_generator import (
     MIN_SENTENCES_PER_WORD,
     generate_material_for_word,
 )
 from app.services.morphology import get_best_lemma_mle
-from app.services.sentence_validator import _is_function_word, _strip_clitics
+from app.services.sentence_validator import (
+    _is_function_word,
+    build_comprehensive_lemma_lookup,
+    lookup_lemma,
+    strip_diacritics,
+)
 from app.services.word_selector import introduce_word
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/discover", tags=["discover"])
 
-# Arabic letters + diacritics + tatweel + superscript alef only — deliberately excludes
-# Arabic punctuation (، ؛ ؟ at U+060C/061B/061F), which sit in the same Unicode block.
-_ARABIC_TOKEN = re.compile(r"[ء-ْٰ]+")
+# A token is a maximal run of Arabic letters + diacritics (matches the reference
+# tokenizer in scripts/reading_readiness.py). Deliberately excludes Arabic
+# punctuation (، ؛ ؟) and digits, which sit in adjacent code points.
+_ARABIC_TOKEN = re.compile(r"[ء-يٰ-ۿݐ-ݿ]+")
 _MAX_WORDS = 20
+# CAMeL POS prefixes that count as teachable content; everything else (preps,
+# particles, pronouns, conjunctions) is a readable function word, not a gap.
+_CONTENT_POS_PREFIXES = ("noun", "adj", "verb", "adv")
+# LLM/CAMeL part-of-speech values that mark a proper noun (never vocabulary).
+_PROPER_NOUN_POS = {"proper_noun", "noun_prop"}
 
 _GLOSS_SCHEMA = {
     "type": "object",
@@ -68,29 +86,25 @@ _GLOSS_SCHEMA = {
 }
 
 
-def _lemmatize(token: str) -> tuple[str, str, str | None] | None:
-    """(diacritized lemma, normalized bare, pos) for an Arabic surface token, or None
-    if it isn't a content word. Falls back to clitic-stripping when CAMeL is unavailable."""
-    norm = _normalize(token)
-    if len(norm) < 2 or _is_function_word(norm):
-        return None
-    lex, pos = token, None
+def _camel_content(token: str, cache: dict) -> tuple[str, str, str] | None:
+    """For an OOV surface token, return (diacritized citation lemma, normalized bare,
+    pos) if CAMeL analyses it as a content word; None for function/proper/unanalyzable.
+    Groups inflected forms of the same word under one citation lemma."""
+    if token in cache:
+        return cache[token]
+    result = None
     try:
-        analysis = get_best_lemma_mle(token)
+        a = get_best_lemma_mle(token)
     except Exception:
-        analysis = None
-    if analysis and analysis.get("lex"):
-        lex, pos = analysis["lex"], analysis.get("pos")
-        bare = _normalize(lex)
-    else:
-        try:
-            stems = _strip_clitics(norm)
-        except Exception:
-            stems = []
-        bare = _normalize(stems[0]) if stems else norm
-    if len(bare) < 2 or _is_function_word(bare):
-        return None
-    return lex, bare, pos
+        a = None
+    if a and a.get("lex"):
+        pos = (a.get("pos") or "").lower()
+        # noun_prop = proper name: readable, not a vocab gap → skip.
+        if pos != "noun_prop" and any(pos.startswith(p) for p in _CONTENT_POS_PREFIXES):
+            lex = a["lex"]
+            result = (lex, _normalize(lex), pos)
+    cache[token] = result
+    return result
 
 
 def _gloss(items: list[dict]) -> dict[int, dict]:
@@ -135,35 +149,41 @@ class DiscoverIn(BaseModel):
 @router.post("/words")
 def discover_words(req: DiscoverIn, db: Session = Depends(get_db)):
     """High-value Arabic lemmas in `text` that aren't in Alif yet, ranked by frequency."""
-    cand: dict[str, dict] = {}  # bare -> {surface, lemma_ar, pos, count}
+    lemma_lookup = build_comprehensive_lemma_lookup(db)
+    ranks = _load_rank_map()
+    cand: dict[str, dict] = {}  # citation bare -> {surface, lemma_ar, pos, count}
+    camel_cache: dict = {}
+
     for tok in _ARABIC_TOKEN.findall(req.text or ""):
-        lem = _lemmatize(tok)
-        if not lem:
+        bare = _normalize(tok)
+        if len(bare) < 2 or _is_function_word(bare) or _is_function_word(bare.replace("ى", "ي")):
             continue
-        lex, bare, pos = lem
-        if bare in cand:
-            cand[bare]["count"] += 1
+        # Already in Alif's vocabulary? The hardened lookup resolves clitics and
+        # variants → canonical, so this catches forms a surface match would miss.
+        if lookup_lemma(bare, lemma_lookup, original_bare=strip_diacritics(tok)) is not None:
+            continue
+        # Genuinely OOV: CAMeL confirms it's a content word, groups inflections under
+        # one citation form, and gives a diacritized lemma for glossing.
+        analysis = _camel_content(tok, camel_cache)
+        if analysis is None:
+            continue  # function / proper / unanalyzable — not a vocab candidate
+        lex, lex_bare, pos = analysis
+        # The citation form itself may already be known even when the surface wasn't
+        # (e.g. an inflection CAMeL reduced to an in-vocab lemma).
+        if lex_bare != bare and lookup_lemma(lex_bare, lemma_lookup) is not None:
+            continue
+        entry = cand.get(lex_bare)
+        if entry:
+            entry["count"] += 1
         else:
-            cand[bare] = {"surface": tok, "lemma_ar": lex, "pos": pos, "count": 1}
+            cand[lex_bare] = {"surface": tok, "lemma_ar": lex, "pos": pos, "count": 1}
+
     if not cand:
         return {"words": [], "count": 0}
 
-    # Genuinely-new only: drop any bare form Alif already has a lemma for.
-    bares = list(cand.keys())
-    existing: set[str] = set()
-    for i in range(0, len(bares), 400):
-        rows = db.query(Lemma.lemma_ar_bare).filter(
-            Lemma.lemma_ar_bare.in_(bares[i : i + 400])
-        ).all()
-        existing.update(r[0] for r in rows)
-    fresh = {b: v for b, v in cand.items() if b not in existing}
-    if not fresh:
-        return {"words": [], "count": 0}
-
     # Rank: frequency-listed words first (most frequent first), then by occurrences.
-    ranks = _load_rank_map()
     ordered = sorted(
-        fresh.items(),
+        cand.items(),
         key=lambda kv: (0, ranks[kv[0]]) if kv[0] in ranks else (1, -kv[1]["count"]),
     )[: max(1, min(req.count, _MAX_WORDS))]
 
@@ -201,10 +221,6 @@ class WordIn(BaseModel):
     transliteration: str | None = None
 
 
-class WordsIn(BaseModel):
-    words: list[WordIn]
-
-
 def _gate_and_generate(lemma_ids: list[int]) -> None:
     """Background: quality-gate the new lemmas, then generate review material. Own
     session so it never blocks the request's write lock."""
@@ -224,30 +240,43 @@ def _gate_and_generate(lemma_ids: list[int]) -> None:
             logger.warning("dragoman material gen failed for %s: %s", lid, e)
 
 
-def _create_and_introduce(db: Session, w: WordIn) -> dict:
+def _create_and_introduce(db: Session, w: WordIn, lemma_lookup: dict) -> dict:
+    """Find-or-create the canonical lemma for `w`, then introduce it immediately
+    (bypassing the daily intro cap — this is an explicit user add). Newly created
+    lemmas are registered in `lemma_lookup` so a repeated word in the same batch
+    resolves to the row we just made instead of being created twice."""
+    if (w.pos or "").lower() in _PROPER_NOUN_POS:
+        raise ValueError(f"refusing to add proper noun {w.lemma_ar_bare!r}")
     bare = _normalize(w.lemma_ar_bare)
-    existing = (
-        db.query(Lemma)
-        .filter(Lemma.canonical_lemma_id.is_(None), Lemma.lemma_ar_bare == bare)
-        .first()
-    )
+    # Hardened existence check: resolves clitics + variants → canonical.
+    existing_id = lookup_lemma(bare, lemma_lookup, original_bare=strip_diacritics(w.lemma_ar_bare))
     created = False
-    if existing:
-        lemma = existing
-    else:
+    if existing_id is not None:
+        lemma = db.query(Lemma).filter(Lemma.lemma_id == existing_id).first()
+    if existing_id is None or lemma is None:
+        gloss = (w.gloss_en or "").strip()
+        if not gloss:
+            # Hard invariant: no words without an English gloss, ever.
+            raise ValueError(f"refusing to create gloss-less lemma {bare!r}")
+        word_category = "proper_name" if (w.pos or "").lower() in _PROPER_NOUN_POS else None
         lemma = Lemma(
             lemma_ar=(w.lemma_ar or bare),
             lemma_ar_bare=bare,
-            gloss_en=w.gloss_en,
+            gloss_en=gloss,
             pos=w.pos,
+            word_category=word_category,
             transliteration_ala_lc=w.transliteration,
-            source="study",
+            source="dragoman",
         )
         db.add(lemma)
         db.flush()
         assign_frequency_rank(lemma)
+        lemma_lookup[bare] = lemma.lemma_id  # in-batch dedupe
         created = True
-    res = introduce_word(db, lemma.lemma_id, source="study")
+    res = introduce_word(
+        db, lemma.lemma_id, source="dragoman",
+        due_immediately=True, enforce_daily_cap=False,
+    )
     return {
         "lemma_id": lemma.lemma_id,
         "lemma_ar": lemma.lemma_ar,
@@ -261,30 +290,41 @@ def _create_and_introduce(db: Session, w: WordIn) -> dict:
 @router.post("/add")
 def add_word(w: WordIn, background_tasks: BackgroundTasks, db: Session = Depends(get_db)):
     """Create + introduce one word; gate and generate material in the background."""
-    out = _create_and_introduce(db, w)
+    lemma_lookup = build_comprehensive_lemma_lookup(db)
+    try:
+        out = _create_and_introduce(db, w, lemma_lookup)
+    except ValueError as e:
+        db.rollback()
+        raise HTTPException(status_code=400, detail=str(e))
     db.commit()
     if out["created"]:
         background_tasks.add_task(_gate_and_generate, [out["lemma_id"]])
-    log_interaction(event="dragoman_word_added", lemma_id=out["lemma_id"])
+        log_interaction(event="dragoman_word_added", lemma_id=out["lemma_id"])
     return out
+
+
+class WordsIn(BaseModel):
+    words: list[WordIn]
 
 
 @router.post("/add-batch")
 def add_words(req: WordsIn, background_tasks: BackgroundTasks, db: Session = Depends(get_db)):
-    """Create + introduce several words at once."""
+    """Create + introduce several words at once. Each word is committed independently
+    so one failure can't roll back the rest of the batch."""
+    lemma_lookup = build_comprehensive_lemma_lookup(db)
     results, new_ids = [], []
     for w in req.words:
         try:
-            out = _create_and_introduce(db, w)
+            out = _create_and_introduce(db, w, lemma_lookup)
+            db.commit()
             results.append(out)
             if out["created"]:
                 new_ids.append(out["lemma_id"])
+                log_interaction(event="dragoman_word_added", lemma_id=out["lemma_id"])
         except Exception as e:
             db.rollback()
+            logger.warning("dragoman add failed for %s: %s", w.lemma_ar_bare, e)
             results.append({"lemma_ar_bare": w.lemma_ar_bare, "error": str(e)})
-    db.commit()
     if new_ids:
         background_tasks.add_task(_gate_and_generate, new_ids)
-        for lid in new_ids:
-            log_interaction(event="dragoman_word_added", lemma_id=lid)
     return {"added": results, "count": len(results)}

--- a/backend/app/routers/discover.py
+++ b/backend/app/routers/discover.py
@@ -1,0 +1,290 @@
+"""Discover vocabulary from external Arabic text (e.g. the Dragoman magazine).
+
+Two jobs:
+  POST /api/discover/words  — given a block of Arabic text, return the highest-value
+       lemmas that are NOT yet in Alif's pool, ranked by MSA frequency, each glossed.
+  POST /api/discover/add[-batch] — create the chosen lemma(s), introduce them into the
+       acquisition pipeline, and (in the background) run the quality gates + generate
+       review material. Fast write up front; the LLM-heavy gating never holds the
+       write lock (own session in a BackgroundTask).
+
+This is the Dragoman → Alif integration: a reader sees an Arabic essay in the magazine,
+Dragoman asks this endpoint which words are worth learning, and renders "add to Alif"
+buttons that POST back here.
+"""
+import logging
+import re
+
+from fastapi import APIRouter, BackgroundTasks, Depends
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from app.database import SessionLocal, get_db
+from app.models import Lemma
+from app.services.interaction_logger import log_interaction
+from app.services.llm import generate_completion
+from app.services.lemma_quality import (
+    _load_rank_map,
+    _normalize,
+    assign_frequency_rank,
+    run_quality_gates,
+)
+from app.services.material_generator import (
+    MIN_SENTENCES_PER_WORD,
+    generate_material_for_word,
+)
+from app.services.morphology import get_best_lemma_mle
+from app.services.sentence_validator import _is_function_word, _strip_clitics
+from app.services.word_selector import introduce_word
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/discover", tags=["discover"])
+
+# Arabic letters + diacritics + tatweel + superscript alef only — deliberately excludes
+# Arabic punctuation (، ؛ ؟ at U+060C/061B/061F), which sit in the same Unicode block.
+_ARABIC_TOKEN = re.compile(r"[ء-ْٰ]+")
+_MAX_WORDS = 20
+
+_GLOSS_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "glosses": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "index": {"type": "integer"},
+                    "gloss_en": {"type": "string"},
+                    "pos": {"type": "string"},
+                    "transliteration": {"type": "string"},
+                    "is_proper_noun": {"type": "boolean"},
+                },
+                "required": ["index", "gloss_en", "pos", "transliteration", "is_proper_noun"],
+            },
+        }
+    },
+    "required": ["glosses"],
+}
+
+
+def _lemmatize(token: str) -> tuple[str, str, str | None] | None:
+    """(diacritized lemma, normalized bare, pos) for an Arabic surface token, or None
+    if it isn't a content word. Falls back to clitic-stripping when CAMeL is unavailable."""
+    norm = _normalize(token)
+    if len(norm) < 2 or _is_function_word(norm):
+        return None
+    lex, pos = token, None
+    try:
+        analysis = get_best_lemma_mle(token)
+    except Exception:
+        analysis = None
+    if analysis and analysis.get("lex"):
+        lex, pos = analysis["lex"], analysis.get("pos")
+        bare = _normalize(lex)
+    else:
+        try:
+            stems = _strip_clitics(norm)
+        except Exception:
+            stems = []
+        bare = _normalize(stems[0]) if stems else norm
+    if len(bare) < 2 or _is_function_word(bare):
+        return None
+    return lex, bare, pos
+
+
+def _gloss(items: list[dict]) -> dict[int, dict]:
+    """LLM-gloss the candidate lemmas. Returns {index: {gloss_en, pos, transliteration,
+    is_proper_noun}}. Empty on failure — callers degrade gracefully."""
+    if not items:
+        return {}
+    listing = "\n".join(
+        f'{it["index"]}. {it["lemma_ar"]} (bare {it["bare"]}'
+        + (f', {it["pos"]}' if it.get("pos") else "")
+        + ")"
+        for it in items
+    )
+    prompt = (
+        "Give a concise English gloss for each Modern Standard Arabic lemma below.\n"
+        "- gloss_en: 1-4 words, the core meaning (no article, no parenthetical).\n"
+        "- pos: noun / verb / adjective / adverb / particle / proper_noun.\n"
+        "- transliteration: ALA-LC romanization of the lemma.\n"
+        "- is_proper_noun: true for names of people/places/organizations.\n\n"
+        f"{listing}"
+    )
+    try:
+        res = generate_completion(
+            prompt=prompt,
+            system_prompt="You are a precise Arabic-English lexicographer.",
+            json_schema=_GLOSS_SCHEMA,
+            temperature=0.0,
+            model_override="claude_haiku",
+            task_type="dragoman_gloss",
+        )
+    except Exception as e:
+        logger.warning("dragoman gloss failed: %s", e)
+        return {}
+    return {g["index"]: g for g in res.get("glosses", []) if "index" in g}
+
+
+class DiscoverIn(BaseModel):
+    text: str
+    count: int = 8
+
+
+@router.post("/words")
+def discover_words(req: DiscoverIn, db: Session = Depends(get_db)):
+    """High-value Arabic lemmas in `text` that aren't in Alif yet, ranked by frequency."""
+    cand: dict[str, dict] = {}  # bare -> {surface, lemma_ar, pos, count}
+    for tok in _ARABIC_TOKEN.findall(req.text or ""):
+        lem = _lemmatize(tok)
+        if not lem:
+            continue
+        lex, bare, pos = lem
+        if bare in cand:
+            cand[bare]["count"] += 1
+        else:
+            cand[bare] = {"surface": tok, "lemma_ar": lex, "pos": pos, "count": 1}
+    if not cand:
+        return {"words": [], "count": 0}
+
+    # Genuinely-new only: drop any bare form Alif already has a lemma for.
+    bares = list(cand.keys())
+    existing: set[str] = set()
+    for i in range(0, len(bares), 400):
+        rows = db.query(Lemma.lemma_ar_bare).filter(
+            Lemma.lemma_ar_bare.in_(bares[i : i + 400])
+        ).all()
+        existing.update(r[0] for r in rows)
+    fresh = {b: v for b, v in cand.items() if b not in existing}
+    if not fresh:
+        return {"words": [], "count": 0}
+
+    # Rank: frequency-listed words first (most frequent first), then by occurrences.
+    ranks = _load_rank_map()
+    ordered = sorted(
+        fresh.items(),
+        key=lambda kv: (0, ranks[kv[0]]) if kv[0] in ranks else (1, -kv[1]["count"]),
+    )[: max(1, min(req.count, _MAX_WORDS))]
+
+    glosses = _gloss(
+        [
+            {"index": i, "lemma_ar": v["lemma_ar"], "bare": b, "pos": v["pos"]}
+            for i, (b, v) in enumerate(ordered)
+        ]
+    )
+    words = []
+    for i, (b, v) in enumerate(ordered):
+        g = glosses.get(i, {})
+        if g.get("is_proper_noun"):
+            continue  # names aren't vocabulary worth scheduling
+        words.append(
+            {
+                "surface": v["surface"],
+                "lemma_ar": v["lemma_ar"],
+                "lemma_ar_bare": b,
+                "gloss_en": g.get("gloss_en"),
+                "pos": g.get("pos") or v["pos"],
+                "transliteration": g.get("transliteration"),
+                "freq_rank": ranks.get(b),
+                "count_in_text": v["count"],
+            }
+        )
+    return {"words": words, "count": len(words)}
+
+
+class WordIn(BaseModel):
+    lemma_ar_bare: str
+    lemma_ar: str | None = None
+    gloss_en: str | None = None
+    pos: str | None = None
+    transliteration: str | None = None
+
+
+class WordsIn(BaseModel):
+    words: list[WordIn]
+
+
+def _gate_and_generate(lemma_ids: list[int]) -> None:
+    """Background: quality-gate the new lemmas, then generate review material. Own
+    session so it never blocks the request's write lock."""
+    db = SessionLocal()
+    try:
+        run_quality_gates(db, lemma_ids, background_enrich=True)
+        db.commit()
+    except Exception as e:
+        logger.warning("dragoman gating failed for %s: %s", lemma_ids, e)
+        db.rollback()
+    finally:
+        db.close()
+    for lid in lemma_ids:
+        try:
+            generate_material_for_word(lid, needed=MIN_SENTENCES_PER_WORD)
+        except Exception as e:
+            logger.warning("dragoman material gen failed for %s: %s", lid, e)
+
+
+def _create_and_introduce(db: Session, w: WordIn) -> dict:
+    bare = _normalize(w.lemma_ar_bare)
+    existing = (
+        db.query(Lemma)
+        .filter(Lemma.canonical_lemma_id.is_(None), Lemma.lemma_ar_bare == bare)
+        .first()
+    )
+    created = False
+    if existing:
+        lemma = existing
+    else:
+        lemma = Lemma(
+            lemma_ar=(w.lemma_ar or bare),
+            lemma_ar_bare=bare,
+            gloss_en=w.gloss_en,
+            pos=w.pos,
+            transliteration_ala_lc=w.transliteration,
+            source="study",
+        )
+        db.add(lemma)
+        db.flush()
+        assign_frequency_rank(lemma)
+        created = True
+    res = introduce_word(db, lemma.lemma_id, source="study")
+    return {
+        "lemma_id": lemma.lemma_id,
+        "lemma_ar": lemma.lemma_ar,
+        "gloss_en": lemma.gloss_en,
+        "created": created,
+        "state": res.get("state"),
+        "already_known": res.get("already_known", False),
+    }
+
+
+@router.post("/add")
+def add_word(w: WordIn, background_tasks: BackgroundTasks, db: Session = Depends(get_db)):
+    """Create + introduce one word; gate and generate material in the background."""
+    out = _create_and_introduce(db, w)
+    db.commit()
+    if out["created"]:
+        background_tasks.add_task(_gate_and_generate, [out["lemma_id"]])
+    log_interaction(event="dragoman_word_added", lemma_id=out["lemma_id"])
+    return out
+
+
+@router.post("/add-batch")
+def add_words(req: WordsIn, background_tasks: BackgroundTasks, db: Session = Depends(get_db)):
+    """Create + introduce several words at once."""
+    results, new_ids = [], []
+    for w in req.words:
+        try:
+            out = _create_and_introduce(db, w)
+            results.append(out)
+            if out["created"]:
+                new_ids.append(out["lemma_id"])
+        except Exception as e:
+            db.rollback()
+            results.append({"lemma_ar_bare": w.lemma_ar_bare, "error": str(e)})
+    db.commit()
+    if new_ids:
+        background_tasks.add_task(_gate_and_generate, new_ids)
+        for lid in new_ids:
+            log_interaction(event="dragoman_word_added", lemma_id=lid)
+    return {"added": results, "count": len(results)}

--- a/backend/app/services/word_selector.py
+++ b/backend/app/services/word_selector.py
@@ -813,11 +813,15 @@ def select_next_words(
 
 def introduce_word(
     db: Session, lemma_id: int, source: str = "study", due_immediately: bool = False,
+    enforce_daily_cap: bool = True,
 ) -> dict:
     """Mark a word as introduced, starting acquisition (Leitner 3-box).
 
     Source values: study (Learn mode), auto_intro (inline review), collocate.
     If due_immediately=True, word is due right now (for auto-intro in current session).
+    When enforce_daily_cap is False, the DAILY_INTRO_CAP is skipped — used for
+    explicit user-initiated adds (e.g. Dragoman "add to Alif") that should start
+    immediately rather than being deferred to a future day.
     Returns the created knowledge record as dict.
     """
     from app.services.acquisition_service import start_acquisition
@@ -848,7 +852,10 @@ def introduce_word(
             }
         if existing.knowledge_state == "encountered":
             # Transition encountered → acquiring
-            ulk = start_acquisition(db, lemma_id, source=source, due_immediately=due_immediately)
+            ulk = start_acquisition(
+                db, lemma_id, source=source, due_immediately=due_immediately,
+                enforce_daily_cap=enforce_daily_cap,
+            )
             if ulk.knowledge_state != "acquiring":
                 db.commit()
                 return {
@@ -884,7 +891,10 @@ def introduce_word(
         }
 
     # New word — start acquisition
-    ulk = start_acquisition(db, lemma_id, source=source, due_immediately=due_immediately)
+    ulk = start_acquisition(
+        db, lemma_id, source=source, due_immediately=due_immediately,
+        enforce_daily_cap=enforce_daily_cap,
+    )
     if ulk.knowledge_state != "acquiring":
         db.commit()
         return {

--- a/backend/tests/test_discover.py
+++ b/backend/tests/test_discover.py
@@ -1,0 +1,110 @@
+"""Tests for the Dragoman vocabulary-discovery router (app/routers/discover.py)."""
+import pytest
+
+from app.models import Lemma, UserLemmaKnowledge
+from app.routers import discover
+
+
+@pytest.fixture
+def seeded(db_session):
+    """A known word (مكتبة, acquiring) so we can prove discovery excludes it."""
+    lem = Lemma(
+        lemma_ar="مَكْتَبَة", lemma_ar_bare="مكتبة", gloss_en="library",
+        pos="noun", source="frequency_core",
+    )
+    db_session.add(lem)
+    db_session.flush()
+    db_session.add(UserLemmaKnowledge(lemma_id=lem.lemma_id, knowledge_state="acquiring"))
+    db_session.commit()
+    return db_session
+
+
+def _no_llm_gloss(monkeypatch, mapping):
+    """Stub the LLM gloss step: mapping is {bare: (gloss, pos, is_proper)}."""
+    def fake_gloss(items):
+        out = {}
+        for it in items:
+            g, pos, proper = mapping.get(it["bare"], ("x", "noun", False))
+            out[it["index"]] = {
+                "gloss_en": g, "pos": pos, "transliteration": "t", "is_proper_noun": proper,
+            }
+        return out
+    monkeypatch.setattr(discover, "_gloss", fake_gloss)
+
+
+def test_words_excludes_known_via_hardened_lookup(client, seeded, monkeypatch):
+    """A word already in the vocabulary (even clitic-attached) is not suggested."""
+    _no_llm_gloss(monkeypatch, {"دستور": ("constitution", "noun", False)})
+    # المكتبة = ال + مكتبة (known); وبالدستور = و+ب+ال+دستور (new) → only دستور suggested.
+    r = client.post("/api/discover/words", json={"text": "زرت المكتبة وبالدستور", "count": 8})
+    assert r.status_code == 200
+    bares = {w["lemma_ar_bare"] for w in r.json()["words"]}
+    assert "مكتبة" not in bares
+    assert "دستور" in bares
+
+
+def test_words_drops_proper_nouns(client, db_session, monkeypatch):
+    _no_llm_gloss(monkeypatch, {"دستور": ("constitution", "noun", True)})
+    r = client.post("/api/discover/words", json={"text": "الدستور مهم", "count": 8})
+    assert r.status_code == 200
+    assert all(not w.get("is_proper_noun") for w in r.json()["words"])
+    assert "دستور" not in {w["lemma_ar_bare"] for w in r.json()["words"]}
+
+
+def test_add_creates_introduces_and_bypasses_cap(client, db_session):
+    r = client.post("/api/discover/add", json={
+        "lemma_ar_bare": "دستور", "lemma_ar": "دُسْتُور",
+        "gloss_en": "constitution", "pos": "noun", "transliteration": "dustūr",
+    })
+    assert r.status_code == 200
+    body = r.json()
+    assert body["created"] is True
+    assert body["state"] == "acquiring"  # introduced immediately, not cap-deferred
+    lem = db_session.query(Lemma).filter(Lemma.lemma_ar_bare == "دستور").first()
+    assert lem is not None and lem.source == "dragoman" and lem.gloss_en == "constitution"
+    ulk = db_session.query(UserLemmaKnowledge).filter(
+        UserLemmaKnowledge.lemma_id == lem.lemma_id
+    ).first()
+    assert ulk is not None and ulk.knowledge_state == "acquiring"
+
+
+def test_add_rejects_glossless_word(client, db_session):
+    r = client.post("/api/discover/add", json={"lemma_ar_bare": "دستور", "gloss_en": ""})
+    # The endpoint refuses with a clean 400 rather than creating a gloss-less lemma.
+    assert r.status_code == 400
+    assert db_session.query(Lemma).filter(Lemma.lemma_ar_bare == "دستور").first() is None
+
+
+def test_add_rejects_proper_noun(client, db_session):
+    r = client.post("/api/discover/add", json={
+        "lemma_ar_bare": "مصر", "gloss_en": "Egypt", "pos": "proper_noun",
+    })
+    assert r.status_code == 400
+    assert db_session.query(Lemma).filter(Lemma.lemma_ar_bare == "مصر").first() is None
+
+
+def test_add_batch_isolates_failures(client, db_session):
+    r = client.post("/api/discover/add-batch", json={"words": [
+        {"lemma_ar_bare": "دستور", "gloss_en": "constitution", "pos": "noun"},
+        {"lemma_ar_bare": "مصر", "gloss_en": "Egypt", "pos": "proper_noun"},  # rejected
+        {"lemma_ar_bare": "اقتصاد", "gloss_en": "economy", "pos": "noun"},
+    ]})
+    assert r.status_code == 200
+    added = r.json()["added"]
+    assert added[0]["created"] is True
+    assert "error" in added[1]
+    assert added[2]["created"] is True
+    # The good words persisted despite the failure between them.
+    bares = {l.lemma_ar_bare for l in db_session.query(Lemma).all()}
+    assert {"دستور", "اقتصاد"} <= bares
+    assert "مصر" not in bares
+
+
+def test_add_batch_dedupes_repeated_word(client, db_session):
+    r = client.post("/api/discover/add-batch", json={"words": [
+        {"lemma_ar_bare": "دستور", "gloss_en": "constitution", "pos": "noun"},
+        {"lemma_ar_bare": "دستور", "gloss_en": "constitution", "pos": "noun"},
+    ]})
+    assert r.status_code == 200
+    rows = db_session.query(Lemma).filter(Lemma.lemma_ar_bare == "دستور").all()
+    assert len(rows) == 1  # second add resolved to the first via in-batch lookup

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -115,6 +115,13 @@ Full endpoint list. See `backend/app/routers/` for implementation.
 | GET | `/api/patterns/{wazn}` | All words with a specific pattern + enrichment JSON, ordered by frequency |
 | GET | `/api/patterns/roots/{root_id}/tree` | Full derivation tree for a root, grouped by pattern |
 
+## Discover (external-text vocabulary, Dragoman integration)
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/api/discover/words` | Given `{text, count}` of Arabic prose, return up to `count` (≤20) high-value lemmas **not yet in Alif**, ranked by MSA frequency then in-text occurrence, each glossed. Word identity goes through the hardened lookup path (`build_comprehensive_lemma_lookup` + `lookup_lemma` — clitics + variants→canonical resolved); genuinely-OOV tokens are confirmed as content words via CAMeL and grouped by citation lemma. Proper nouns dropped. Read-only. Each word: `{surface, lemma_ar, lemma_ar_bare, gloss_en, pos, transliteration, freq_rank, count_in_text}`. |
+| POST | `/api/discover/add` | `{lemma_ar_bare, lemma_ar?, gloss_en?, pos?, transliteration?}` → find-or-create the canonical lemma and **introduce it immediately**, bypassing `DAILY_INTRO_CAP` (explicit user add). Quality gates + material generation run in a background task (own session, no write-lock hold). Rejects gloss-less words and proper nouns with `400`. Lemmas tagged `source="dragoman"`. |
+| POST | `/api/discover/add-batch` | `{words: [WordIn,...]}` → same as `/add` per word, each committed independently so one failure can't roll back the rest; repeated words in one batch dedupe to a single lemma. Returns `{added: [...], count}`. |
+
 ## Settings
 | Method | Path | Description |
 |--------|------|-------------|


### PR DESCRIPTION
## What & why

New router `app/routers/discover.py` (3 endpoints) so the **Dragoman** polyglot magazine can turn an Arabic essay into vocabulary the reader can add to Alif. The reader sees an Arabic bilingual piece in Dragoman; Dragoman asks Alif which words are worth learning, and renders "add to Alif" buttons that POST back here.

This grows Alif's vocab from **real reading material** the user is already engaging with, rather than only the frequency-core curriculum.

## Endpoints

### `POST /api/discover/words`  — read-only
Given a block of Arabic text, return the highest-value lemmas **not yet in Alif**, ranked by frequency, each glossed.

- Tokenize (Arabic-letters-only regex; deliberately excludes `،؛؟` which share the Unicode block).
- Lemmatize each token via `morphology.get_best_lemma_mle`, falling back to `sentence_validator._strip_clitics` when CAMeL is unavailable.
- Drop function words (`_is_function_word`) and any bare form that already has a canonical row in `lemmas` (genuinely-new only).
- Rank: frequency-listed words first (most frequent first, via `lemma_quality._load_rank_map`), then by occurrence count.
- Gloss the top N with `llm.generate_completion` (`claude_haiku`, constrained `json_schema` → `gloss_en` / `pos` / `transliteration` / `is_proper_noun`); proper nouns are dropped.

Request: `{ "text": "...", "count": 8 }` → Response: `{ "words": [{surface, lemma_ar, lemma_ar_bare, gloss_en, pos, transliteration, freq_rank, count_in_text}], "count": N }`.

### `POST /api/discover/add` and `POST /api/discover/add-batch`
Create the chosen lemma(s) and introduce them into acquisition.

- Find-or-create the canonical lemma (`assign_frequency_rank` on create), then `word_selector.introduce_word(source="study")`. **Fast path, committed up front.**
- The LLM-heavy work — `run_quality_gates` (variant detection) + `generate_material_for_word` — is deferred to a FastAPI `BackgroundTask` that opens **its own session**, so the request never holds the SQLite write lock across LLM calls (per the repo's write-lock discipline).

## Design notes / reuse
- No new NLP or LLM scaffolding: reuses `morphology`, `sentence_validator`, `lemma_quality`, `word_selector`, `llm`, `material_generator`.
- No hallucinated lemmas enter review unvetted — created lemmas still go through `run_quality_gates`, and glosses come from the constrained-decoding path.
- CORS already allows all origins (`main.py`); wired with `app.include_router(discover.router)`.
- Arabic-only by nature (CAMeL morphology / Semitic roots / clitic stripping).

## Verification done
- Router imports against the real stack and registers all 3 routes; full app boots with it wired.
- Lemmatization checked on real MSA prose (clitics stripped, verbs/nouns/adjectives correctly reduced); fixed an Arabic-punctuation tokenization bug found in testing.
- `/words` DB-read SQL + normalized parameters confirmed correct.

## Reviewer notes
- The end-to-end `/words` path (DB filter + glossing) was **not** run against a seeded DB locally — my local `alif.db` lacks the `lemmas` table. Please sanity-check against the server DB.
- Client buttons live on the HTTPS Dragoman Pages site, so they need an nginx HTTPS route to this backend (documented on the Dragoman side); no change required in this repo.
- `introduce_word` is called with `source="study"` — open to a more specific source tag if you'd prefer to distinguish Dragoman-origin words.

🤖 Generated with [Claude Code](https://claude.com/claude-code)