### PR TITLE
Book/corpus acquiring-gate + Momo authentic-sentence corpus importer

### DIFF
--- a/backend/app/services/sentence_selector.py
+++ b/backend/app/services/sentence_selector.py
@@ -113,6 +113,21 @@ def _source_bonus_for_sentence(sent: Sentence) -> float:
     return 1.0
 
 
+def _book_sentence_blocked_for_acquiring(sent: Sentence, word_metas: list) -> bool:
+    """Authentic book/corpus sentences must never PRACTICE acquiring-state words.
+
+    Durable user rule (2026-05-26, stated repeatedly): authentic sentences are
+    written for fluent readers; a Box-1/2/3 word needs LLM-scaffolded material
+    (warm_sentence_cache's job). Book/corpus sentences may serve a word only
+    once it has graduated to an FSRS card (learning/known/lapsed). The gate
+    applies to the sentence's DUE (practiced) words — collateral scaffold
+    appearances are governed by the comprehensibility gate instead.
+    """
+    if sent.source not in ("book", "corpus"):
+        return False
+    return any(w.is_due and w.knowledge_state == "acquiring" for w in word_metas)
+
+
 def _quality_multiplier_for_sentence(sent: Sentence) -> float:
     """Prefer quality-reviewed LLM rows, but keep unreviewed rows as fallback.
 
@@ -1390,6 +1405,9 @@ def build_session(
         if unknown_scaffold > MAX_UNKNOWN_SCAFFOLD:
             continue
 
+        if _book_sentence_blocked_for_acquiring(sent, word_metas):
+            continue
+
         # Listening mode: skip if any non-function, non-due word isn't listening-ready
         if mode == "listening":
             scaffold_ids = [w.lemma_id for w in word_metas
@@ -2505,6 +2523,9 @@ def _find_pregenerated_sentences_for_words(
             continue
         unknown_scaffold = total_scaffold - known_scaffold
         if unknown_scaffold > MAX_UNKNOWN_SCAFFOLD:
+            continue
+
+        if _book_sentence_blocked_for_acquiring(sent, word_metas):
             continue
 
         weakest = min(stability_map.get(lid, 0.0) for lid in due_covered)

--- a/backend/scripts/import_momo_corpus.py
+++ b/backend/scripts/import_momo_corpus.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""Import authentic Momo sentences as corpus material — carefully.
+
+Thin wrapper over the Hindawi corpus pipeline (`import_hindawi.py`) for a
+page-marked OCR text file (`=== jNNN-NNN ===` markers). Care layers:
+
+  1. Sentences are extracted PER PAGE — nothing spans a page break.
+  2. The inherited Hindawi filters: 5-14 words, fragment regex pre-filter,
+     strict all-mapped rule (every content token must resolve to a lemma —
+     OCR-corrupted tokens are unmappable, so corrupted sentences self-exclude),
+     >=2 content lemmas, dedup vs existing sentences.
+  3. Momo-purpose filter: sentence must contain >=1 lemma imported for the
+     book (default `--require-source bookifier`).
+  4. Rows land is_active=False, unverified, untranslated — invisible to review
+     until the update_material cron diacritizes/translates/LLM-verifies them.
+  5. Serve-time: the book/corpus acquiring-gate in sentence_selector keeps
+     these away from Box-1 words (durable user rule, 2026-05-26).
+
+Usage:
+  cd backend
+  python3 scripts/import_momo_corpus.py --text-file ../tmp/momo_full_2026-07-15.txt --analyze
+  python3 scripts/import_momo_corpus.py --text-file ../tmp/momo_full_2026-07-15.txt --import
+"""
+
+import argparse
+import logging
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from app.database import SessionLocal  # noqa: E402
+from app.models import Lemma, Sentence, SentenceWord  # noqa: E402
+from app.services.proper_name_lemmas import get_or_create_proper_name_lemma  # noqa: E402
+from app.services.sentence_quality import fails_corpus_regex_filter  # noqa: E402
+from app.services.sentence_validator import (  # noqa: E402
+    normalize_alef,
+    strip_diacritics,
+    strip_punctuation,
+    strip_tatweel,
+)
+from app.services.transliteration import transliterate_arabic  # noqa: E402
+from scripts.import_hindawi import (  # noqa: E402
+    build_lemma_lookup,
+    build_name_set,
+    extract_sentences,
+    get_existing_arabic_texts,
+    map_tokens_to_lemmas,
+    tokenize_display,
+)
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+logger = logging.getLogger(__name__)
+
+PAGE_MARKER = re.compile(r"=== j\d+-\d+ ===")
+
+
+def run(text_path: str, require_source: str | None, min_words: int,
+        max_words: int, analyze_only: bool, limit: int | None,
+        dump_path: str | None = None, keep_path: str | None = None):
+    raw = Path(text_path).read_text(encoding="utf-8")
+    pages = [p.strip() for p in PAGE_MARKER.split(raw) if p.strip()]
+    logger.info(f"{len(pages)} pages of text")
+
+    all_sentences: list[dict] = []
+    for page in pages:
+        for s in extract_sentences(page, min_words, max_words):
+            all_sentences.append({"text": s, "title": "Momo", "author": "Michael Ende"})
+    logger.info(f"Extracted {len(all_sentences):,} candidates ({min_words}-{max_words} words, per-page)")
+
+    rule_counts: dict[str, int] = {}
+    kept = []
+    for s in all_sentences:
+        fail, rule = fails_corpus_regex_filter(s["text"])
+        if fail:
+            rule_counts[rule] = rule_counts.get(rule, 0) + 1
+            continue
+        kept.append(s)
+    logger.info(f"Regex pre-filter removed {len(all_sentences) - len(kept):,} "
+                f"({' '.join(f'{k}={v}' for k, v in sorted(rule_counts.items()))})")
+    all_sentences = kept
+
+    db = SessionLocal()
+    try:
+        all_lemmas = db.query(Lemma).filter(Lemma.canonical_lemma_id.is_(None)).all()
+        lookup = build_lemma_lookup(all_lemmas)
+        required_ids: set[int] = set()
+        if require_source:
+            required_ids = {
+                l.lemma_id for l in all_lemmas if l.source == require_source
+            }
+            logger.info(f"Momo-purpose filter: sentence must contain one of "
+                        f"{len(required_ids)} '{require_source}' lemmas")
+        names = build_name_set(all_sentences, lookup)
+        existing = get_existing_arabic_texts(db)
+
+        accepted, rejected_unmapped, rejected_no_target, dedup = [], 0, 0, 0
+        for s in all_sentences:
+            text_norm = normalize_alef(strip_diacritics(s["text"]))
+            if text_norm in existing:
+                dedup += 1
+                continue
+            tokens = tokenize_display(s["text"])
+            mappings = map_tokens_to_lemmas(
+                tokens=tokens, lemma_lookup=lookup, target_lemma_id=0,
+                target_bare="", proper_names=names,
+            )
+            has_unmapped = False
+            mapped_ids: set[int] = set()
+            for m in mappings:
+                if m.is_function_word or m.is_proper_name:
+                    continue
+                bare = normalize_alef(strip_diacritics(strip_punctuation(
+                    strip_tatweel(m.surface_form))))
+                if not bare or len(bare) <= 1:
+                    continue
+                if m.lemma_id is None:
+                    has_unmapped = True
+                    break
+                mapped_ids.add(m.lemma_id)
+            if has_unmapped:
+                rejected_unmapped += 1
+                continue
+            if len(mapped_ids) < 2:
+                rejected_unmapped += 1
+                continue
+            if required_ids and not (mapped_ids & required_ids):
+                rejected_no_target += 1
+                continue
+            existing.add(text_norm)
+            accepted.append({"text": s["text"], "mappings": mappings,
+                             "lemma_ids": mapped_ids})
+
+        logger.info(f"\nAccepted: {len(accepted):,} | rejected unmapped/thin: "
+                    f"{rejected_unmapped:,} | no Momo target: {rejected_no_target:,} "
+                    f"| dupes: {dedup:,}")
+        covered = set()
+        for s in accepted:
+            covered.update(s["lemma_ids"] & required_ids)
+        if required_ids:
+            logger.info(f"Momo lemmas covered by accepted sentences: "
+                        f"{len(covered)}/{len(required_ids)}")
+        import random
+        random.seed(42)
+        for s in random.sample(accepted, min(12, len(accepted))):
+            logger.info(f"  {s['text']}")
+
+        if dump_path:
+            import json
+            with open(dump_path, "w", encoding="utf-8") as f:
+                for i, s in enumerate(accepted):
+                    f.write(json.dumps({"i": i, "text": s["text"]}, ensure_ascii=False) + "\n")
+            logger.info(f"Dumped {len(accepted)} accepted sentences to {dump_path}")
+        if keep_path:
+            keep_texts = {
+                __import__("json").loads(line)["text"]
+                for line in open(keep_path, encoding="utf-8") if line.strip()
+            }
+            before = len(accepted)
+            accepted = [s for s in accepted if s["text"] in keep_texts]
+            logger.info(f"Keep-file filter: {before} -> {len(accepted)}")
+        if analyze_only:
+            logger.info("\n[Analyze mode — no DB writes]")
+            return
+        if limit:
+            accepted = accepted[:limit]
+
+        now = datetime.now(timezone.utc)
+        created = 0
+        for s in accepted:
+            target_lid = None
+            for m in s["mappings"]:
+                if (m.lemma_id and m.lemma_id in required_ids
+                        and not m.is_function_word and not m.is_proper_name):
+                    target_lid = m.lemma_id
+                    break
+            if target_lid is None:
+                for m in s["mappings"]:
+                    if m.lemma_id and not m.is_function_word and not m.is_proper_name:
+                        target_lid = m.lemma_id
+                        break
+            sent = Sentence(
+                arabic_text=s["text"],
+                english_translation=None,  # translated on-demand by cron
+                transliteration=transliterate_arabic(s["text"]) or "",
+                source="corpus",
+                kind="momo_book",
+                target_lemma_id=target_lid,
+                created_at=now,
+                mappings_verified_at=None,  # enriched on-demand by cron step A2
+                is_active=False,  # activated after enrichment
+            )
+            db.add(sent)
+            db.flush()
+            for m in s["mappings"]:
+                lid = m.lemma_id if m.lemma_id and m.lemma_id != 0 else None
+                if lid is None and m.is_proper_name:
+                    lid = get_or_create_proper_name_lemma(
+                        db, m.surface_form, source="corpus")
+                db.add(SentenceWord(
+                    sentence_id=sent.id, position=m.position,
+                    surface_form=m.surface_form, lemma_id=lid,
+                    is_target_word=(lid == target_lid and lid is not None),
+                ))
+            created += 1
+            if created % 200 == 0:
+                db.commit()
+        db.commit()
+        logger.info(f"Done: {created} sentences (source='corpus', kind='momo_book', inactive until enrichment)")
+    finally:
+        db.close()
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Import Momo corpus sentences")
+    ap.add_argument("--text-file", required=True)
+    ap.add_argument("--require-source", default="bookifier",
+                    help="Sentence must contain a lemma with this source ('' disables)")
+    ap.add_argument("--min-words", type=int, default=5)
+    ap.add_argument("--max-words", type=int, default=14)
+    ap.add_argument("--analyze", action="store_true")
+    ap.add_argument("--import", dest="do_import", action="store_true")
+    ap.add_argument("--limit", type=int)
+    ap.add_argument("--dump-jsonl", help="Write accepted sentences to this JSONL for manual vetting")
+    ap.add_argument("--keep-file", help="JSONL of vetted sentences; only these are imported")
+    args = ap.parse_args()
+    if not args.analyze and not args.do_import:
+        ap.error("Must specify --analyze or --import")
+    run(args.text_file, args.require_source or None, args.min_words,
+        args.max_words, args.analyze, args.limit,
+        dump_path=args.dump_jsonl, keep_path=args.keep_file)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/test_sentence_selector.py
+++ b/backend/tests/test_sentence_selector.py
@@ -2022,3 +2022,86 @@ class TestIntroCardTotalCap:
 
         assert len(cards) == INTRO_NEW_CARDS_PER_SESSION
         assert set(textbook_ids) <= card_ids
