### PR TITLE
iOS: standalone EAS preview build + expo-updates OTA (replaces dev-client-on-Metro)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ npx expo start --web  # opens on localhost:8081
 - **TTS**: ElevenLabs REST, `eleven_multilingual_v2`, PVC voice. Audio cached by SHA256 in `backend/data/audio/`. Story audio in `backend/data/story-audio/`.
 - **NLP**: Rule-based clitic stripping + known-form matching + CAMeL disambiguation + LLM disambiguation. See `docs/nlp-pipeline.md`.
 - **Migrations**: Alembic for SQLite. Every schema change needs a migration. Auto-runs on startup.
-- **Hosting**: Hetzner (46.225.75.29), venv + systemd (no Docker). Backend: systemd service `alif-backend`, port 3000, venv at `/opt/alif/backend/.venv/`. Frontend: systemd service `alif-expo`, port 8081. Spanish Pilot: systemd service `alif-spanish-pilot`, port 3100. Polyglot: systemd service `polyglot-backend`, port 3002, fronted by an in-app reverse proxy at `/polyglot/*` (`backend/app/routers/polyglot_proxy.py`, mounted in `backend/app/main.py`, forwarding to `127.0.0.1:3002`) so the client only needs alif's port 3000. DuckDNS: `alifstian.duckdns.org`. Data at `/opt/alif/backend/data/`. Limbic at `/opt/limbic` (PYTHONPATH), cost DB at `/opt/limbic-data/llm_costs.db`.
+- **Hosting**: Hetzner (46.225.75.29), venv + systemd (no Docker). Backend: systemd service `alif-backend`, port 3000, venv at `/opt/alif/backend/.venv/`. Frontend: systemd service `alif-expo`, port 8081 (serves the **web** version; since 2026-07-15 the iOS app is a standalone EAS `preview` build with expo-updates OTA — it embeds its JS bundle and does not touch Metro; see Deployment). Spanish Pilot: systemd service `alif-spanish-pilot`, port 3100. Polyglot: systemd service `polyglot-backend`, port 3002, fronted by an in-app reverse proxy at `/polyglot/*` (`backend/app/routers/polyglot_proxy.py`, mounted in `backend/app/main.py`, forwarding to `127.0.0.1:3002`) so the client only needs alif's port 3000. DuckDNS: `alifstian.duckdns.org`. Data at `/opt/alif/backend/data/`. Limbic at `/opt/limbic` (PYTHONPATH), cost DB at `/opt/limbic-data/llm_costs.db`.
 - **Spanish Pilot**: Standalone UX-validation prototype at `spanish-pilot/` — separate SQLite, separate systemd `alif-spanish-pilot` on port 3100 (`/opt/alif-pilot/`). Norwegian UI, no English. Tests Alif's word-level SRS + intro cards + memory hooks on 60 Norwegian school students learning Spanish. See `spanish-pilot/README.md`. Does NOT share any code with main Alif backend — completely isolated.
 - **Polyglot**: Sister app at `polyglot/` for Modern Greek (primary), Ancient Greek, and Latin. Separate Python package (`polyglot-backend`), separate venv (`polyglot/.venv`), separate SQLite (`polyglot/polyglot.db`), separate FastAPI process on port 3002 (prod; 3001 dev). Reading-as-mapping primary UX (lazy PDF intake → tap unknowns → next-page presumes rest known). Uses simplemma for lemmatization with a dual-provider LLM-in-context quality gate — Codex `gpt-5.5` primary + Claude failover via `polyglot/app/services/llm_cli.py`. FSRS + acquisition Leitner + leech engine ported from Alif (`/api/reviews/{submit,introduce,due,stats}`); `mark_lemma(state='unknown')` enrols into Box 1 immediately. **Do NOT confuse `backend/` and `polyglot/`** — see `polyglot/CLAUDE.md` for project-specific rules. **Mirror Alif's design and code by default; divergence requires a specific Greek/Latin-driven reason recorded in the change. Alif is the product of 100+ days of real-user iteration — do not redesign it.** See `polyglot/CLAUDE.md` § "Ground design and code in Alif". Frontend (`frontend/`) talks to both; user picks via a Globe tab driven by `frontend/lib/language-context.tsx`. Plan: after ~6 weeks of dogfooding both languages, extract a shared `alif_core/` Python package (FSRS, acquisition, session builder) — premature now.
 - **LLM Cost Tracking**: All litellm calls auto-logged via `limbic.cerebellum.cost_log` callback. Sync to local: `python -m limbic.cerebellum.cost_log sync`. Reports: `python -m limbic.cerebellum.cost_log report --days 7`.
@@ -258,7 +258,24 @@ ssh alif "cd /opt/alif/backend && .venv/bin/pip install -e . -q && systemctl res
 ssh alif "cd /opt/alif && git checkout main && git pull --ff-only && git log --oneline -1 && systemctl restart polyglot-backend && systemctl is-active polyglot-backend"
 # If polyglot dependencies changed: ssh alif "cd /opt/alif/polyglot && .venv/bin/pip install -e . -q && systemctl restart polyglot-backend"
 
