### PR TITLE
Elapsed-interval graduation (Tier E) — credit long retention in acquisition

### DIFF
--- a/backend/app/services/acquisition_service.py
+++ b/backend/app/services/acquisition_service.py
@@ -11,12 +11,15 @@ Box 2→3 and 3→graduation enforce real inter-session spacing (sleep consolida
 
 Graduation is tiered (2026-03-03):
   - First correct review (times_seen was 0, rating >= 3) → instant graduation
+  - Elapsed-interval (Tier E): correct review after >= 3 days real gap → any box
   - Perfect accuracy (100%) + 3+ reviews → graduate from any box
   - High accuracy (≥80%) + 4+ reviews + box ≥ 2 → graduate
   - Standard: box >= 3 + times_seen >= 5 + accuracy >= 60% + 2 calendar days
 
 2026-02-14: Added due-date gating for box 2+ and calendar-day graduation check.
 2026-03-03: Added tiered graduation — first-correct instant grad + relaxed criteria.
+2026-07-08: Added Tier E (elapsed-interval) — a long real retention interval is
+            direct proof of consolidation the fixed Leitner intervals discarded.
 """
 
 import logging
@@ -48,6 +51,13 @@ FAST_GRAD_INTRO_GAP = timedelta(minutes=10)
 # Correct reviews inside the intro-card gap count for exposure/accuracy, but
 # should stay in Box 1 and come back soon instead of proving consolidation.
 FAST_INTRO_RETRY_INTERVAL = timedelta(minutes=30)
+# Tier E (elapsed-interval) graduation: a correct review after at least this much
+# real elapsed time since the previous review demonstrates durable retention that
+# already exceeds a fresh graduate's initial FSRS stability (S₀(Good) ≈ 2.3d) and
+# the deepest Leitner rung (Box 3 = 3d). The fixed box intervals otherwise discard
+# this signal; FSRS's whole premise is that surviving a long interval is high-value
+# evidence, so a word recognized after this long graduates straight to FSRS.
+ELAPSED_GRADUATION_MIN_INTERVAL = timedelta(days=3)
 
 
 def _intro_shown_recently(ulk: UserLemmaKnowledge, now: datetime) -> bool:
@@ -403,6 +413,7 @@ def submit_acquisition_review(
     old_times_seen = ulk.times_seen or 0
     old_times_correct = ulk.times_correct or 0
     old_knowledge_state = ulk.knowledge_state
+    old_last_reviewed = ulk.last_reviewed  # captured before the update below (Tier E elapsed)
     recent_intro = _intro_shown_recently(ulk, now)
 
     # Update review counts
@@ -425,10 +436,11 @@ def submit_acquisition_review(
     # correct rating seconds after seeing the card is working memory, not
     # learning, and bypassing acquisition robs the encoding phase.
     graduated = False
+    grad_reason: Optional[str] = None
     if old_times_seen == 0 and rating_int >= 3:
         if not recent_intro:
-            _graduate(ulk, now, db=db)
             graduated = True
+            grad_reason = "first_correct"
 
     # Box advancement logic
     # Box 1→2: allowed for encoding unless this is intro-card working memory
@@ -499,23 +511,45 @@ def submit_acquisition_review(
         new_times_correct = ulk.times_correct
         accuracy = new_times_correct / new_times_seen if new_times_seen > 0 else 0
 
+        # Elapsed since the previous review — the retention interval just proven.
+        elapsed_since_last = None
+        if old_last_reviewed is not None:
+            olr = old_last_reviewed
+            if olr.tzinfo is None:
+                olr = olr.replace(tzinfo=timezone.utc)
+            elapsed_since_last = now - olr
+
+        # Tier E: Elapsed-interval graduation. A correct recognition after a long
+        # real gap proves consolidation more strongly than the Leitner ramp itself,
+        # so graduate from any box. Requires rating >= 3 (a *failed* review after a
+        # long gap means it was forgotten — no graduation), unlike tiers 1-3 which
+        # ignore the current rating. The intro working-memory gate is definitionally
+        # satisfied by a multi-day gap; not_recent_intro kept for symmetry.
+        if (not recent_intro and rating_int >= 3
+                and elapsed_since_last is not None
+                and elapsed_since_last >= ELAPSED_GRADUATION_MIN_INTERVAL):
+            graduated = True
+            grad_reason = "elapsed_interval"
         # Tier 1: Perfect accuracy, 3+ reviews → graduate from any box.
         # The intro-card gap blocks this too; otherwise three immediate
         # same-session correct answers could still graduate on working memory.
-        if not recent_intro and accuracy >= 1.0 and new_times_seen >= 3:
+        elif not recent_intro and accuracy >= 1.0 and new_times_seen >= 3:
             graduated = True
+            grad_reason = "perfect_accuracy"
         # Tier 2: High accuracy (≥80%), 4+ reviews → graduate from box ≥ 2
         elif not recent_intro and accuracy >= 0.80 and new_times_seen >= 4 and ulk.acquisition_box >= 2:
             graduated = True
+            grad_reason = "high_accuracy"
         # Tier 3: Standard (existing criteria) — requires due for spacing
         elif is_due and (ulk.acquisition_box >= 3
               and new_times_seen >= GRADUATION_MIN_REVIEWS
               and accuracy >= GRADUATION_MIN_ACCURACY
               and _reviews_span_calendar_days(db, ulk.lemma_id, GRADUATION_MIN_CALENDAR_DAYS)):
             graduated = True
+            grad_reason = "standard"
 
     if graduated:
-        _graduate(ulk, now, db=db)
+        _graduate(ulk, now, db=db, reason=grad_reason)
 
     # Log review
     log_entry = ReviewLog(
@@ -535,6 +569,7 @@ def submit_acquisition_review(
             "acquisition_box_before": old_box,
             "acquisition_box_after": ulk.acquisition_box,
             "graduated": graduated,
+            "graduation_reason": grad_reason,
             "pre_times_seen": old_times_seen,
             "pre_times_correct": old_times_correct,
             "pre_knowledge_state": old_knowledge_state,
@@ -580,7 +615,12 @@ def _count_known_root_siblings(db: Session, lemma_id: int) -> int:
     )
 
 
-def _graduate(ulk: UserLemmaKnowledge, now: datetime, db: Session | None = None) -> None:
+def _graduate(
+    ulk: UserLemmaKnowledge,
+    now: datetime,
+    db: Session | None = None,
+    reason: Optional[str] = None,
+) -> None:
     """Graduate a word from acquisition to FSRS."""
     from fsrs import Scheduler, Card, Rating
 
@@ -608,6 +648,7 @@ def _graduate(ulk: UserLemmaKnowledge, now: datetime, db: Session | None = None)
         times_seen=ulk.times_seen,
         times_correct=ulk.times_correct,
         root_boost=root_boost,
+        graduation_reason=reason,
     )
 
 

--- a/backend/tests/test_acquisition.py
+++ b/backend/tests/test_acquisition.py
@@ -4,6 +4,7 @@ from app.models import Lemma, ReviewLog, Root, Sentence, SentenceReviewLog, User
 from app.services.acquisition_service import (
     BOX_INTERVALS,
     DAILY_INTRO_CAP,
+    ELAPSED_GRADUATION_MIN_INTERVAL,
     FAST_GRAD_INTRO_GAP,
     FAST_INTRO_RETRY_INTERVAL,
     GRADUATION_MIN_ACCURACY,
@@ -278,6 +279,74 @@ def test_tier2_blocked_by_low_accuracy(db_session):
     result = submit_acquisition_review(db_session, lemma.lemma_id, rating_int=3)
     assert result["new_state"] == "acquiring"
     assert result.get("graduated") is not True
+
+
+# --- submit_acquisition_review: Tier E (elapsed-interval graduation) ---
+
+
+def _seen_box1_word(db, days_since_last_review, box=1, times_seen=1, times_correct=1):
+    """An acquiring word already seen once, last reviewed `days_since_last_review`
+    days ago and overdue — the state of an acquiring word picked up after a break.
+    Tier 0 can't fire (times_seen > 0) and no intro card is recent."""
+    lemma = _create_lemma(db)
+    start_acquisition(db, lemma.lemma_id)
+    ulk = db.query(UserLemmaKnowledge).filter_by(lemma_id=lemma.lemma_id).first()
+    now = datetime.now(timezone.utc)
+    ulk.acquisition_box = box
+    ulk.times_seen = times_seen
+    ulk.times_correct = times_correct
+    ulk.last_reviewed = now - timedelta(days=days_since_last_review)
+    ulk.acquisition_next_due = (
+        now - timedelta(days=days_since_last_review) + BOX_INTERVALS[box]
+    )
+    db.flush()
+    return lemma
+
+
+def test_tier_e_long_gap_correct_graduates(db_session):
+    """A Box-1 word recognized correctly after a gap ≥ the elapsed threshold graduates
+    straight to FSRS — the long retention interval is the proof, box notwithstanding."""
+    lemma = _seen_box1_word(db_session, days_since_last_review=14)
+    result = submit_acquisition_review(db_session, lemma.lemma_id, rating_int=3)
+    assert result["graduated"] is True
+    assert result["new_state"] == "learning"
+    # Reason recorded for per-tier lapse analysis in production telemetry.
+    log = (
+        db_session.query(ReviewLog)
+        .filter_by(lemma_id=lemma.lemma_id)
+        .order_by(ReviewLog.reviewed_at.desc())
+        .first()
+    )
+    assert log.fsrs_log_json["graduation_reason"] == "elapsed_interval"
+
+
+def test_tier_e_short_gap_does_not_graduate(db_session):
+    """Below the elapsed threshold, a correct review just advances the box (no Tier E)."""
+    lemma = _seen_box1_word(db_session, days_since_last_review=1)
+    result = submit_acquisition_review(db_session, lemma.lemma_id, rating_int=3)
+    assert result.get("graduated") is not True
+    assert result["new_state"] == "acquiring"
+    assert result["acquisition_box"] == 2  # normal box 1→2 advancement
+
+
+def test_tier_e_failed_review_after_long_gap_does_not_graduate(db_session):
+    """A *failed* recognition after a long gap means the word was forgotten. Tier E
+    requires rating ≥ 3, so the word resets to Box 1 instead of graduating."""
+    lemma = _seen_box1_word(db_session, days_since_last_review=14)
+    result = submit_acquisition_review(db_session, lemma.lemma_id, rating_int=1)
+    assert result.get("graduated") is not True
+    assert result["new_state"] == "acquiring"
+    assert result["acquisition_box"] == 1  # Again resets to box 1
+
+
+def test_tier_e_fires_from_box_2(db_session):
+    """Tier E is box-agnostic: a long-gap correct review graduates a Box-2 word too."""
+    lemma = _seen_box1_word(
+        db_session, days_since_last_review=ELAPSED_GRADUATION_MIN_INTERVAL.days + 5, box=2
+    )
+    result = submit_acquisition_review(db_session, lemma.lemma_id, rating_int=3)
+    assert result["graduated"] is True
+    assert result["new_state"] == "learning"
 
 
 # --- submit_acquisition_review: box advancement ---

--- a/docs/scheduling-system.md
+++ b/docs/scheduling-system.md
@@ -379,6 +379,7 @@ GRADUATION_MIN_ACCURACY = 0.60
 GRADUATION_MIN_CALENDAR_DAYS = 2
 FAST_GRAD_INTRO_GAP = 10m
 FAST_INTRO_RETRY_INTERVAL = 30m
+ELAPSED_GRADUATION_MIN_INTERVAL = 3d   # Tier E: correct review after this real gap → graduate
 ```
 
 ### Graduation Criteria (Tiered — 2026-03-03)
@@ -388,6 +389,8 @@ Graduation uses a tiered system. Tier 0/1/2 can fire on **any review** (includin
 **Why collateral reviews count for graduation (tiers 0-2)**: Previously all tiers required `is_due`, but a correct review reschedules the word +3 days. Words appearing as collateral in multiple sentences would get 80%+ accuracy across many exposures but only one "due" review per 3-day cycle — trapping high-accuracy words in acquisition indefinitely. Since tier 1/2 already require high accuracy (80-100%), the spacing proof is redundant.
 
 **Tier 0 — First-correct instant graduation**: If a word's very first review is correct (rating ≥ 3, `times_seen` was 0), it graduates immediately. Data shows 0% lapse rate for fast graduates. FSRS safety net catches false positives.
+
+**Tier E — Elapsed-interval graduation (2026-07-08)**: If a correct review (rating ≥ 3, not inside the intro working-memory window) lands after at least `ELAPSED_GRADUATION_MIN_INTERVAL` (= 3 days) of real elapsed time since the *previous* review, the word graduates from **any box**. Rationale: surviving a long interval is exactly the consolidation proof the Leitner ramp exists to establish — 3 days already exceeds Box 3's interval and a fresh graduate's initial FSRS stability (S₀(Good) ≈ 2.3 d). The fixed box intervals otherwise discard this signal, so a word recognized 14 days overdue used to merely advance one box (the inverse of how the FSRS phase rewards long successful intervals). Unlike Tiers 1–3, Tier E is **rating-gated**: a *failed* review after a long gap means the word was forgotten, so it resets to Box 1 rather than graduating. Elapsed is measured as `now − last_reviewed` (the retention interval just demonstrated), captured before the review updates `last_reviewed`. This is the primary reason words graduate cleanly when a learner returns from a break with a pile of overdue acquiring words.
 
 **Intro working-memory gate** (expanded 2026-05-17): if the intro card was shown within `FAST_GRAD_INTRO_GAP = 10 minutes`, a correct review is counted as a real exposure but must not prove consolidation. During that window, Tier 0 is skipped, Box 1 stays Box 1, Tier 1/2 graduation is blocked, and the word is scheduled with `FAST_INTRO_RETRY_INTERVAL = 30 minutes`. Production data on 2026-05-17 showed most current Box 2 words had their first correct review within two minutes of the intro card; those were working-memory recognitions, not durable next-day readiness. Words with no intro card shown (e.g. encountered → auto-introduced via collateral) bypass the gate and can still fast-grad.
 
@@ -1787,6 +1790,7 @@ Cap = `0` if `high_stability_due < MIN_DUE_TARGETS`, else `clamp(high_stability_
 | `GRADUATION_MIN_REVIEWS` | 5 | Min reviews before graduation (tier 3 standard) |
 | `GRADUATION_MIN_ACCURACY` | 0.60 | Min accuracy for graduation (tier 3 standard) |
 | `GRADUATION_MIN_CALENDAR_DAYS` | 2 | Reviews must span this many UTC calendar days (tier 3 only) |
+| `ELAPSED_GRADUATION_MIN_INTERVAL` | 3 days | Tier E: a correct review (rating ≥ 3) after this much real elapsed time since the last review graduates from any box — long-interval retention is direct consolidation proof (2026-07-08) |
 | `ROOT_SIBLING_THRESHOLD` | 2 | Known root siblings needed for Easy graduation boost |
 | Tier 0: first-correct | times_seen=0 + rating≥3 | Instant graduation on first correct review (any review) |
 | Tier 1: perfect | accuracy=100% + seen≥3 | Graduate from any box (any review, no due-gating) |

--- a/research/experiment-log.md
+++ b/research/experiment-log.md
@@ -46,6 +46,42 @@ Running lab notebook for Alif's learning algorithm. Each entry documents what ch
 
 ═══════════════════════ ENTRIES (newest first) ═══════════════════════
 
+## 2026-07-08 (change): Elapsed-interval graduation — Leitner phase now credits long retention
+
+**Why.** User (returning from a ~2-week break with 195 acquiring words due, most overdue)
+asked: "if I recognize a Box-1 word that is 14 days overdue, should it graduate straight to
+FSRS?" Tracing `submit_acquisition_review()` confirmed it does **not** — it advances one box
+(1→2) and reschedules +1 day, identical to a correct answer 4 hours late. The Leitner phase
+is **time-blind**: `is_due` (elapsed) is computed only as an *advancement gate*, never as
+*evidence* of retention. This is the inverse of the FSRS phase, which rewards a long
+successful interval with a large stability jump. There is also an internal inconsistency:
+Tier 0 instant-graduates a word on its *first-ever* correct recognition (no intro card,
+cited 0% lapse), yet a *second* correct recognition 14 days later — strictly stronger
+evidence — was denied graduation purely by the `times_seen == 0` guard. Backwards.
+
+**Prior-art check (Rule #14).** The only related entry (`2026-05-04` textbook-scan / "don't
+skip the Leitner ramp", and the origin `2026-02-14` due-date gating) argues freshly-*read*
+words with **zero retention proof** shouldn't skip the ramp. This change is the opposite
+evidence state — words with **demonstrated long-interval retention** — so it's consistent
+with, not a re-proposal of, that guardrail.
+
+**Change.** New box-agnostic **Tier E** in `acquisition_service.py`: a correct review
+(`rating ≥ 3`, `not recent_intro`) after `now - last_reviewed ≥ ELAPSED_GRADUATION_MIN_INTERVAL`
+(= 3 days, = Box 3's interval and > S₀(Good)≈2.3d) graduates to FSRS. The working-memory
+gate is definitionally satisfied by a multi-day gap; the `not recent_intro` guard is kept
+for symmetry. A *failed* review after a long gap still does NOT graduate (you forgot it) —
+that's the `rating ≥ 3` guard, distinguishing Tier E from tiers 1–3 which fire regardless
+of rating. Threshold is a named constant, tuned via `simulate_sessions.py` (must not raise
+lapse rate — the whole point of the two-phase guard). Telemetry: `graduation_reason` added
+to the acquisition `ReviewLog.fsrs_log_json` and to the `word_graduated` interaction event
+so per-tier lapse rate is measurable in production. **v2 (not shipped):** seed the graduated
+FSRS card's stability from the real elapsed interval (py-fsrs fixes first-review S₀ from a
+table, so this needs a seeded prior state) — deferred.
+
+**Incidental fix.** Tier 0 called `_graduate()` at its own site *and* again at the shared
+`if graduated:` site → double FSRS-card creation + double `word_graduated` log. Restructured
+so all tiers set `graduated`/`grad_reason` and `_graduate()` is called exactly once.
+
 ## 2026-06-22 (fix): Leech low-priority cooldown now reads core_rank, not sparse frequency_rank
 
 **Why.** A 5-day health audit (sentence generation healthy — no locks, no stalls; cron


### PR DESCRIPTION
## Problem

The Leitner acquisition phase is **time-blind**. Recognizing a Box-1 word 14 days overdue merely advanced it one box (1→2, +1 day) — identical to a correct answer 4 hours late. `is_due` (elapsed) was computed only as an *advancement gate*, never as *evidence* of retention. This is the inverse of the FSRS phase, which rewards a long successful interval with a large stability jump.

There was also an internal inconsistency: Tier 0 instant-graduates a word on its *first-ever* correct recall (no intro card, 0% lapse in prod), yet a *second* correct recall 14 days later — strictly stronger evidence — was denied graduation purely by the `times_seen == 0` guard.

Surfaced by the user returning from a ~2-week break with 195 acquiring words due, most overdue.

## Change

New box-agnostic **Tier E**: a correct review (`rating >= 3`, not inside the intro working-memory window) after `now - last_reviewed >= ELAPSED_GRADUATION_MIN_INTERVAL` (= 3 days, = Box 3's interval and > S0(Good) ≈ 2.3d) graduates straight to FSRS. Rating-gated, unlike tiers 1–3: a *failed* recall after a long gap means it was forgotten, so it resets to Box 1.

Adds `graduation_reason` to the acquisition `ReviewLog.fsrs_log_json` and the `word_graduated` event so per-tier lapse rate is measurable in production.

**Incidental fix:** the Tier 0 path called `_graduate()` at its own site *and* again at the shared `if graduated:` site → double FSRS-card creation + double `word_graduated` log. All tiers now set `graduated`/`grad_reason` and `_graduate()` runs exactly once.

## Safety

Bounded and self-healing: a false-positive Tier E graduate re-tests in ~2.3 days via FSRS and lapses back. Strictly more conservative than Tier 0, which has shipped safely. Reversible via one constant. Full fast suite (1369) green; 4 new Tier E tests cover graduate / below-threshold / failed-after-gap / box-2.

See experiment-log 2026-07-08 and docs/scheduling-system.md §5.