### PR TITLE
Re-test conformance v2 + honest debt labels

### DIFF
--- a/backend/app/services/acquisition_service.py
+++ b/backend/app/services/acquisition_service.py
@@ -640,10 +640,16 @@ def submit_acquisition_review(
     recent_intro = _intro_shown_recently(ulk, now)
     retest_gate = _quiz_retest_after_failure(db, lemma_id, now, review_mode, rating_int)
 
-    # Update review counts
-    ulk.times_seen = old_times_seen + 1
-    if rating_int >= 3:
-        ulk.times_correct = old_times_correct + 1
+    # Update review counts. A guarded re-test success (retest_gate) is pure
+    # re-encoding: it enters neither the graduation numerator NOR denominator.
+    # Incrementing only times_seen would unfairly depress cumulative accuracy
+    # (Tier 1/2 read it); incrementing both would inflate it (conformance v2,
+    # 2026-07-25). The event still logs to ReviewLog with
+    # fsrs_log_json.retest_credit_blocked and bumps total_encounters.
+    if not retest_gate:
+        ulk.times_seen = old_times_seen + 1
+        if rating_int >= 3:
+            ulk.times_correct = old_times_correct + 1
     ulk.last_reviewed = now
     ulk.total_encounters = (ulk.total_encounters or 0) + 1
 

--- a/backend/tests/test_retest_credit_guard.py
+++ b/backend/tests/test_retest_credit_guard.py
@@ -72,6 +72,12 @@ def test_quiz_success_after_recent_failure_does_not_advance_box(db_session):
     if due.tzinfo is None:
         due = due.replace(tzinfo=timezone.utc)
     assert due > datetime.now(timezone.utc) + BOX_INTERVALS[1] - timedelta(minutes=5)
+    # Counter neutrality (conformance v2): the guarded success enters neither
+    # the graduation numerator nor denominator — otherwise a later organic
+    # review would see inflated (or unfairly deflated) cumulative accuracy.
+    assert ulk.times_seen == 3
+    assert ulk.times_correct == 1
+    assert ulk.total_encounters == 1  # still recorded as an encounter
 
 
 def test_reading_success_after_recent_failure_still_advances(db_session):
@@ -128,6 +134,9 @@ def test_quiz_miss_still_resets_box(db_session):
         review_mode="quiz", comprehension_signal="no_idea", commit=False,
     )
     assert ulk.acquisition_box == 1
+    # Misses are genuine evidence and DO count in the lifetime counters
+    assert ulk.times_seen == 5
+    assert ulk.times_correct == 3
 
 
 def test_leech_window_excludes_quiz_successes(db_session):

--- a/docs/scheduling-system.md
+++ b/docs/scheduling-system.md
@@ -1995,19 +1995,25 @@ treatment arm = deterministic hash of `session_id:lemma_id`, see experiment-log)
    queues a re-test; after ≥4 min AND ≥3 cards (expires at 20 min) the card renders
    as an out-of-band phase. Caps: 3/session, 1/lemma/session; a failed re-test drops
    the lemma for the session. The queue **persists across session fragments/swaps**
-   (wall-clock expiry only — same-day amendment after fragments silently dropped it).
-   Client-side only — no session-build involvement.
+   (wall-clock expiry only) and an entry is consumed **only by a successful non-empty
+   card fetch** — network errors leave it queued for retry (conformance v2). Pure
+   queue logic lives in `frontend/lib/review/retest.ts` (`pickReadyRetest`, `retestArm`,
+   `RETEST_PROTOCOL_VERSION`). Client-side only — no session-build involvement.
 2. **Auto wrap-up** (both arms — product policy, not a treatment, per same-day
-   amendment): at session completion the quiz auto-runs for ALL failed lemmas not
-   already checkpointed (`parent_card_type="wrapup_auto"`).
+   amendment): at session completion the quiz auto-runs for ALL **rating-1** lemmas
+   not already checkpointed (`parent_card_type="wrapup_auto"`). Rating-2/confused
+   words are excluded (exact-surface pilot population; conformance v2).
 3. **Manual wrap-up**: unchanged action-menu button.
 
 **Credit guard** (`RETEST_CREDIT_GAP = 30 min`, `acquisition_service.py`): a quiz-mode
 success within the gap of a rating-1 review clears the 5-min retry due-date to the box
 interval but cannot promote a box, fast-graduate, or Tier-E/1/2 graduate — the intro