-# Deploy frontend (Expo dev server is a systemd service; shared by alif + polyglot)
+# Deploy frontend — TWO targets since 2026-07-15:
+#
+# (a) iOS app (primary): standalone EAS "preview" build with expo-updates (OTA).
+#     The JS bundle is embedded — the app launches instantly offline, NO Metro
+#     dependency. UI changes ship over the air from the local checkout (merge to
+#     main + pull first so you publish exactly what's merged):
+cd frontend && eas update --channel preview --message "<what changed>"
+#     The phone picks the update up in the background on next launch and applies
+#     it the launch after (fallbackToCacheTimeout=0 default). NATIVE changes
+#     (new native module, permissions, icon, app.json ios/android keys) do NOT
+#     ship via OTA: bump "version" in app.json (runtimeVersion policy is
+#     appVersion — the bump is what stops old binaries receiving incompatible JS),
+#     then rebuild + reinstall:
+#       cd frontend && eas build --platform ios --profile preview
+#     Install from the expo.dev build page link on the phone. Ad-hoc profile
+#     expires Mar 2027; device UDID already registered.
+#
+# (b) Web version (+ legacy Expo Go): still the Hetzner Metro dev server.
 # NOTE: a bare `systemctl restart alif-expo` keeps Metro's transform cache and can
 # serve a STALE bundle (frontend code changes silently don't appear; symptom seen
 # 2026-05-25 — a screen showed the wrong language's data though source + backend
@@ -272,9 +289,9 @@ ssh alif "cd /opt/alif && git checkout main && git pull --ff-only && cd backend 
 # scripts/deploy.sh links /opt/alif-update-material.sh to deploy/alif-update-material.sh
 # from the checked-out Git main. Do not scp cron wrappers to production.
 
