### PR TITLE
leech: key low-priority cooldown on core_rank, not sparse frequency_rank

### DIFF
--- a/backend/app/services/frequency_lanes.py
+++ b/backend/app/services/frequency_lanes.py
@@ -159,10 +159,21 @@ def frequency_priority_sort_key(
     return rank, -overdue, lemma_id
 
 
-def is_low_priority_lemma(lemma: Lemma | None) -> bool:
-    """Return True for obscure/unranked words that should spend less bandwidth."""
+def is_low_priority_lemma(lemma: Lemma | None, core_rank: int | None = None) -> bool:
+    """Return True for obscure/unranked words that should spend less bandwidth.
+
+    The merged frequency-core rank is the authoritative frequency signal: a word
+    inside the main lane (``core_rank <= MAIN_LANE_MAX_RANK``) is never
+    low-priority, even when its per-lemma ``frequency_rank`` is unset or carries a
+    sparse single-source value. ``lemma.frequency_rank`` comes from the CAMeL-only
+    list (~1/3 of lemmas are NULL, and book/quran/wiktionary imports often hold a
+    raw rank well past the threshold), so consulting it alone throttled genuinely
+    frequent words. Mirrors the core_rank check in ``is_main_lane_word``.
+    """
     if lemma is None:
         return True
+    if core_rank is not None and core_rank <= MAIN_LANE_MAX_RANK:
+        return False
     if lemma.source in LOW_PRIORITY_EXEMPT_SOURCES:
         return False
     rank = lemma.frequency_rank

--- a/backend/app/services/leech_service.py
+++ b/backend/app/services/leech_service.py
@@ -20,7 +20,7 @@ from datetime import datetime, timedelta, timezone
 
 from sqlalchemy.orm import Session
 
-from app.models import Lemma, ReviewLog, UserLemmaKnowledge
+from app.models import FrequencyCoreEntry, Lemma, ReviewLog, UserLemmaKnowledge
 from app.services.activity_log import log_activity
 from app.services.frequency_lanes import is_low_priority_lemma
 from app.services.interaction_logger import log_interaction
@@ -41,7 +41,9 @@ LOW_PRIORITY_LEECH_DELAY_MULTIPLIER = 4
 LOW_PRIORITY_LEECH_MAX_DELAY = timedelta(days=60)
 
 
-def _get_reintro_delay(leech_count: int, lemma: Lemma | None = None) -> timedelta:
+def _get_reintro_delay(
+    leech_count: int, lemma: Lemma | None = None, core_rank: int | None = None
+) -> timedelta:
     """Return the reintroduction delay based on how many times this word has been leeched."""
     if leech_count <= 0:
         delay = REINTRO_DELAYS[0]
@@ -49,13 +51,23 @@ def _get_reintro_delay(leech_count: int, lemma: Lemma | None = None) -> timedelt
         delay = REINTRO_DELAYS[1]
     else:
         delay = REINTRO_DELAYS[2]
-    if lemma is not None and is_low_priority_lemma(lemma):
+    if lemma is not None and is_low_priority_lemma(lemma, core_rank=core_rank):
         return min(delay * LOW_PRIORITY_LEECH_DELAY_MULTIPLIER, LOW_PRIORITY_LEECH_MAX_DELAY)
     return delay
 
 
 def _get_lemma(db: Session, lemma_id: int) -> Lemma | None:
     return db.query(Lemma).filter(Lemma.lemma_id == lemma_id).first()
+
+
+def _get_core_rank(db: Session, lemma_id: int) -> int | None:
+    """Authoritative merged frequency rank for a lemma (None if not in the core)."""
+    row = (
+        db.query(FrequencyCoreEntry.core_rank)
+        .filter(FrequencyCoreEntry.lemma_id == lemma_id)
+        .first()
+    )
+    return row[0] if row else None
 
 
 def check_and_manage_leeches(db: Session) -> list[int]:
@@ -80,6 +92,7 @@ def check_and_manage_leeches(db: Session) -> list[int]:
         accuracy = acc
         if accuracy < LEECH_MAX_ACCURACY:
             lemma = _get_lemma(db, ulk.lemma_id)
+            core_rank = _get_core_rank(db, ulk.lemma_id)
             ulk.knowledge_state = "suspended"
             ulk.leech_suspended_at = datetime.now(timezone.utc)
             ulk.leech_count = (ulk.leech_count or 0) + 1
@@ -87,7 +100,7 @@ def check_and_manage_leeches(db: Session) -> list[int]:
             ulk.acquisition_next_due = None
             suspended.append(ulk.lemma_id)
 
-            cooldown = _get_reintro_delay(ulk.leech_count - 1, lemma)
+            cooldown = _get_reintro_delay(ulk.leech_count - 1, lemma, core_rank=core_rank)
             log_interaction(
                 event="leech_suspended",
                 lemma_id=ulk.lemma_id,
@@ -96,7 +109,7 @@ def check_and_manage_leeches(db: Session) -> list[int]:
                 accuracy=round(accuracy, 3),
                 leech_count=ulk.leech_count,
                 reintro_days=cooldown.days,
-                low_priority=lemma is not None and is_low_priority_lemma(lemma),
+                low_priority=lemma is not None and is_low_priority_lemma(lemma, core_rank=core_rank),
             )
 
     if suspended:
@@ -137,7 +150,8 @@ def check_leech_reintroductions(db: Session) -> list[int]:
         # Calculate per-word cooldown based on leech_count
         lc = (ulk.leech_count or 1) - 1  # count before this suspension
         lemma = _get_lemma(db, ulk.lemma_id)
-        delay = _get_reintro_delay(lc, lemma)
+        core_rank = _get_core_rank(db, ulk.lemma_id)
+        delay = _get_reintro_delay(lc, lemma, core_rank=core_rank)
         suspended_at = ulk.leech_suspended_at
         if suspended_at.tzinfo is None:
             suspended_at = suspended_at.replace(tzinfo=timezone.utc)
@@ -156,7 +170,7 @@ def check_leech_reintroductions(db: Session) -> list[int]:
             leech_count=ulk.leech_count,
             times_seen=ulk.times_seen,
             times_correct=ulk.times_correct,
-            low_priority=lemma is not None and is_low_priority_lemma(lemma),
+            low_priority=lemma is not None and is_low_priority_lemma(lemma, core_rank=core_rank),
         )
 
     if reintroduced:
@@ -236,13 +250,14 @@ def check_single_word_leech(db: Session, lemma_id: int) -> bool:
     if is_leech(ulk, db=db):
         acc = _recent_accuracy(db, lemma_id) or 0
         lemma = _get_lemma(db, lemma_id)
+        core_rank = _get_core_rank(db, lemma_id)
         ulk.knowledge_state = "suspended"
         ulk.leech_suspended_at = datetime.now(timezone.utc)
         ulk.leech_count = (ulk.leech_count or 0) + 1
         ulk.acquisition_box = None
         ulk.acquisition_next_due = None
 
-        cooldown = _get_reintro_delay(ulk.leech_count - 1, lemma)
+        cooldown = _get_reintro_delay(ulk.leech_count - 1, lemma, core_rank=core_rank)
         log_interaction(
             event="leech_suspended",
             lemma_id=lemma_id,
@@ -251,7 +266,7 @@ def check_single_word_leech(db: Session, lemma_id: int) -> bool:
             recent_accuracy=round(acc, 3),
             leech_count=ulk.leech_count,
             reintro_days=cooldown.days,
-            low_priority=lemma is not None and is_low_priority_lemma(lemma),
+            low_priority=lemma is not None and is_low_priority_lemma(lemma, core_rank=core_rank),
         )
         return True
 

--- a/backend/tests/test_leech_service.py
+++ b/backend/tests/test_leech_service.py
@@ -391,6 +391,50 @@ def test_low_priority_leech_reintroduction_uses_longer_cooldown(db_session):
     assert lemma.lemma_id in reintroduced
 
 
+def test_get_reintro_delay_core_rank_overrides_sparse_frequency_rank():
+    """A frequent core word (good core_rank) is not throttled even when its
+    per-lemma frequency_rank is unset or sparse/huge."""
+    lemma = Lemma(
+        lemma_ar="دفاع", lemma_ar_bare="دفاع", gloss_en="defense",
+        source="book", frequency_rank=None,  # would be low-priority on its own
+    )
+    # No core_rank → low-priority → 4x cooldown
+    assert _get_reintro_delay(0, lemma) == REINTRO_DELAYS[0] * LOW_PRIORITY_LEECH_DELAY_MULTIPLIER
+    # In-main-lane core_rank → full priority → normal cooldown
+    assert _get_reintro_delay(0, lemma, core_rank=1705) == REINTRO_DELAYS[0]
+    # core_rank past the main lane → still low-priority
+    assert (
+        _get_reintro_delay(0, lemma, core_rank=9000)
+        == REINTRO_DELAYS[0] * LOW_PRIORITY_LEECH_DELAY_MULTIPLIER
+    )
+
+
+def test_frequent_core_leech_reintroduced_on_normal_cooldown(db_session):
+    """A leech that is frequent by core_rank but has a sparse frequency_rank is
+    reintroduced on the normal 3-day cooldown, not the 4x low-priority delay."""
+    from app.models import FrequencyCoreEntry
+
+    lemma = _create_lemma(db_session, arabic="دفاع", english="defense", frequency_rank=None)
+    db_session.add(FrequencyCoreEntry(
+        core_rank=1705, lemma_id=lemma.lemma_id, lemma_key="دفاع",
+        display_form="دفاع", score=1.0,
+    ))
+    now = datetime.now(timezone.utc)
+    # Suspended just past the NORMAL cooldown but well within the 4x low-priority one.
+    db_session.add(UserLemmaKnowledge(
+        lemma_id=lemma.lemma_id,
+        knowledge_state="suspended",
+        leech_suspended_at=now - (REINTRO_DELAYS[0] + timedelta(hours=1)),
+        leech_count=1,
+        times_seen=10,
+        times_correct=2,
+    ))
+    db_session.commit()
+
+    reintroduced = check_leech_reintroductions(db_session)
+    assert lemma.lemma_id in reintroduced
+
+
 def test_leech_count_incremented_on_suspension(db_session):
     """leech_count is incremented each time a word is leech-suspended."""
     lemma = _create_lemma(db_session)

