### PR TITLE
Reintro-card cooldown + rescue slot reservation + readable burndown

### DIFF
--- a/backend/app/routers/review.py
+++ b/backend/app/routers/review.py
@@ -584,16 +584,65 @@ def sync_reviews(body: BulkSyncIn, db: Session = Depends(get_db)):
     return {"results": results}
 
 
+def _stamp_intro_shown(db: Session, lemma_id: int):
+    """Persist ``experiment_intro_shown_at``, retrying on SQLite lock errors.
+
+    The timestamp gates re-showing of intro, rescue, and struggling-reintro
+    cards. A silent rollback re-fires the same card on the next session build
+    (observed 2026-05-04 for lemma #2650). Returns the ULK row or None.
+    """
+    from datetime import datetime
+    import time
+    from sqlalchemy.exc import OperationalError
+    from app.models import UserLemmaKnowledge
+
+    ulk = db.query(UserLemmaKnowledge).filter(
+        UserLemmaKnowledge.lemma_id == lemma_id,
+    ).first()
+    if not ulk:
+        return None
+    ulk.experiment_intro_shown_at = datetime.utcnow()
+    for attempt in range(3):
+        try:
+            db.commit()
+            break
+        except OperationalError:
+            db.rollback()
+            if attempt == 2:
+                logging.getLogger(__name__).warning(
+                    f"experiment_intro_shown_at failed to persist for lemma {lemma_id} "
+                    f"after 3 retries — card may re-fire next session"
+                )
+                break
+            time.sleep(0.1 * (2 ** attempt))
+            # Re-attach the dirty change after rollback cleared the session
+            ulk = db.query(UserLemmaKnowledge).filter(
+                UserLemmaKnowledge.lemma_id == lemma_id,
+            ).first()
+            if not ulk:
+                return None
+            ulk.experiment_intro_shown_at = datetime.utcnow()
+    return ulk
+
+
 @router.post("/reintro-result")
 def submit_reintro_result(
     body: ReintroResultIn,
+    db: Session = Depends(get_db),
 ):
     """Acknowledge an informational re-introduction card without reviewing it.
 
     The following sentence is the actual retrieval attempt.  Legacy
     ``remember`` / ``show_again`` values may still arrive from the offline
     queue, but they are intentionally treated as acknowledgements only.
+
+    The ack stamps ``experiment_intro_shown_at`` (no review credit — the
+    PR #207 acknowledgement-only invariant holds) so the struggling-reintro
+    cooldown in ``build_session`` can suppress the same card re-firing in
+    every session of the day.
     """
