### PR TITLE
Stabilize snap page translation and learning targets

### DIFF
--- a/backend/app/routers/discover.py
+++ b/backend/app/routers/discover.py
@@ -2,7 +2,7 @@
 
 Endpoints:
   POST /api/discover/words  — given a block of Arabic text, return the highest-value
-       lemmas that are NOT yet in Alif's pool, glossed. Two consumers:
+       lemmas that are NOT yet in the learner's active curriculum, glossed. Two consumers:
          • Dragoman: "what should I learn next" — MSA, ranked common-first (default).
          • Bookifier: a glossary attached to a *specific* (often dialectal/vulgar)
            text — `selection="distinctive"` ranks the load-bearing vocabulary of
@@ -28,7 +28,7 @@ from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy.orm import Session
 
 from app.database import SessionLocal, get_db
-from app.models import Lemma
+from app.models import Lemma, UserLemmaKnowledge
 from app.services.interaction_logger import log_interaction
 from app.services.lemma_quality import (
     _load_rank_map,
@@ -81,6 +81,12 @@ _FB_ENCLITICS = (("هما", 2), ("كما", 2), ("هم", 2), ("هن", 2), ("كم"
 # Rank assigned to words absent from the MSA frequency list (treated as maximally
 # rare for distinctive ranking — they carry the most lift).
 _OOV_RANK = 100_000
+# These states mean a word is already in the learner's active curriculum.  A lemma
+# merely existing in the corpus database does not mean the learner knows it: corpus
+# import creates many Lemma rows without UserLemmaKnowledge rows.
+_ALREADY_LEARNING_STATES = {
+    "new", "acquiring", "learning", "known", "lapsed", "suspended"
+}
 
 _GLOSS_SCHEMA = {
     "type": "object",
@@ -249,7 +255,7 @@ class DiscoverIn(BaseModel):
 
 @router.post("/words")
 def discover_words(req: DiscoverIn, db: Session = Depends(get_db)):
-    """High-value Arabic lemmas in `text` not yet in Alif, glossed."""
+    """High-value Arabic lemmas in `text` not yet being learned, glossed."""
     words = discover_words_in_text(
         db, req.text, count=req.count, selection=req.selection, include_oov=req.include_oov
     )
@@ -263,10 +269,23 @@ def discover_words_in_text(
     selection: str = "common_first",
     include_oov: bool = False,
 ) -> list[dict]:
-    """Core word-discovery: the highest-value lemmas in `text` not yet in Alif,
+    """Core word-discovery: the highest-value lemmas in `text` not yet being learned,
     glossed. Shared by the /words endpoint and the photo /snap endpoint so both go
     through one tokenize → classify → rank → gloss path."""
     lemma_lookup = build_comprehensive_lemma_lookup(db)
+    already_learning_ids = {
+        lemma_id
+        for (lemma_id,) in db.query(UserLemmaKnowledge.lemma_id)
+        .filter(UserLemmaKnowledge.knowledge_state.in_(_ALREADY_LEARNING_STATES))
+        .all()
+    }
+    lemma_cache: dict[int, Lemma | None] = {}
+
+    def get_lemma(lemma_id: int) -> Lemma | None:
+        if lemma_id not in lemma_cache:
+            lemma_cache[lemma_id] = db.get(Lemma, lemma_id)
+        return lemma_cache[lemma_id]
+
     ranks = _load_rank_map()
     # key bare -> {surfaces: {form: count}, lemma_ar, pos, root, count, source}
     cand: dict[str, dict] = {}
@@ -276,18 +295,34 @@ def discover_words_in_text(
         bare = _normalize(tok)
         if len(bare) < 2 or _is_function_word(bare) or _is_function_word(bare.replace("ى", "ي")):
             continue
-        # Already in Alif's vocabulary? The hardened lookup resolves clitics and
-        # variants → canonical, so this catches forms a surface match would miss.
-        if lookup_lemma(bare, lemma_lookup, original_bare=strip_diacritics(tok)) is not None:
+        # Resolve against the corpus, but only suppress words the learner has actually
+        # introduced.  Previously every corpus Lemma was treated as "known", which
+        # left ordinary book pages with zero or one suggestion.
+        existing_id = lookup_lemma(
+            bare, lemma_lookup, original_bare=strip_diacritics(tok)
+        )
+        if existing_id in already_learning_ids:
             continue
-        c = _classify(tok, bare, camel_cache, include_oov)
+        existing = get_lemma(existing_id) if existing_id is not None else None
+        if existing is not None:
+            existing_bare = _normalize(existing.lemma_ar_bare)
+            c = (
+                existing_bare,
+                existing.lemma_ar or existing.lemma_ar_bare,
+                existing.pos,
+                existing.root.root if existing.root else None,
+                "database",
+            )
+        else:
+            c = _classify(tok, bare, camel_cache, include_oov)
         if c is None:
             continue
         key, lemma_ar, pos, root, source = c
         if not key or _is_function_word(key):
             continue
-        # The citation/fallback form itself may already be known.
-        if key != bare and lookup_lemma(key, lemma_lookup) is not None:
+        # The citation/fallback form itself may already be in active learning.
+        key_id = lookup_lemma(key, lemma_lookup) if key != bare else existing_id
+        if key_id in already_learning_ids:
             continue
         entry = cand.get(key)
         if entry:
@@ -300,6 +335,12 @@ def discover_words_in_text(
             cand[key] = {
                 "surfaces": {tok: 1}, "lemma_ar": lemma_ar, "pos": pos,
                 "root": root, "count": 1, "source": source,
+                "gloss_en": existing.gloss_en if existing is not None else None,
+                "transliteration": (
+                    existing.transliteration_ala_lc if existing is not None else None
+                ),
+                "register": existing.register if existing is not None else None,
+                "dialect": existing.dialect if existing is not None else None,
             }
 
     if not cand:
@@ -322,13 +363,30 @@ def discover_words_in_text(
     find_example = _example_finder(text or "")
     examples = {b: find_example(set(v["surfaces"])) for b, v in ordered}
 
-    glosses = _gloss(
-        [
-            {"index": i, "lemma_ar": v["lemma_ar"], "bare": b, "pos": v["pos"],
-             "example": examples.get(b)}
-            for i, (b, v) in enumerate(ordered)
-        ]
-    )
+    # Corpus lemmas already have reviewed lexical metadata, so use it directly.
+    # Only genuinely new/OOV forms need the second model call.  Besides lowering
+    # latency, this means the common photographed-page path is not made fragile by
+    # an unrelated text-model/CLI failure after OCR has already succeeded.
+    glosses = {
+        i: {
+            "gloss_en": v.get("gloss_en"),
+            "pos": v.get("pos"),
+            "transliteration": v.get("transliteration"),
+            "is_proper_noun": (v.get("pos") or "").lower() in _PROPER_NOUN_POS,
+            "register": v.get("register"),
+            "dialect": v.get("dialect"),
+        }
+        for i, (_, v) in enumerate(ordered)
+        if v["source"] == "database" and v.get("gloss_en")
+    }
+    needs_gloss = [
+        {"index": i, "lemma_ar": v["lemma_ar"], "bare": b, "pos": v["pos"],
+         "example": examples.get(b)}
+        for i, (b, v) in enumerate(ordered)
+        if i not in glosses
+    ]
+    if needs_gloss:
+        glosses.update(_gloss(needs_gloss))
 
     words = []
     for i, (b, v) in enumerate(ordered):
@@ -348,7 +406,10 @@ def discover_words_in_text(
         # /add does. The pre-gloss checks ran on the surface/key; a gloss correction
         # can land on a form that's already in the vocabulary, so re-check here —
         # otherwise we'd offer a word that /add immediately reports "already known".
-        if lookup_lemma(lemma_bare, lemma_lookup, original_bare=lemma_bare) is not None:
+        corrected_id = lookup_lemma(
+            lemma_bare, lemma_lookup, original_bare=lemma_bare
+        )
+        if corrected_id in already_learning_ids:
             continue
         surfaces = sorted(v["surfaces"], key=lambda s: -v["surfaces"][s])
         words.append(

--- a/backend/app/services/ocr_service.py
+++ b/backend/app/services/ocr_service.py
@@ -148,6 +148,7 @@ def _call_gemini_vision(
     prompt: str,
     system_prompt: str = "",
     model_override: str | None = None,
+    timeout_seconds: int = 300,
 ) -> dict:
     """Call Gemini Vision API with an image and prompt.
 
@@ -185,7 +186,7 @@ def _call_gemini_vision(
             model=model,
             messages=messages,
             temperature=0.1,
-            timeout=300,
+            timeout=timeout_seconds,
             api_key=api_key,
             response_format={"type": "json_object"},
         )
@@ -274,9 +275,7 @@ def extract_text_and_translation(image_bytes: bytes) -> dict:
 
     Returns {"arabic_text": str, "translation_en": str}.
     """
-    result = _call_gemini_vision(
-        image_bytes,
-        prompt=(
+    prompt = (
             "This image is a page of Arabic text that a reader is studying.\n"
             "1. Extract ALL the Arabic text exactly as written: preserve any diacritics "
             "that are present, preserve paragraph breaks as newlines, do NOT add "
@@ -285,18 +284,58 @@ def extract_text_and_translation(image_bytes: bytes) -> dict:
             "2. Provide a faithful, fluent English translation of that text — accurate "
             "to the meaning and natural in English (not a word-for-word gloss).\n"
             'Respond with JSON: {"arabic_text": "the Arabic", "translation_en": "the English"}'
-        ),
-        system_prompt=(
+        )
+    system_prompt = (
             "You are an expert Arabic reader and translator. Extract the Arabic text "
             "accurately and translate it faithfully. Respond with JSON only."
-        ),
-    )
+        )
+
+    # Interactive snaps used to inherit the general OCR call's five-minute timeout
+    # while the app abandoned the request after one minute. Bound each attempt and
+    # retry once: transient provider/JSON failures are common enough that a single
+    # attempt made the feature feel random, but the total still stays within the
+    # client's request window.
+    first_error: Exception | None = None
+    try:
+        result = _call_gemini_vision(
+            image_bytes, prompt=prompt, system_prompt=system_prompt,
+            timeout_seconds=90,
+        )
+    except Exception as e:
+        first_error = e
+        result = {}
+
+    if not isinstance(result, dict) or not (result.get("arabic_text") or "").strip():
+        if first_error:
+            logger.warning("snap vision attempt failed; retrying once: %s", first_error)
+        else:
+            logger.warning("snap vision returned no Arabic; retrying once")
+        result = _call_gemini_vision(
+            image_bytes, prompt=prompt, system_prompt=system_prompt,
+            timeout_seconds=90,
+        )
+
     if not isinstance(result, dict):
         return {"arabic_text": "", "translation_en": ""}
-    return {
-        "arabic_text": result.get("arabic_text") or "",
-        "translation_en": result.get("translation_en") or "",
-    }
+    arabic_text = result.get("arabic_text") or ""
+    translation = result.get("translation_en") or ""
+
+    # A valid OCR result with a missing translation is salvageable without asking
+    # the user to photograph the page again.
+    if arabic_text.strip() and not translation.strip():
+        try:
+            translated = _call_llm_text(
+                "Translate this Arabic text faithfully and fluently into English. "
+                "Return JSON only.\n\n"
+                f"Arabic:\n{arabic_text}\n\n"
+                'Schema: {"translation_en": "the English translation"}',
+                system_prompt="You are an expert Arabic-English translator.",
+            )
+            translation = translated.get("translation_en") or ""
+        except Exception as e:
+            logger.warning("snap translation fallback failed: %s", e)
+
+    return {"arabic_text": arabic_text, "translation_en": translation}
 
 
 def _step1_extract_words(image_bytes: bytes) -> list[str]:

--- a/backend/tests/test_discover.py
+++ b/backend/tests/test_discover.py
@@ -159,6 +159,31 @@ def test_words_excludes_known_via_hardened_lookup(client, seeded, monkeypatch):
     assert "دستور" in bares
 
 
+def test_words_includes_corpus_lemma_not_yet_in_learning(client, db_session, monkeypatch):
+    """A corpus row is lexical metadata, not proof that the learner knows the word.
+
+    This is the photographed-book regression: the database contains most ordinary
+    page vocabulary, while only UserLemmaKnowledge says what is already learning.
+    """
+    lem = Lemma(
+        lemma_ar="دُسْتُور", lemma_ar_bare="دستور", gloss_en="constitution",
+        pos="noun", source="corpus",
+    )
+    db_session.add(lem)
+    db_session.commit()
+
+    def fail_if_called(_items):
+        raise AssertionError("a corpus lemma with a gloss should not require the gloss LLM")
+
+    monkeypatch.setattr(discover, "_gloss", fail_if_called)
+    r = client.post("/api/discover/words", json={"text": "الدستور", "count": 8})
+
+    assert r.status_code == 200
+    word = next(w for w in r.json()["words"] if w["lemma_ar_bare"] == "دستور")
+    assert word["gloss_en"] == "constitution"
+    assert word["lemma_source"] == "database"
+
+
 def test_words_drops_proper_nouns(client, db_session, monkeypatch):
     _no_llm_gloss(monkeypatch, {"دستور": ("constitution", "noun", True)})
     r = client.post("/api/discover/words", json={"text": "الدستور مهم", "count": 8})

--- a/backend/tests/test_ocr.py
+++ b/backend/tests/test_ocr.py
@@ -80,6 +80,41 @@ class TestOCRService:
         assert "القِرَاءَةَ" in result
         mock_vision.assert_called_once()
 
+    @patch("app.services.ocr_service._call_gemini_vision")
+    def test_snap_ocr_retries_transient_vision_failure(self, mock_vision):
+        from app.services.ocr_service import extract_text_and_translation
+
+        mock_vision.side_effect = [
+            TimeoutError("provider timeout"),
+            {"arabic_text": "هذا كتاب", "translation_en": "This is a book."},
+        ]
+
+        result = extract_text_and_translation(b"fake_image_data")
+
+        assert result["translation_en"] == "This is a book."
+        assert mock_vision.call_count == 2
+        assert all(
+            call.kwargs["timeout_seconds"] == 90
+            for call in mock_vision.call_args_list
+        )
+
+    @patch("app.services.ocr_service._call_llm_text")
+    @patch("app.services.ocr_service._call_gemini_vision")
+    def test_snap_ocr_salvages_missing_translation(self, mock_vision, mock_text):
+        from app.services.ocr_service import extract_text_and_translation
+
+        mock_vision.return_value = {"arabic_text": "هذا كتاب", "translation_en": ""}
+        mock_text.return_value = {"translation_en": "This is a book."}
+
+        result = extract_text_and_translation(b"fake_image_data")
+
+        assert result == {
+            "arabic_text": "هذا كتاب",
+            "translation_en": "This is a book.",
+        }
+        mock_vision.assert_called_once()
+        mock_text.assert_called_once()
+
     @patch("app.services.ocr_service._step3_translate")
     @patch("app.services.ocr_service._step2_morphology")
     @patch("app.services.ocr_service._step1_extract_words")

--- a/frontend/app/snap.tsx
+++ b/frontend/app/snap.tsx
@@ -19,7 +19,7 @@ type AddState = "idle" | "adding" | "added" | "known" | "error";
 
 // Snap-to-read: photograph an authentic Arabic page → faithful English translation
 // + the top unknown words as add-to-Alif chips. One synchronous backend round trip
-// (Gemini OCR/translation + Haiku gloss), so the reader gets help in the moment
+// (OCR/translation plus lexical lookup), so the reader gets help in the moment
 // rather than batch-importing a book after the fact.
 export default function SnapScreen() {
   const [busy, setBusy] = useState(false);

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1054,8 +1054,8 @@ export async function extractTextFromImage(imageUri: string): Promise<string> {
 // --- Snap-to-read ---
 
 /** Photograph an Arabic page → faithful English translation + the top unknown
- *  words (glossed) ready to add. One synchronous round trip: Gemini OCR/translation
- *  + Haiku gloss run server-side, so allow a generous timeout. */
+ *  words (glossed) ready to add. Corpus words reuse stored metadata; genuinely new
+ *  forms are glossed server-side, so allow a generous recovery timeout. */
 export async function snapDiscover(
   imageUri: string,
   count = 5
@@ -1067,7 +1067,9 @@ export async function snapDiscover(
   formData.append("file", { uri: imageUri, name: filename, type } as any);
 
   const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), 60000);
+  // The backend makes two bounded 90s vision attempts for transient OCR/provider
+  // failures. Keep the mobile request alive long enough for the recovery attempt.
+  const timer = setTimeout(() => controller.abort(), 210000);
   try {
     const res = await fetch(`${BASE_URL}/api/discover/snap?count=${count}`, {
       method: "POST",

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -1209,8 +1209,8 @@ export interface SessionEndData {
 // --- Snap-to-read: photo → translation + discoverable vocabulary chips ---
 
 /** One candidate word from the discover/snap pipeline (mirrors the backend
- *  /api/discover words schema). Words already in Alif's vocabulary are excluded
- *  upstream, so every chip is a genuinely-new word the reader can add. */
+ *  /api/discover words schema). Words already in active learning are excluded
+ *  upstream; a chip may reuse lexical metadata from an existing corpus lemma. */
 export interface DiscoverWord {
   surface: string;
   surface_forms: string[];


### PR DESCRIPTION
Fix snap-to-read so corpus lemmas are filtered by the learner's actual curriculum state, reuse stored lexical metadata, retry transient OCR failures, recover missing translations, and align the mobile timeout with backend recovery. Includes focused backend regressions and frontend type validation.