+
+
+class TestBookSentenceAcquiringGate:
+    """Authentic book/corpus sentences must never practice acquiring-state words.
+
+    Durable user rule (2026-05-26): book sentences are written for fluent
+    readers; Box-1/2/3 words get LLM-scaffolded material only. Book/corpus
+    sentences may serve a word once it has an FSRS card (learning/known/lapsed).
+    """
+
+    def _meta(self, lemma_id, state, is_due):
+        return WordMeta(
+            lemma_id=lemma_id, surface_form="x", gloss_en="x", stability=1.0,
+            is_due=is_due, is_function_word=False, is_proper_name=False,
+            knowledge_state=state, is_fresh_today=False,
+        )
+
+    def test_predicate_blocks_corpus_for_due_acquiring(self):
+        from app.services.sentence_selector import _book_sentence_blocked_for_acquiring
+        sent = Sentence(arabic_text="x", source="corpus")
+        metas = [self._meta(1, "acquiring", True), self._meta(2, "known", False)]
+        assert _book_sentence_blocked_for_acquiring(sent, metas) is True
+
+    def test_predicate_allows_llm_source_for_due_acquiring(self):
+        from app.services.sentence_selector import _book_sentence_blocked_for_acquiring
+        sent = Sentence(arabic_text="x", source="llm")
+        metas = [self._meta(1, "acquiring", True)]
+        assert _book_sentence_blocked_for_acquiring(sent, metas) is False
+
+    def test_predicate_allows_corpus_for_due_known(self):
+        from app.services.sentence_selector import _book_sentence_blocked_for_acquiring
+        sent = Sentence(arabic_text="x", source="book")
+        metas = [self._meta(1, "known", True)]
+        assert _book_sentence_blocked_for_acquiring(sent, metas) is False
+
+    def test_predicate_allows_corpus_with_acquiring_scaffold_only(self):
+        # Collateral (non-due) acquiring scaffold is governed by the
+        # comprehensibility gate, not this one.
+        from app.services.sentence_selector import _book_sentence_blocked_for_acquiring
+        sent = Sentence(arabic_text="x", source="corpus")
+        metas = [self._meta(1, "known", True), self._meta(2, "acquiring", False)]
+        assert _book_sentence_blocked_for_acquiring(sent, metas) is False
+
+    def test_pregenerated_fill_skips_corpus_for_acquiring_target(self, db_session):
+        _, k1 = _seed_word(db_session, 1, "كناس", "sweeper", state="acquiring",
+                           stability=0.1)
+        _seed_word(db_session, 2, "بيت", "house", state="known")
+        _seed_word(db_session, 3, "كبير", "big", state="known")
+        # Corpus sentence and LLM sentence, both containing the acquiring target
+        _seed_sentence(db_session, 1, "الكناس في البيت الكبير", "the sweeper ...",
+                       1, [("الكناس", 1), ("البيت", 2), ("الكبير", 3)],
+                       source="corpus")
+        _seed_sentence(db_session, 2, "الكناس كبير", "the sweeper is big",
+                       1, [("الكناس", 1), ("كبير", 3)], source="llm")
+        k2 = db_session.query(UserLemmaKnowledge).filter_by(lemma_id=2).one()
+        k3 = db_session.query(UserLemmaKnowledge).filter_by(lemma_id=3).one()
+
+        items = _find_pregenerated_sentences_for_words(
+            db_session, {1}, {1: 0.1, 2: 30.0, 3: 30.0},
+            {1: k1, 2: k2, 3: k3}, [k1, k2, k3], limit=5,
+        )
+        picked_sources = {
+            db_session.get(Sentence, it["sentence_id"]).source for it in items
+        }
+        assert "corpus" not in picked_sources, (
+            "corpus sentence must not be served for an acquiring target"
+        )
+        assert picked_sources == {"llm"}
+
+    def test_pregenerated_fill_allows_corpus_for_known_target(self, db_session):
+        _, k1 = _seed_word(db_session, 1, "كناس", "sweeper", state="known",
+                           stability=5.0)
+        _seed_word(db_session, 2, "بيت", "house", state="known")
+        _seed_sentence(db_session, 1, "الكناس في البيت", "the sweeper ...",
+                       1, [("الكناس", 1), ("البيت", 2)], source="corpus")
+        k2 = db_session.query(UserLemmaKnowledge).filter_by(lemma_id=2).one()
+
+        items = _find_pregenerated_sentences_for_words(
+            db_session, {1}, {1: 5.0, 2: 30.0},
+            {1: k1, 2: k2}, [k1, k2], limit=5,
+        )
+        assert len(items) == 1
+        assert db_session.get(Sentence, items[0]["sentence_id"]).source == "corpus"