-working-memory gate extended to failure re-tests. Quiz successes are also excluded
-from the leech sliding window (`leech_service._recent_accuracy`); quiz misses count
-normally everywhere.
+working-memory gate extended to failure re-tests. It is also **counter-neutral**
+(conformance v2): neither `times_seen` nor `times_correct` increments, so later
+organic reviews see unbiased cumulative accuracy (`total_encounters` + ReviewLog with
+`fsrs_log_json.retest_credit_blocked` still record it). Quiz successes are also
+excluded from the leech sliding window (`leech_service._recent_accuracy`); quiz
+misses count normally everywhere.
 
 ### 19.5 ~~Next-Session Recap~~ — REMOVED (2026-02-14)
 

--- a/frontend/app/index.tsx
+++ b/frontend/app/index.tsx
@@ -67,6 +67,12 @@ import StoryInfoModal from "../lib/review/StoryInfoModal";
 import WordInfoCard, { FocusWordMark } from "../lib/review/WordInfoCard";
 import { ConfusionPicker } from "../lib/review/ConfusionPicker";
 import { canSkipDueObligations } from "../lib/review/auto-skip";
+import {
+  CHECKPOINT_MAX_PER_SESSION,
+  RETEST_PROTOCOL_VERSION,
+  pickReadyRetest,
+  retestArm,
+} from "../lib/review/retest";
 import { IntroducedWordsTable } from "../lib/IntroducedWordsTable";
 import { GraduatedWordsTable } from "../lib/GraduatedWordsTable";
 import { bestVocalizedDisplayForm } from "../lib/arabic-display";