+    _stamp_intro_shown(db, body.lemma_id)
+
     log_interaction(
         event="reintro_acknowledged",
         lemma_id=body.lemma_id,
@@ -655,36 +704,8 @@ def acknowledge_experiment_intro(
     2026-05-04 for lemma #2650 — 3 intros across 3 sessions). Retry on
     OperationalError instead of swallowing it.
     """
-    from datetime import datetime
-    import time
-    from sqlalchemy.exc import OperationalError
-    from app.models import UserLemmaKnowledge
-
-    ulk = db.query(UserLemmaKnowledge).filter(
-        UserLemmaKnowledge.lemma_id == body.lemma_id,
-    ).first()
+    ulk = _stamp_intro_shown(db, body.lemma_id)
     experiment_group = ulk.experiment_group if ulk else None
-    if ulk:
-        ulk.experiment_intro_shown_at = datetime.utcnow()
-        for attempt in range(3):
-            try:
-                db.commit()
-                break
-            except OperationalError:
-                db.rollback()
-                if attempt == 2:
-                    logging.getLogger(__name__).warning(
-                        f"experiment_intro_shown_at failed to persist for lemma {body.lemma_id} "
-                        f"after 3 retries — intro may re-fire next session"
-                    )
-                    break
-                time.sleep(0.1 * (2 ** attempt))
-                # Re-attach the dirty change after rollback cleared the session
-                ulk = db.query(UserLemmaKnowledge).filter(
-                    UserLemmaKnowledge.lemma_id == body.lemma_id,
-                ).first()
-                if ulk:
-                    ulk.experiment_intro_shown_at = datetime.utcnow()
 
     log_interaction(
         event="experiment_intro_shown",

--- a/backend/app/services/sentence_selector.py
+++ b/backend/app/services/sentence_selector.py
@@ -993,11 +993,22 @@ def build_session(
         db, due_lemma_ids, knowledge_by_id, overdue_days_map, limit
     )
 
-    # Identify struggling words: seen 3+ times, never correct
+    # Identify struggling words: seen 3+ times, never correct. Skip words whose
+    # reintro card was acknowledged within the cooldown — the /reintro-result
+    # ack stamps experiment_intro_shown_at, and re-teaching the same word in
+    # every one of the day's sessions is wasted exposure (up to 9 repeats in
+    # 3 days observed before the cooldown, 2026-07-20).
+    reintro_cooldown_cutoff = now - timedelta(hours=REINTRO_SHOWN_COOLDOWN_HOURS)
     struggling_ids: set[int] = set()
     for lid in list(due_lemma_ids):
         k = knowledge_by_id.get(lid)
         if k and (k.times_seen or 0) >= 3 and (k.times_correct or 0) == 0:
+            shown_at = k.experiment_intro_shown_at
+            if shown_at is not None:
+                if shown_at.tzinfo is None:
+                    shown_at = shown_at.replace(tzinfo=timezone.utc)
+                if shown_at > reintro_cooldown_cutoff:
+                    continue
             struggling_ids.add(lid)
 
     # Keep struggling words in due_lemma_ids so they get sentences through
@@ -2181,6 +2192,19 @@ def _build_reintro_cards(
 RESCUE_MIN_SEEN = 4
 RESCUE_MAX_ACCURACY = 0.50
 RESCUE_COOLDOWN_DAYS = 7
+# Struggling-word reintro cards re-fire every session build until the word's
+# first correct review; with several sessions per day the same card repeated
+# up to 9× in 3 days (حَشَرَة #4230, observed 2026-07-20). The frontend ack
+# (/reintro-result) now stamps experiment_intro_shown_at, and this cooldown
+# suppresses another reintro card for the same lemma until it elapses.
+# 20h (not 24) so a once-daily rhythm with uneven session times still allows
+# one card per day.
+REINTRO_SHOWN_COOLDOWN_HOURS = 20
+# When both new-word and rescue candidates are present, guarantee rescue this
+# many of the INTRO_NEW_CARDS_PER_SESSION slots. Without a reservation, a
+# large explicit import (202 words on 2026-07-15) fills all 6 slots with new
+# cards for weeks and rescue re-teaching is fully starved.
+RESCUE_RESERVED_SLOTS = 2
 
 
 INTRO_CARDS_BASE = 4
@@ -2295,13 +2319,16 @@ def _build_intro_cards(
 
     rescue_dynamic_cap = _dynamic_intro_cap(db)
     # `INTRO_NEW_CARDS_PER_SESSION` is the total ceiling on intro cards in a
-    # session. Priority order: new (real learning) > rescue (re-teach).
+    # session. Priority order: new (real learning) > rescue (re-teach), but
+    # rescue keeps a small reservation so a large new-word backlog (e.g. an
+    # explicit 200-word import) can't starve re-teaching for weeks.
     total_budget = INTRO_NEW_CARDS_PER_SESSION
+    rescue_reserve = min(RESCUE_RESERVED_SLOTS, len(rescue_card_ids), rescue_dynamic_cap)
 
     new_cards = _build_reintro_cards(
         db,
         new_card_ids,
-        limit=min(len(new_card_ids), total_budget),
+        limit=min(len(new_card_ids), total_budget - rescue_reserve),
     )
     remaining = max(0, total_budget - len(new_cards))
     rescue_cards = (

--- a/backend/tests/test_reintro.py
+++ b/backend/tests/test_reintro.py
@@ -274,6 +274,95 @@ class TestReintroEndpoint:
         assert knowledge.times_correct == 0
         assert db_session.query(ReviewLog).count() == 0
 
+    def test_acknowledgement_stamps_intro_shown(self, db_session, client):
+        """The reintro ack must persist experiment_intro_shown_at so the
+        struggling-reintro cooldown can suppress same-day repeats (a word got
+        9 reintro cards in 3 days before this, 2026-07-20)."""
+        _, knowledge = _seed_word(
+            db_session, 1, "صعب", "difficult",
+            state="acquiring", stability=0.1, due_hours=-1,
+            times_seen=5, times_correct=0,
+        )
+        assert knowledge.experiment_intro_shown_at is None
+        db_session.commit()
+
+        resp = client.post(
+            "/api/review/reintro-result",
+            json={"lemma_id": 1, "result": "acknowledged", "session_id": "s"},
+        )
+        assert resp.status_code == 200
+        db_session.refresh(knowledge)
+        assert knowledge.experiment_intro_shown_at is not None
+
+
+class TestReintroCooldown:
+    def test_fresh_ack_suppresses_reintro_card(self, db_session):
+        """A struggling word acked within the cooldown gets no reintro card."""
+        _, knowledge = _seed_word(
+            db_session, 1, "صعب", "difficult",
+            stability=0.1, due_hours=-1, times_seen=5, times_correct=0,
+        )
+        # Naive datetime, matching how the ack endpoint writes the stamp.
+        knowledge.experiment_intro_shown_at = datetime.utcnow() - timedelta(hours=1)
+        db_session.commit()
+
+        result = build_session(db_session, limit=10, log_events=False)
+        assert result.get("reintro_cards", []) == []
+
+    def test_stale_ack_allows_reintro_card(self, db_session):
+        """Once the cooldown has elapsed the reintro card may fire again."""
+        _, knowledge = _seed_word(
+            db_session, 1, "صعب", "difficult",
+            stability=0.1, due_hours=-1, times_seen=5, times_correct=0,
+        )
+        knowledge.experiment_intro_shown_at = datetime.utcnow() - timedelta(hours=21)
+        db_session.commit()
+
+        result = build_session(db_session, limit=10, log_events=False)
+        reintro = result.get("reintro_cards", [])
+        assert len(reintro) == 1
+        assert reintro[0]["lemma_id"] == 1
+
+
+class TestRescueReservation:
+    def test_rescue_not_starved_by_new_backlog(self, db_session):
+        """With a big never-reviewed backlog, rescue still gets reserved slots.
+
+        Before 2026-07-20 a 200-word explicit import filled all 6 intro slots
+        with new cards for weeks while 50 rescue-eligible words waited.
+        """
+        from app.services.sentence_selector import _build_intro_cards
+
+        new_ids, rescue_ids = [], []
+        for i in range(1, 9):  # 8 new candidates (times_seen=0)
+            _, k = _seed_word(
+                db_session, i, f"جديد{i}", f"new-{i}",
+                state="acquiring", times_seen=0, times_correct=0,
+            )
+            k.acquisition_box = 1
+            new_ids.append(i)
+        for i in range(20, 22):  # 2 rescue candidates (seen 6, correct 1)
+            _, k = _seed_word(
+                db_session, i, f"عالق{i}", f"stuck-{i}",
+                state="acquiring", times_seen=6, times_correct=1,
+            )
+            k.acquisition_box = 1
+            rescue_ids.append(i)
+        db_session.commit()
+
+        knowledge_by_id = {
+            u.lemma_id: u for u in db_session.query(UserLemmaKnowledge).all()
+        }
+        cards = _build_intro_cards(
+            db_session, knowledge_by_id, set(new_ids) | set(rescue_ids)
+        )
+        card_ids = [c["lemma_id"] for c in cards]
+        n_new = sum(1 for cid in card_ids if cid in new_ids)
+        n_rescue = sum(1 for cid in card_ids if cid in rescue_ids)
+        assert len(cards) <= 6
+        assert n_rescue == 2, f"rescue starved: {card_ids}"
+        assert n_new == 4
+
 
 class TestContextDiversity:
     def test_least_shown_sentence_preferred(self, db_session):

--- a/docs/scheduling-system.md
+++ b/docs/scheduling-system.md
@@ -1776,6 +1776,8 @@ remaining cards on the next card advance. See Section 8 "Sentence Pre-Warming" f
 | `MAX_ON_DEMAND_PER_SESSION` | 10 | Reference constant (callers control actual cap via remaining session capacity) |
 | `MAX_REINTRO_PER_SESSION` | 3 | Struggling word reintro card limit |
 | `STRUGGLING_MIN_SEEN` | 3 | Threshold for struggling classification (seen 3+, 0 correct) |
+| `REINTRO_SHOWN_COOLDOWN_HOURS` | 20 | Suppress another struggling-reintro card for a lemma after its `/reintro-result` ack stamped `experiment_intro_shown_at` (2026-07-20; a word had repeated 9× in 3 days with several sessions/day) |
+| `RESCUE_RESERVED_SLOTS` | 2 | Of the 6 `INTRO_NEW_CARDS_PER_SESSION` slots, guarantee this many to rescue re-teach cards when rescue candidates exist — a large explicit import otherwise fills all slots with new cards for weeks (2026-07-20) |
 | Comprehensibility threshold | 60% | Min known scaffold words to show sentence |
 | Unknown scaffold cap | 2 | Hard cap on unknown non-target words per sentence |
 | Acquiring box-1 excluded | stability < 0.5 | Box-1 words don't count as "known" scaffold |

--- a/frontend/app/stats.tsx
+++ b/frontend/app/stats.tsx
@@ -147,10 +147,18 @@ export default function StatsScreen() {
               const learnedH = day.words_learned > 0 && maxReviews > 0
                 ? Math.max((day.words_learned / maxReviews) * 80, 3)
                 : 0;
-              // Due-backlog burndown marker on an independent scale: a falling
-              // dot line means the review debt is shrinking day over day.
-              const backlogH = day.due_backlog != null && maxBacklog > 0
-                ? (day.due_backlog / maxBacklog) * 80
+              // Due-backlog burndown marker, zoomed to the window's min–max
+              // range. Scaled against zero the daily net change (±3% of a
+              // ~1,100-word backlog) moved the dot ~2px and the line read as
+              // flat even while the learner was gaining ~35 words/day.
+              const backlogVals = last14
+                .map((d) => d.due_backlog)
+                .filter((v): v is number => v != null);
+              const minBacklog = backlogVals.length > 0 ? Math.min(...backlogVals) : 0;
+              const backlogH = day.due_backlog != null && backlogVals.length > 0
+                ? maxBacklog > minBacklog
+                  ? ((day.due_backlog - minBacklog) / (maxBacklog - minBacklog)) * 70 + 5
+                  : 40
                 : null;
               return (
                 <View key={day.date} style={styles.barContainer}>
@@ -197,6 +205,28 @@ export default function StatsScreen() {
               )}
             </View>
           </View>
+          {(() => {
+            // Numeric burndown readout: the zoomed dot line shows shape, this
+            // shows magnitude — current backlog and the net change over the
+            // last ~week of days that have data.
+            const withBacklog = daily_history
+              .slice(-14)
+              .filter((d) => d.due_backlog != null);
+            if (withBacklog.length < 2) return null;
+            const latest = withBacklog[withBacklog.length - 1].due_backlog as number;
+            const ref = withBacklog[Math.max(0, withBacklog.length - 8)];
+            const delta = latest - (ref.due_backlog as number);
+            const refDay = ref.date.slice(5).replace("-", "/");
+            return (
+              <Text style={[styles.legendText, { marginTop: 4 }]}>
+                Due backlog now {latest.toLocaleString()} ·{" "}
+                <Text style={{ color: delta <= 0 ? colors.stateKnown : colors.missed }}>
+                  {delta <= 0 ? "" : "+"}{delta.toLocaleString()}
+                </Text>{" "}
+                since {refDay}
+              </Text>
+            );
+          })()}
         </View>
       )}
 

--- a/research/experiment-log.md
+++ b/research/experiment-log.md
@@ -46,6 +46,46 @@ Running lab notebook for Alif's learning algorithm. Each entry documents what ch
 
 ═══════════════════════ ENTRIES (newest first) ═══════════════════════
 
+## 2026-07-20: Reintro-card cooldown + rescue slot reservation + readable burndown
+
+**Trigger.** User report: (1) the same struggling-word reintro cards repeat — حَشَرَة
+"insect" #4230 was shown **9 reintro cards in 3 days** (07-17→19), وَفَّرَ #4300 6 in 3 days —
+while (2) words the user keeps failing get no re-teach cards at all, and (3) the stats
+burndown dot line "gives no sense of progress".
+
+**Diagnosis (analysis-2026-07-20-post-injection-checkup.md is the companion checkup).**
+- Struggling reintro cards (`due + seen≥3 + 0 correct` → `_build_reintro_cards`, limit 3)
+  are rebuilt **every session with no cooldown and no shown-stamp**. The frontend faithfully
+  acked every card (`reintro_acknowledged` ×8 for #4230), but `/reintro-result` — made
+  acknowledgement-only in PR #207 — persisted **nothing**, so each of the day's 3–8 sessions
+  re-fired the same card. (Same failure class as the 2026-05-04 lemma #2650 intro repeat.)
+- Rescue cards (acquiring, seen≥4, acc<50%, 7-day cooldown) were **fully starved since the
+  07-15 202-word bookifier import**: new-word cards have strict priority over the 6-slot
+  intro budget, and 49 un-introed new words consume all 6 slots every session while 50
+  rescue-eligible words wait.
+- The burndown dot was scaled against zero: a −35/day trend on a ~1,150 backlog moves the
+  dot ~2px in 80px — flat by construction.
+
+**Changes (PR sh/reintro-cooldown-rescue-slots).**
+1. `/reintro-result` now stamps `experiment_intro_shown_at` (shared `_stamp_intro_shown`
+   helper with the intro-ack's lock-retry; still **no review credit** — the PR #207
+   acknowledgement-only invariant holds). `build_session` skips struggling words whose stamp
+   is fresher than `REINTRO_SHOWN_COOLDOWN_HOURS=20` → at most ~1 reintro card/day/word.
+   Side effect (intended): a reintro-acked word also starts the 7-day rescue cooldown.
+2. `RESCUE_RESERVED_SLOTS=2`: `_build_intro_cards` caps new cards at 4 when rescue
+   candidates exist, guaranteeing rescue up to 2 of the 6 slots (still bounded by
+   `_dynamic_intro_cap`). No rescue candidates → new keeps all 6.
+3. Stats chart: burndown dots re-scaled to the 14-day min–max window + a numeric readout
+   ("Due backlog now N · ±Δ since MM/DD", green/red).
+
+**Expected.** Reintro repeats drop from up-to-9/3d to ≤3/3d per word; rescue cards reappear
+within a day (50 candidates queued); intro-card mix shifts from 6 new to 4 new + 2 rescue
+until the injection backlog drains. **Verify in ~1 week:** grep `card_shown` logs — no
+lemma with >1 reintro/day; rescue-card share > 0; user-felt repetition gone.
+
+**Tests.** `test_reintro.py` +5: ack stamps ULK; fresh stamp suppresses card; stale stamp
+(21h) re-allows; rescue reservation 4+2 split; existing ack-only invariants untouched.
+
 ## 2026-07-15: Cron Step E lemma enrichment was structurally unable to drain — hooks-query drift + timeout-kill data loss
 
 **Trigger.** User imported 96 words from Bookifier (`POST /api/discover/add-batch`, 06:22 + 06:53 UTC) and found مِهْنَة (#4359) with no enrichment (no root, etymology, pattern, hooks) hours later, despite `gates_completed_at` being stamped.


### PR DESCRIPTION
Fixes two intro-card efficiency defects reported 2026-07-20 plus the unreadable burndown chart.

**Repeated reintro cards**: struggling-word reintro cards (due + seen≥3 + never correct) were rebuilt every session with no cooldown — حَشَرَة #4230 got 9 cards in 3 days. The frontend acked every one, but `/reintro-result` (acknowledgement-only since PR #207) persisted nothing. The ack now stamps `experiment_intro_shown_at` (still no review credit) via a `_stamp_intro_shown` helper shared with the intro ack, and `build_session` skips struggling words acked within `REINTRO_SHOWN_COOLDOWN_HOURS=20`.

**Rescue starvation**: new-word cards had strict priority over the 6-slot intro budget, so the 07-15 202-word import starves rescue re-teaching for weeks (50 candidates waiting, 0 served). `RESCUE_RESERVED_SLOTS=2` guarantees rescue 2 slots when candidates exist; new keeps all 6 otherwise.

**Burndown readability**: the stats dot line was scaled against zero, so a −35/day trend on a ~1,150 backlog moved ~2px. Dots now scale to the window min–max, with a numeric readout (current backlog + delta over last week, green/red).

Diagnosis + companion analysis: `research/analysis-2026-07-20-post-injection-checkup.md`; experiment-log entry 2026-07-20. Backend fast suite 1454 passed; frontend 183 passed, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)