-# Expo URL (always display after deploy):
-# exp://alifstian.duckdns.org:8081
-# Web: http://alifstian.duckdns.org:8081
+# Web URL (always display after a web deploy):
+# http://alifstian.duckdns.org:8081
+# iOS: standalone app (EAS preview build + OTA) — exp:// URL no longer used on the phone
 ```
 
 Server-side config that lives outside the app process (cron wrappers, etc.) is versioned under `deploy/`. The cron wrapper at `/opt/alif-update-material.sh` is the authoritative supply-chain entry for daily intros — it sets `ALIF_RUN_CRON_PREGENERATION=1`, `ALIF_RUN_CRON_LEMMA_ENRICHMENT=1`, `ALIF_FREQ_CORE_INTAKE_MAX_RANK=3000`, `ALIF_FREQ_CORE_INTAKE_LIMIT=10` so the intake script can keep filling the top-frequency lemma pool past rank 1000. Without these, intros silently dry up once you graduate past the easy tier. See `deploy/README.md` and the 2026-05-13 experiment-log entry.

--- a/frontend/app.json
+++ b/frontend/app.json
@@ -54,6 +54,12 @@
       "eas": {
         "projectId": "20b68974-631b-4074-83df-64d741f72325"
       }
+    },
+    "runtimeVersion": {
+      "policy": "appVersion"
+    },
+    "updates": {
+      "url": "https://u.expo.dev/20b68974-631b-4074-83df-64d741f72325"
     }
   }
 }

--- a/frontend/eas.json
+++ b/frontend/eas.json
@@ -9,11 +9,15 @@
       "distribution": "internal",
       "ios": {
         "simulator": false
-      }
+      },
+      "channel": "development"
     },
     "preview": {
-      "distribution": "internal"
+      "distribution": "internal",
+      "channel": "preview"
     },
-    "production": {}
+    "production": {
+      "channel": "production"
+    }
   }
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -26,6 +26,7 @@
         "expo-linking": "~8.0.11",
         "expo-router": "~6.0.23",
         "expo-status-bar": "~3.0.9",
+        "expo-updates": "~29.0.18",
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "react-native": "0.81.5",
@@ -2365,9 +2366,9 @@
       }
     },
     "node_modules/@expo/plist": {
-      "version": "0.4.8",
-      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.4.8.tgz",
-      "integrity": "sha512-pfNtErGGzzRwHP+5+RqswzPDKkZrx+Cli0mzjQaus1ZWFsog5ibL+nVT3NcporW51o8ggnt7x813vtRbPiyOrQ==",
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.4.9.tgz",
+      "integrity": "sha512-MPVpmKGfnQEnrCzgxuXcmPP/y/t6AVm+DcSb2Myp21LKWv1N3l8uFxMggesfF4ixAxkRlGmMMx9GyDC9M+XklQ==",
       "license": "MIT",
       "dependencies": {
         "@xmldom/xmldom": "^0.8.8",
@@ -7432,6 +7433,12 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-eas-client": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/expo-eas-client/-/expo-eas-client-1.0.8.tgz",
+      "integrity": "sha512-5or11NJhSeDoHHI6zyvQDW2cz/yFyE+1Cz8NTs5NK8JzC7J0JrkUgptWtxyfB6Xs/21YRNifd3qgbBN3hfKVgA==",
+      "license": "MIT"
+    },
     "node_modules/expo-file-system": {
       "version": "19.0.21",
       "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-19.0.21.tgz",
@@ -7477,6 +7484,12 @@
         "expo": "*"
       }
     },
+    "node_modules/expo-json-utils": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/expo-json-utils/-/expo-json-utils-0.15.0.tgz",
+      "integrity": "sha512-duRT6oGl80IDzH2LD2yEFWNwGIC2WkozsB6HF3cDYNoNNdUvFk6uN3YiwsTsqVM/D0z6LEAQ01/SlYvN+Fw0JQ==",
+      "license": "MIT"
+    },
     "node_modules/expo-keep-awake": {
       "version": "15.0.8",
       "resolved": "https://registry.npmjs.org/expo-keep-awake/-/expo-keep-awake-15.0.8.tgz",
@@ -7499,6 +7512,19 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-manifests": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/expo-manifests/-/expo-manifests-1.0.11.tgz",
+      "integrity": "sha512-6zItytTewN37Cjhp3glUg0ozrgW2GwB8x9wtfzUNoJIMmxO38nnGdTLMaotYhRqdf5PP2Dzdmej1HDHXVNUpRw==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config": "~12.0.13",
+        "expo-json-utils": "~0.15.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-modules-autolinking": {
@@ -7885,6 +7911,127 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-structured-headers": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/expo-structured-headers/-/expo-structured-headers-5.0.0.tgz",
+      "integrity": "sha512-RmrBtnSphk5REmZGV+lcdgdpxyzio5rJw8CXviHE6qH5pKQQ83fhMEcigvrkBdsn2Efw2EODp4Yxl1/fqMvOZw==",
+      "license": "MIT"
+    },
+    "node_modules/expo-updates": {
+      "version": "29.0.18",
+      "resolved": "https://registry.npmjs.org/expo-updates/-/expo-updates-29.0.18.tgz",
+      "integrity": "sha512-qn0YDM7wVwghQAaxb9NYzzwrmj+v8Djz5H+Zft4/myG9SPg4ICAfDy52IVF0K+/GH/oNgsFfzmmLl6hIkDu42g==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/code-signing-certificates": "^0.0.6",
+        "@expo/plist": "^0.4.9",
+        "@expo/spawn-async": "^1.7.2",
+        "arg": "4.1.0",
+        "chalk": "^4.1.2",
+        "debug": "^4.3.4",
+        "expo-eas-client": "~1.0.8",
+        "expo-manifests": "~1.0.11",
+        "expo-structured-headers": "~5.0.0",
+        "expo-updates-interface": "~2.0.0",
+        "getenv": "^2.0.0",
+        "glob": "^13.0.0",
+        "ignore": "^5.3.1",
+        "resolve-from": "^5.0.0"
+      },
+      "bin": {
+        "expo-updates": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-updates-interface": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/expo-updates-interface/-/expo-updates-interface-2.0.0.tgz",
+      "integrity": "sha512-pTzAIufEZdVPKql6iMi5ylVSPqV1qbEopz9G6TSECQmnNde2nwq42PxdFBaUEd8IZJ/fdJLQnOT3m6+XJ5s7jg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-updates/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/expo-updates/node_modules/arg": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.0.tgz",
+      "integrity": "sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg==",
+      "license": "MIT"
+    },
+    "node_modules/expo-updates/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/expo-updates/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/expo-updates/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/expo-updates/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/expo-updates/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/expo/node_modules/@expo/cli": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,6 +29,7 @@
     "expo-linking": "~8.0.11",
     "expo-router": "~6.0.23",
     "expo-status-bar": "~3.0.9",
+    "expo-updates": "~29.0.18",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-native": "0.81.5",


### PR DESCRIPTION
The iOS app was an EAS development client fetching its JS bundle from the Hetzner Metro dev server on every launch — causing frequent slow reloads (every deploy restarts Metro and wipes its cache) and a hard network dependency at startup, for a UI that rarely changes.

This switches iOS to a standalone internal-distribution build with embedded JS + EAS Update (OTA):

- `expo-updates` ~29.0.18 added; `app.json` gets `updates.url` + `runtimeVersion: {policy: appVersion}` (via `eas update:configure`; also deduplicates the Android permissions array the tool doubled)
- `eas.json` build profiles get channels (`development`/`preview`/`production`)
- New deploy contract documented in CLAUDE.md: JS-only change → `eas update --channel preview`; native change → bump `version` + rebuild. Web version still served by the Hetzner Metro service, unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)