@@ -85,7 +91,8 @@ interface SessionResults {
 interface WordOutcome {
   arabic: string;
   english: string | null;
-  failed: boolean;
+  failed: boolean; // missed OR confused — display/manual-wrapup semantics
+  rating1: boolean; // strictly rating-1 (missed / no_idea) — re-test eligibility
   prevState: string; // knowledge_state before this session
   canonical_lemma_id: number | null;
 }
@@ -95,33 +102,6 @@ type SessionSlot =
   | { type: "intro"; candidateIndex: number }
   | { type: "experiment_intro"; introIndex: number }
   | { type: "verse"; verseIndex: number };
-
-// --- Rapid re-exposure re-test experiment (2026-07-25) ---
-// A rating-1 failure in the treatment arm earns one active bare-recall
-// re-test a few minutes later (mid-session checkpoint) or at session end
-// (auto wrap-up). Timing is wall-clock based: the <10min massed-practice
-// window is deliberately avoided (failure-gap analysis 2026-07-25).
-const RETEST_MIN_GAP_MS = 4 * 60 * 1000;
-const RETEST_EXPIRE_MS = 20 * 60 * 1000;
-const RETEST_MIN_CARDS_BETWEEN = 3;
-const CHECKPOINT_MAX_PER_SESSION = 3;
-
-/**
- * Deterministic 50/50 arm assignment per (session, lemma) failure event.
- * djb2-xor over `${sessionId}:${lemmaId}`, unsigned-32; even hash → treatment.
- * Python mirror for analysis:
- *   h = 5381
- *   for c in f"{session_id}:{lemma_id}": h = ((h * 33) ^ ord(c)) & 0xFFFFFFFF
- *   arm = "treatment" if h % 2 == 0 else "control"
- */
-function retestArm(sessionId: string, lemmaId: number): "treatment" | "control" {
-  const s = `${sessionId}:${lemmaId}`;
-  let h = 5381;
-  for (let i = 0; i < s.length; i++) {
-    h = (Math.imul(h, 33) ^ s.charCodeAt(i)) >>> 0;
-  }
-  return h % 2 === 0 ? "treatment" : "control";
-}
 
 /**
  * Build an interleaved session: an intro card is emitted immediately before
@@ -652,7 +632,7 @@ export function ReviewScreen({ fixedMode }: { fixedMode: ReviewMode }) {
         lemma_id: card.lemma_id,
         card_index: wrapUpIndex,
         total_cards: wrapUpCards.length,
-        detail: wrapUpVariant === "wrapup_auto" ? { variant: "wrapup_auto" } : undefined,
+        detail: wrapUpVariant === "wrapup_auto" ? { variant: "wrapup_auto", v: RETEST_PROTOCOL_VERSION } : undefined,
       });
     }
   }, [inWrapUp, wrapUpIndex, wrapUpCards, wrapUpVariant, sentenceSession?.session_id]);
@@ -668,7 +648,9 @@ export function ReviewScreen({ fixedMode }: { fixedMode: ReviewMode }) {
     autoWrapUpTriggeredRef.current = true;
     const missedTreatment: number[] = [];
     for (const [lemmaId, outcome] of wordOutcomes) {
-      if (!outcome.failed) continue;
+      // rating-1 only (conformance v2): confused/rating-2 words belong to the
+      // exact-surface pilot and must not receive bare-recall re-tests.
+      if (!outcome.rating1) continue;
       const cid = outcome.canonical_lemma_id ?? lemmaId;
       if (retestTestedRef.current.has(cid)) continue;
       if (!missedTreatment.includes(cid)) missedTreatment.push(cid);
@@ -1315,10 +1297,17 @@ export function ReviewScreen({ fixedMode }: { fixedMode: ReviewMode }) {
         if (w.is_proper_name || w.is_function_word) continue;
 
         let failed = false;
+        let rating1 = false;
         if (signal === "no_idea") {
           failed = true;
+          rating1 = true;
         } else if (signal === "partial") {
-          if (missedSet.has(w.lemma_id) || confusedSet.has(w.lemma_id)) failed = true;
+          if (missedSet.has(w.lemma_id)) {
+            failed = true;
+            rating1 = true;
+          } else if (confusedSet.has(w.lemma_id)) {
+            failed = true; // rating 2 — display only, never re-test eligible
+          }
         }
 
         const existing = next.get(w.lemma_id);
@@ -1326,6 +1315,7 @@ export function ReviewScreen({ fixedMode }: { fixedMode: ReviewMode }) {
           next.set(w.lemma_id, {
             ...existing,
             failed: existing.failed || failed,
+            rating1: existing.rating1 || rating1,
             canonical_lemma_id:
               existing.canonical_lemma_id ?? w.canonical_lemma_id ?? null,
           });
@@ -1334,6 +1324,7 @@ export function ReviewScreen({ fixedMode }: { fixedMode: ReviewMode }) {
             arabic: w.surface_form,
             english: w.gloss_en,
             failed,
+            rating1,
             prevState: w.knowledge_state ?? "new",
             canonical_lemma_id: w.canonical_lemma_id ?? null,
           });
@@ -1605,20 +1596,25 @@ export function ReviewScreen({ fixedMode }: { fixedMode: ReviewMode }) {
       return;
     }
     const now = Date.now();
-    retestQueueRef.current = retestQueueRef.current.filter(
-      e => now - e.failedAtMs < RETEST_EXPIRE_MS
-    );
-    const ready = retestQueueRef.current.find(
-      e => now - e.failedAtMs >= RETEST_MIN_GAP_MS && e.cardsSince >= RETEST_MIN_CARDS_BETWEEN
-    );
+    const { queue, ready } = pickReadyRetest(retestQueueRef.current, now);
+    retestQueueRef.current = queue;
     if (!ready) return;
-    retestQueueRef.current = retestQueueRef.current.filter(e => e.lemmaId !== ready.lemmaId);
-    retestTestedRef.current.add(ready.lemmaId);
+    // Conformance v2: the entry stays queued (and un-"tested") until the card
+    // fetch returns a non-empty result — a network failure must not consume
+    // the learner's one re-test. Double-fire is prevented by the fetching flag.
     checkpointFetchingRef.current = true;
     const gapMs = now - ready.failedAtMs;
     getWrapUpCards([], [ready.lemmaId], sentenceSession.session_id)
       .then(cards => {
-        if (cards.length === 0) return;
+        if (cards.length === 0) {
+          // Endpoint filtered the lemma (suspended / function word / open
+          // exact-surface episode) — retrying would return empty again. Drop
+          // the entry but leave it un-tested so tier 3 handles it normally.
+          retestQueueRef.current = retestQueueRef.current.filter(e => e.lemmaId !== ready.lemmaId);
+          return;
+        }
+        retestQueueRef.current = retestQueueRef.current.filter(e => e.lemmaId !== ready.lemmaId);
+        retestTestedRef.current.add(ready.lemmaId);
         checkpointShownCountRef.current += 1;
         setWrapUpCards(cards);
         setWrapUpIndex(0);
@@ -1629,10 +1625,10 @@ export function ReviewScreen({ fixedMode }: { fixedMode: ReviewMode }) {
           card_type: "checkpoint",
           session_id: sentenceSession.session_id,
           lemma_id: ready.lemmaId,
-          detail: { arm: "treatment", gap_ms: gapMs, cards_since: ready.cardsSince },
+          detail: { arm: "treatment", gap_ms: gapMs, cards_since: ready.cardsSince, v: RETEST_PROTOCOL_VERSION },
         });
       })
-      .catch(() => {}) // offline / error → tiers 2 and 3 cover the word
+      .catch(() => {}) // network error — entry stays queued; retried on a later advance until expiry
       .finally(() => {
         checkpointFetchingRef.current = false;
       });

--- a/frontend/app/stats.tsx
+++ b/frontend/app/stats.tsx
@@ -1160,7 +1160,7 @@ function DebtCard({ debt, recovery }: { debt: DebtBreakdown; recovery: RecoveryS
         )}
       </View>
       <Text style={styles.recoverySubtitle}>
-        {debt.urgent} need attention · {debt.mid + debt.mature} stable words waiting (low urgency)
+        {debt.urgent} fragile · {debt.mid + debt.mature} on longer intervals (slower decay, still ~75% recall when served)
       </Text>
       <View style={styles.bookBarTrack}>
         <View style={{ width: `${(debt.urgent / total) * 100}%`, backgroundColor: colors.missed }} />
@@ -1170,14 +1170,14 @@ function DebtCard({ debt, recovery }: { debt: DebtBreakdown; recovery: RecoveryS
       <View style={styles.bookLegend}>
         <Text style={[styles.legendText, { color: colors.missed }]}>{debt.urgent} fragile</Text>
         <Text style={[styles.legendText, { color: colors.noIdea }]}>{debt.mid} mid</Text>
-        <Text style={[styles.legendText, { color: colors.accent }]}>{debt.mature} solid (30d+ memory)</Text>
+        <Text style={[styles.legendText, { color: colors.accent }]}>{debt.mature} at 30d+ intervals</Text>
       </View>
       <Text style={styles.debtDetail}>
         {debt.untouched_14d} due words not seen in 14+ days
         {toUnlock != null
           ? toUnlock > 0
-            ? ` · ${toUnlock} above the ${recovery!.main_fsrs_limit} gate — pay down to unlock new words`
-            : ` · under the ${recovery!.main_fsrs_limit} intake gate ✓`
+            ? ` · ${toUnlock} above the ${recovery!.main_fsrs_limit} FSRS gate (one of the recovery gates above)`
+            : ` · under the ${recovery!.main_fsrs_limit} FSRS gate ✓`
           : ""}
       </Text>
     </View>

--- a/frontend/lib/__tests__/retest.test.ts
+++ b/frontend/lib/__tests__/retest.test.ts
@@ -1,0 +1,84 @@
+import {
+  RETEST_EXPIRE_MS,
+  RETEST_MIN_CARDS_BETWEEN,
+  RETEST_MIN_GAP_MS,
+  RetestEntry,
+  pickReadyRetest,
+  retestArm,
+} from "../review/retest";
+
+const T0 = 1_753_400_000_000; // fixed wall-clock origin
+
+function entry(overrides: Partial<RetestEntry> = {}): RetestEntry {
+  return { lemmaId: 42, failedAtMs: T0, cardsSince: 0, ...overrides };
+}
+
+describe("retestArm", () => {
+  it("is deterministic and matches the documented python mirror", () => {
+    // Python mirror: h=5381; for c in s: h=(((h*33)&0xFFFFFFFF)^ord(c)); h%2
+    // Precomputed for "abc:1": djb2-xor unsigned-32
+    const s = "abc:1";
+    let h = 5381;
+    for (let i = 0; i < s.length; i++) {
+      h = (Math.imul(h, 33) ^ s.charCodeAt(i)) >>> 0;
+    }
+    const expected = h % 2 === 0 ? "treatment" : "control";
+    expect(retestArm("abc", 1)).toBe(expected);
+    expect(retestArm("abc", 1)).toBe(retestArm("abc", 1));
+  });
+
+  it("splits roughly 50/50 over many lemmas", () => {
+    let treatment = 0;
+    for (let i = 0; i < 1000; i++) {
+      if (retestArm("session-xyz", i) === "treatment") treatment++;
+    }
+    expect(treatment).toBeGreaterThan(400);
+    expect(treatment).toBeLessThan(600);
+  });
+});
+
+describe("pickReadyRetest", () => {
+  it("returns null before the minimum wall-clock gap", () => {
+    const q = [entry({ cardsSince: RETEST_MIN_CARDS_BETWEEN })];
+    const { ready } = pickReadyRetest(q, T0 + RETEST_MIN_GAP_MS - 1);
+    expect(ready).toBeNull();
+  });
+
+  it("returns null before enough intervening cards", () => {
+    const q = [entry({ cardsSince: RETEST_MIN_CARDS_BETWEEN - 1 })];
+    const { ready } = pickReadyRetest(q, T0 + RETEST_MIN_GAP_MS + 1);
+    expect(ready).toBeNull();
+  });
+
+  it("returns the matured entry when both conditions hold", () => {
+    const q = [entry({ cardsSince: RETEST_MIN_CARDS_BETWEEN })];
+    const { ready } = pickReadyRetest(q, T0 + RETEST_MIN_GAP_MS);
+    expect(ready?.lemmaId).toBe(42);
+  });
+
+  it("does NOT remove the returned entry — removal happens only after a successful fetch", () => {
+    const q = [entry({ cardsSince: 5 })];
+    const { queue, ready } = pickReadyRetest(q, T0 + RETEST_MIN_GAP_MS);
+    expect(ready).not.toBeNull();
+    expect(queue).toHaveLength(1);
+  });
+
+  it("prunes expired entries", () => {
+    const q = [
+      entry({ lemmaId: 1, cardsSince: 5 }),
+      entry({ lemmaId: 2, failedAtMs: T0 + 10 * 60_000, cardsSince: 5 }),
+    ];
+    const { queue, ready } = pickReadyRetest(q, T0 + RETEST_EXPIRE_MS);
+    expect(queue.map(e => e.lemmaId)).toEqual([2]);
+    expect(ready?.lemmaId).toBe(2);
+  });
+
+  it("picks the oldest matured entry first", () => {
+    const q = [
+      entry({ lemmaId: 1, failedAtMs: T0, cardsSince: 5 }),
+      entry({ lemmaId: 2, failedAtMs: T0 + 60_000, cardsSince: 5 }),
+    ];
+    const { ready } = pickReadyRetest(q, T0 + RETEST_MIN_GAP_MS + 120_000);
+    expect(ready?.lemmaId).toBe(1);
+  });
+});

--- a/frontend/lib/review/retest.ts
+++ b/frontend/lib/review/retest.ts
@@ -1,0 +1,56 @@
+// Rapid re-exposure re-test experiment (2026-07-25, conformance v2).
+// Pure helpers extracted from app/index.tsx so the queue state machine is
+// unit-testable. A rating-1 failure in the treatment arm earns one active
+// bare-recall re-test a few minutes later; timing is wall-clock based — the
+// <10min massed-practice window is deliberately avoided.
+
+export const RETEST_MIN_GAP_MS = 4 * 60 * 1000;
+export const RETEST_EXPIRE_MS = 20 * 60 * 1000;
+export const RETEST_MIN_CARDS_BETWEEN = 3;
+export const CHECKPOINT_MAX_PER_SESSION = 3;
+/** Experiment protocol version. v1 = launch day (pre-conformance); v2 = rating-1-only
+ * auto wrap-up, requeue-on-fetch-failure, counter-neutral guarded credit. */
+export const RETEST_PROTOCOL_VERSION = 2;
+
+export interface RetestEntry {
+  lemmaId: number;
+  failedAtMs: number;
+  cardsSince: number;
+}
+
+/**
+ * Deterministic 50/50 arm assignment per (session, lemma) failure event.
+ * djb2-xor over `${sessionId}:${lemmaId}`, unsigned-32; even hash → treatment.
+ * Python mirror for analysis:
+ *   h = 5381
+ *   for c in f"{session_id}:{lemma_id}": h = (((h * 33) & 0xFFFFFFFF) ^ ord(c))
+ *   arm = "treatment" if h % 2 == 0 else "control"
+ */
+export function retestArm(sessionId: string, lemmaId: number): "treatment" | "control" {
+  const s = `${sessionId}:${lemmaId}`;
+  let h = 5381;
+  for (let i = 0; i < s.length; i++) {
+    h = (Math.imul(h, 33) ^ s.charCodeAt(i)) >>> 0;
+  }
+  return h % 2 === 0 ? "treatment" : "control";
+}
+
+/**
+ * Prune expired entries in place and return the first matured entry, or null.
+ * Does NOT remove the returned entry — the caller removes it only after the
+ * card fetch returns a non-empty result (a network failure must not consume
+ * the learner's one re-test; conformance fix 2026-07-25).
+ */
+export function pickReadyRetest(queue: RetestEntry[], nowMs: number): {
+  queue: RetestEntry[];
+  ready: RetestEntry | null;
+} {
+  const pruned = queue.filter(e => nowMs - e.failedAtMs < RETEST_EXPIRE_MS);
+  const ready =
+    pruned.find(
+      e =>
+        nowMs - e.failedAtMs >= RETEST_MIN_GAP_MS &&
+        e.cardsSince >= RETEST_MIN_CARDS_BETWEEN
+    ) ?? null;
+  return { queue: pruned, ready };
+}

--- a/research/experiment-log.md
+++ b/research/experiment-log.md
@@ -83,6 +83,33 @@ should sanitize as if the model will disobey the prompt.
 
 ## 2026-07-25: Rapid re-exposure re-test after failure — pre-registered 50/50 experiment (PR #220)
 
+**Amendment 2 — conformance v2 (same day, evening).** An adversarial review of
+`research/alif-learning-system-proposal-2026-07-25.md` (and its counter-review) found
+three implementation defects that violated this registration; all three are FIXES back
+to the registered spec, not protocol changes. Analysis must treat deploy time of the
+conformance PR as the **v2 window boundary** (telemetry carries `v: 2` in checkpoint /
+wrapup_auto `card_shown` detail); v1-window treatment deliveries are contaminated and
+excluded from the primary analysis.
+1. **Auto wrap-up leaked rating-2/confused words** (`wordOutcomes.failed` included the
+   confused set — the exact-surface pilot's population). Fixed: new `rating1` flag;
+   auto wrap-up is strictly rating-1.
+2. **A failed checkpoint card fetch consumed the re-test** (entry dequeued + marked
+   tested before fetch; on error, tier 2 was also blocked). Fixed: entry stays queued
+   until a non-empty fetch succeeds (`pickReadyRetest` in `lib/review/retest.ts`);
+   empty responses drop the entry un-tested (tier 3 covers).
+3. **Guarded successes still fed graduation accuracy** (`times_seen`/`times_correct`
+   incremented before the advancement block, inflating later Tier-1/2 checks). Fixed:
+   counter-neutral — a `retest_gate` success increments neither counter (not just the
+   numerator, which would unfairly deflate accuracy); `total_encounters` + ReviewLog
+   (`retest_credit_blocked`) still record the event.
+Also from the same review: session-completion data (31% completion; completed sessions
+median ~16-17 distinct rating-1 lemmas incl. collateral no_idea fan-out; observed 10-
+and 8-card auto wrap-ups on day 1) — workload is a watch item under the existing
+completion-rate guardrail, no cap added. FSRS matched-prediction calibration (predicted
+at actual review time vs observed: ~89-93% vs ~77-79% across stability buckets, version
+caveat) → DebtCard labels softened ("solid/low urgency" → interval-based wording).
+Protocol is now FROZEN for the pre-registered readout window.
+
 **Amendment (same day, before any treatment data accrued, commit after `7afbe39`):**
 after first real use the user reported (a) receiving almost nothing, (b) "marking
 things wrong that I should know, unless I get to try it again, is no point."


### PR DESCRIPTION
Fixes three defects vs the 2026-07-25 pre-registration (all restore registered behavior, none change protocol):

1. **Rating-1 only**: auto wrap-up iterated `wordOutcomes.failed`, which includes rating-2/confused words — the exact-surface pilot's population. New `rating1` flag; strictly enforced.
2. **Requeue on fetch failure**: checkpoint entries were dequeued + marked tested before the card fetch; a network error consumed the learner's re-test and blocked tier 2. Entries now survive until a non-empty fetch succeeds; empty responses drop un-tested (tier 3 covers).
3. **Counter-neutral guarded credit**: a `retest_gate` success incremented `times_seen`/`times_correct` before advancement was blocked, inflating later Tier-1/2 accuracy. Now increments neither (suppressing only the numerator would unfairly deflate accuracy).

Queue logic extracted to `lib/review/retest.ts` (pure, 8 new jest tests incl. fetch-failure semantics); `RETEST_PROTOCOL_VERSION=2` in checkpoint/wrapup_auto telemetry marks the clean analysis window. Backend guard tests extended with counter assertions.

Also: DebtCard wording per matched-prediction FSRS calibration (predicted ~89–93% vs observed ~77–79%) — 'solid/low urgency' → interval-based labels; intake line clarified as the FSRS gate (one of three recovery gates).

Experiment-log Amendment 2 freezes the protocol for the readout window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)