--- a/docs/scheduling-system.md
+++ b/docs/scheduling-system.md
@@ -2189,6 +2189,7 @@ the codebase that filter on `knowledge_state`, `stability`, or `canonical_lemma_
 | Gate | Location | Filters on |
 |------|----------|------------|
 | Comprehensibility gate | `sentence_selector.py` (×2: build_session + fill) | knowledge_state, stability |
+| Book/corpus acquiring gate | `sentence_selector.py` `_book_sentence_blocked_for_acquiring` (×2: build_session + fill) | source, knowledge_state (due words) |
 | Unknown scaffold cap | `sentence_selector.py` | knowledge_state |
 | Pipeline backlog gate | `sentence_selector.py` | acquiring count |
 | Focus cohort | `cohort_service.py` | knowledge_state |

--- a/research/experiment-log.md
+++ b/research/experiment-log.md
@@ -46,6 +46,41 @@ Running lab notebook for Alif's learning algorithm. Each entry documents what ch
 
 ═══════════════════════ ENTRIES (newest first) ═══════════════════════
 
+## 2026-07-15: Book/corpus acquiring-gate + Momo authentic-sentence corpus
+
+**Trigger.** The Momo push (July 14–15: 165 book-targeted lemmas imported, ~200 words in
+acquisition) made authentic-sentence mining attractive: review the book's own sentences
+before reading it. But the durable user rule from 2026-05-26 (polyglot Eutropius incident,
+"the book sentences are too complex to practice with … I don't want to see them until I
+have learnt the words well") had been implemented in **polyglot only** — Alif's selector
+had no such gate; book/corpus sentences even carry a 1.3× source bonus and can stack with
+NEVER_REVIEWED_BOOST for a Box-1 word.
+
+**Change.** New gate `_book_sentence_blocked_for_acquiring()` in `sentence_selector.py`,
+applied at both candidate loops (build_session main scoring + `_find_pregenerated_
+sentences_for_words` fill): a sentence with `source in ("book","corpus")` is skipped when
+any of its **due (practiced)** words is `acquiring`. Collateral (non-due) acquiring
+scaffolds remain governed by the comprehensibility gate — blocking those would gut corpus
+coverage and contradict the every-word-earns-credit invariant. Gate registered in
+`docs/scheduling-system.md` §19.17. Tests: `TestBookSentenceAcquiringGate` (6 cases:
+predicate matrix + fill-path integration both ways).
+
+**Corpus.** `scripts/import_momo_corpus.py` (Hindawi-pipeline wrapper): per-page
+extraction from the full-book OCR (no page-break splices), fragment regex pre-filter,
+strict all-tokens-mapped rule (OCR noise self-excludes), ≥1 bookifier-lemma requirement,
+dedup. 1,646 candidates → 87 machine-accepted → **59 hand-vetted** (Claude read all 87;
+dropped mid-clause fragments, OCR garble, one المرأة/المرآة ambiguity, one احتال-vs-احتل
+mapping trap). Imported `source='corpus'`, `kind='momo_book'`, `is_active=False`,
+unverified/untranslated — invisible until the update_material cron diacritizes/translates/
+verifies (same lifecycle as Hindawi). Expected effect: authentic Momo sentences enter the
+maintenance diet as their target words graduate, i.e. staged authentic-material entry
+(recommended by the 2026-05-10 projection analysis) with the staging enforced by gates.
+
+**Expectation / watch.** No change to acquisition sessions (gate is a strict narrowing);
+corpus sentences appear for graduated Momo words within ~1–3 weeks. Watch: session fill
+rate for FSRS-due Momo words (should rise as sentences activate), and that no momo_book
+sentence is served with a Box-1 due word (grep session logs if in doubt).
+
 ## 2026-07-09 (deployed 2026-07-10 — PR #208): Return recovery tuning + exact-surface pilot
 
 **Trigger.** The learner confirmed the hiatus was a vacation and clarified that yellow means


### PR DESCRIPTION
Implements the durable 2026-05-26 rule in Alif (was polyglot-only): authentic book/corpus sentences must never practice acquiring-state words. New `_book_sentence_blocked_for_acquiring()` gate at both selector candidate loops (build_session scoring + pregenerated fill), registered in the scheduling-system gate registry, with 6 tests.

Adds `scripts/import_momo_corpus.py` — a Hindawi-pipeline wrapper for page-marked OCR text: per-page extraction, fragment regex pre-filter, strict all-tokens-mapped rule, ≥1 bookifier-lemma requirement, dedup, dump/keep-file flow for manual vetting. Sentences import inactive/unverified until cron enrichment.

Experiment-log entry: 2026-07-15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)