--- a/docs/scheduling-system.md
+++ b/docs/scheduling-system.md
@@ -1816,7 +1816,7 @@ Cap = `0` if `high_stability_due < MIN_DUE_TARGETS`, else `clamp(high_stability_
 | Reintro delay (1st) | 3 days | First leech suspension |
 | Reintro delay (2nd) | 7 days | Second suspension |
 | Reintro delay (3rd+) | 14 days | Third and subsequent suspensions |
-| Low-priority leech delay multiplier | 4×, capped at 60 days | Obscure/unranked leeches stay suspended longer before automatic reintro |
+| Low-priority leech delay multiplier | 4×, capped at 60 days | Obscure/unranked leeches stay suspended longer before automatic reintro. "Low-priority" = `is_low_priority_lemma()`: a word is **exempt** (full-priority, normal cooldown) when its merged frequency-core `core_rank ≤ MAIN_LANE_MAX_RANK` (5000), regardless of the sparse per-lemma `frequency_rank` (2026-06-22 — previously keyed on `frequency_rank` alone, which throttled 55 genuinely-frequent leeches up to 8 weeks because that field is NULL for ~1/3 of lemmas) |
 | Reintro target | Acquisition box 1 | Stats preserved, fresh sentences |
 
 ### Topic (`topic_service.py`)

--- a/research/experiment-log.md
+++ b/research/experiment-log.md
@@ -46,6 +46,54 @@ Running lab notebook for Alif's learning algorithm. Each entry documents what ch
 
 ═══════════════════════ ENTRIES (newest first) ═══════════════════════
 
+## 2026-06-22 (fix): Leech low-priority cooldown now reads core_rank, not sparse frequency_rank
+
+**Why.** A 5-day health audit (sentence generation healthy — no locks, no stalls; cron
+completing every 3h; ~10–31 acquisitions/day; north-star graduations positive daily)
+turned up a real throttle bug while investigating the user's felt "gaps in frequent
+words." Of 107 suspended leeches, Step F reintroduction was healthy (0 overdue), but **92
+were flagged low-priority** and getting the 4× cooldown (12–56 days instead of 3–14).
+`is_low_priority_lemma()` decided this from `lemma.frequency_rank` — a sparse CAMeL-only
+field that is NULL for ~1/3 of lemmas (1287/3939) and, for book/quran/wiktionary imports,
+often holds a raw single-source rank in the tens/hundreds of thousands. Result: **55
+leeches that are genuinely frequent by the merged `frequency_core_entries.core_rank` (≤
+2000) — تَابَ (repent, 430), سَمَّى (name, 413), أَنْفَقَ (spend, 504), شَفَةٌ (lip,
+1397), دِفَاع (defense, 1705)… — were held out of rotation for up to 8 weeks.** The
+source-based exemption (`LOW_PRIORITY_EXEMPT_SOURCES = {duolingo, avp_a1,
+frequency_core}`) missed them because they entered via other paths and only later matched
+into the core.
+
+**What.** `is_low_priority_lemma(lemma, core_rank=None)` now returns False (full priority,
+normal cooldown) when `core_rank ≤ MAIN_LANE_MAX_RANK (5000)`, before the
+frequency_rank/source checks — mirroring the core_rank check `is_main_lane_word()` has had
+since the 2026-05-04 main-/slow-lane split. `leech_service.py` resolves core_rank via a
+new `_get_core_rank(db, lemma_id)` (FrequencyCoreEntry lookup) at its 3 suspension/reintro
+sites and threads it through `_get_reintro_delay(..., core_rank=)`. Pure relaxation: no
+word that was full-priority becomes low-priority; only the inverse. The per-leech lookup
+runs in the 3-hourly cron (Step F) and on single-review suspension, never in session build.
+
+**Design intent confirmed (Rule #14).** The 2026-05-04 "Prioritize frequent words" entry
+established that main-lane = `core/proxy rank ≤ 5000`. `is_main_lane_word` already
+consulted core_rank; the leech reintro path simply never got the same awareness — an
+inconsistency, not a deliberate choice. Fix aligns the two.
+
+**Expected effect.** The ~55 frequent leeches reintroduce on the 3/7/14-day schedule
+instead of 12/28/56. They re-enter acquisition box 1 sooner, get fresh sentences (Step F),
+and have a chance to escape leech status via the sliding window — directly serving the
+"frequent words I struggled with keep disappearing" complaint. Obscure tail leeches
+(core_rank > 5000 or no core entry) keep the 4× cap. Note these leeches were never a
+*coverage* gap (already attempted, parked by design) — distinct from the 522
+never-introduced rank-2001+ words (a consumption/intake-pace matter) and the rank-3000
+intake ceiling (`ALIF_FREQ_CORE_INTAKE_MAX_RANK`).
+
+**How to verify.** After deploy, the next Step F should reintroduce the now-due frequent
+leeches; `grep leech_reintroduced` in interactions, and re-run the leech audit — the
+low-priority count among core_rank≤2000 leeches should drop to ~0.
+
+**Tests.** `test_get_reintro_delay_core_rank_overrides_sparse_frequency_rank` (unit: NULL
+frequency_rank + good core_rank → normal delay; core_rank past lane → still 4×) +
+`test_frequent_core_leech_reintroduced_on_normal_cooldown` (e2e through the FCE lookup).
+
 ## 2026-06-21 (feature): Snap-to-read — photo → translation + add-to-Alif word chips
 
 **Why.** The user reads increasingly authentic/classical texts and was using Gemini


### PR DESCRIPTION
## Problem

A 5-day server health audit (sentence generation healthy — no DB locks, no stalls; cron completing every 3h; north-star graduations positive daily) surfaced a real throttle bug while investigating felt "gaps in frequent words."

Of **107 suspended leeches**, Step F reintroduction was healthy (0 overdue), but **92 were flagged low-priority** and getting the 4× cooldown (12–56 days instead of 3–14). `is_low_priority_lemma()` decided this from `lemma.frequency_rank` — a CAMeL-only field that is **NULL for ~1/3 of lemmas** (1287/3939) and, for book/quran/wiktionary imports, holds a raw single-source rank in the tens/hundreds of thousands.

Result: **55 leeches that are genuinely frequent by the merged `frequency_core_entries.core_rank` (≤ 2000)** — تَابَ (repent, 430), سَمَّى (name, 413), أَنْفَقَ (spend, 504), شَفَةٌ (lip, 1397), دِفَاع (defense, 1705)… — were held out of rotation for up to **8 weeks**. The source-based exemption (`{duolingo, avp_a1, frequency_core}`) missed them because they entered via other paths and only later matched into the core.

## Fix

`is_low_priority_lemma(lemma, core_rank=None)` now returns False (full priority, normal cooldown) when `core_rank ≤ MAIN_LANE_MAX_RANK (5000)`, before the frequency_rank/source checks — **mirroring the core_rank check `is_main_lane_word()` has had since the 2026-05-04 main-/slow-lane split.** `leech_service.py` resolves core_rank via a new `_get_core_rank()` at its 3 suspension/reintro sites and threads it through `_get_reintro_delay()`.

Pure relaxation — no word that was full-priority becomes low-priority; only the inverse. The per-leech lookup runs in the 3-hourly cron (Step F) and on single-review suspension, never in session build.

## Effect

The ~55 frequent leeches reintroduce on the 3/7/14-day schedule instead of 12/28/56, re-enter acquisition box 1, get fresh sentences, and get a chance to escape leech status. **Self-healing:** the next Step F after deploy reintroduces any frequent leech already past its normal cooldown. Obscure tail leeches (core_rank > 5000 or no core entry) keep the 4× cap.

These leeches were never a *coverage* gap — distinct from the 522 never-introduced rank-2001+ words (intake pace) and the rank-3000 intake ceiling.

## Design intent confirmed

The 2026-05-04 "Prioritize frequent words" change established main-lane = core rank ≤ 5000. `is_main_lane_word` already consulted core_rank; the leech reintro path simply never got the same awareness — an inconsistency, not a deliberate choice.