### PR TITLE
roots: list root-showcase sentences on the root detail page

### DIFF
--- a/backend/app/routers/roots.py
+++ b/backend/app/routers/roots.py
@@ -3,7 +3,8 @@ from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from app.database import get_db
-from app.models import Lemma, Root, UserLemmaKnowledge
+from app.models import Lemma, Root, Sentence, UserLemmaKnowledge
+from app.services.sentence_eligibility import reviewable_sentence_clauses
 
 router = APIRouter(prefix="/api/roots", tags=["roots"])
 
@@ -100,11 +101,35 @@ def get_root(root_id: int, db: Session = Depends(get_db)):
             "cefr_level": l.cefr_level,
         })
 
+    # Root-showcase sentences: LLM-generated to pack as many lemmas of THIS root
+    # into one sentence as possible. The sentence->root link lives on
+    # Sentence.root_focus_id (indexed). Gate with reviewable_sentence_clauses()
+    # so the page never shows a sentence the review engine would reject.
+    showcase_sentences = [
+        {
+            "id": s.id,
+            "arabic_text": s.arabic_text,
+            "english_translation": s.english_translation,
+            "root_word_count": sum(1 for w in s.words if w.is_target_word),
+        }
+        for s in (
+            db.query(Sentence)
+            .filter(
+                Sentence.root_focus_id == root_id,
+                Sentence.kind == "root_showcase",
+                reviewable_sentence_clauses(),
+            )
+            .order_by(Sentence.created_at.desc().nullslast())
+            .all()
+        )
+    ]
+
     return {
         "root_id": root.root_id,
         "root": root.root,
         "core_meaning_en": root.core_meaning_en,
         "enrichment": root.enrichment_json,
+        "showcase_sentences": showcase_sentences,
         "patterns": [
             {
                 "wazn": k if k != "_unclassified" else None,

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -106,7 +106,7 @@ Full endpoint list. See `backend/app/routers/` for implementation.
 | Method | Path | Description |
 |--------|------|-------------|
 | GET | `/api/roots` | List all roots with knowledge stats (total_words, known_words, coverage_pct, has_enrichment). Sorted by total_words desc. |
-| GET | `/api/roots/{root_id}` | Root detail with enrichment JSON + derivation tree grouped by wazn pattern. Each word includes knowledge_state, frequency_rank, transliteration. 404 if not found. |
+| GET | `/api/roots/{root_id}` | Root detail with enrichment JSON + derivation tree grouped by wazn pattern. Each word includes knowledge_state, frequency_rank, transliteration. Also returns `showcase_sentences`: reviewable `kind='root_showcase'` sentences focused on this root (via `Sentence.root_focus_id`), each with `arabic_text`, `english_translation`, and `root_word_count` (# of `is_target_word` words). 404 if not found. |
 
 ## Patterns
 | Method | Path | Description |

--- a/frontend/app/root/[id].tsx
+++ b/frontend/app/root/[id].tsx
@@ -150,6 +150,27 @@ export default function RootDetailScreen() {
         </View>
       )}
 
+      {root.showcase_sentences && root.showcase_sentences.length > 0 && (
+        <View style={styles.showcaseSection}>
+          <Text style={styles.showcaseLabel}>Root showcase sentences</Text>
+          {root.showcase_sentences.map((s) => (
+            <View key={s.id} style={styles.showcaseCard}>
+              <Text style={styles.showcaseArabic}>{s.arabic_text}</Text>
+              {s.english_translation && (
+                <Text style={styles.showcaseTranslation}>
+                  {ltr(s.english_translation)}
+                </Text>
+              )}
+              {s.root_word_count > 0 && (
+                <Text style={styles.showcaseCount}>
+                  {s.root_word_count} word{s.root_word_count !== 1 ? "s" : ""} from this root
+                </Text>
+              )}
+            </View>
+          ))}
+        </View>
+      )}
+
       {root.patterns.map((pattern, pi) => (
         <View key={pi} style={styles.patternGroup}>
           <Pressable
@@ -318,6 +339,44 @@ const styles = StyleSheet.create({
     fontSize: 13,
     color: colors.accent,
     fontWeight: "500",
+  },
+
+  showcaseSection: {
+    width: "100%",
+    maxWidth: 500,
+    marginTop: 16,
+  },
+  showcaseLabel: {
+    fontSize: 16,
+    color: colors.accent,
+    fontWeight: "700",
+    marginBottom: 6,
+  },
+  showcaseCard: {
+    backgroundColor: colors.surface,
+    borderRadius: 8,
+    padding: 12,
+    marginBottom: 6,
+  },
+  showcaseArabic: {
+    fontSize: 22,
+    color: colors.arabic,
+    fontFamily: fontFamily.arabic,
+    writingDirection: "rtl",
+    lineHeight: 38,
+    textAlign: "right",
+  },
+  showcaseTranslation: {
+    fontSize: 14,
+    color: colors.text,
+    lineHeight: 20,
+    marginTop: 6,
+    writingDirection: "ltr" as const,
+  },
+  showcaseCount: {
+    fontSize: 12,
+    color: colors.textSecondary,
+    marginTop: 6,
   },
 
   patternGroup: {

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -998,11 +998,19 @@ export interface RootDetailPattern {
   words: RootDetailWord[];
 }
 
+export interface RootShowcaseSentence {
+  id: number;
+  arabic_text: string;
+  english_translation: string | null;
+  root_word_count: number;
+}
+
 export interface RootDetail {
   root_id: number;
   root: string;
   core_meaning_en: string | null;
   enrichment: RootEnrichment | null;
+  showcase_sentences: RootShowcaseSentence[];
   patterns: RootDetailPattern[];
   total_words: number;
 }


### PR DESCRIPTION
## What

Root-showcase sentences (`kind='root_showcase'`) are LLM-generated to pack as many lemmas of a single Arabic root into one sentence as possible. They already carry an indexed `Sentence.root_focus_id` link back to their root, but nothing in the UI surfaced them.

This adds them to the root detail page:

- **Backend** (`GET /api/roots/{root_id}`): new `showcase_sentences` field — reviewable (`reviewable_sentence_clauses()`) showcase sentences for the root, each with `arabic_text`, `english_translation`, and `root_word_count` (count of `is_target_word` words = words belonging to this root).
- **Frontend** (`/root/[id]`): a "Root showcase sentences" section between the enrichment block and the wazn patterns. Renders only when the root has showcases.
- **Docs**: updated the endpoint row in `docs/api-reference.md`.

No schema change — the sentence→root index already existed. Prod currently has 47 showcase sentences across 8 roots.