### PR TITLE
Document Momo activation boundary

### DIFF
--- a/IDEAS.md
+++ b/IDEAS.md
@@ -177,6 +177,9 @@ the seven approved parents, their 40 replaced child mappings, and those two
 new events; the three exclusions, every other table, active count (1,960), and
 all *Momo* visibility remained unchanged. All seven are prepared but inactive.
 Any activation is a separate policy decision and was not part of this rollout.
+A post-rollout activation-only dry-run found only `52134` currently eligible;
+`52199` is blocked by an acquiring lemma, the other five have no FSRS demand,
+and capacity is zero while 1,960 active sentences exceed the 1,950 ceiling.
 
 Before this rollout, production had zero prepared authentic rows and zero
 active Book OCR stories, so no corpus rollback or cleanup was needed. PR #236

--- a/research/experiment-log.md
+++ b/research/experiment-log.md
@@ -162,6 +162,10 @@ active stayed zero, and integrity remained `ok`. **Result: H confirmed.**
 Source-aware QA removed the provenance false positive without relaxing the
 negative gate. The cohort is prepared, not activated; activation remains a
 separate decision and currently has zero capacity under the 1,950 ceiling.
+A final activation-only dry-run made that boundary explicit: `52134` was the
+sole eligible row, `52199` was blocked because one lemma is acquiring, and
+`52133, 52135, 52136, 52195, 52198` had no FSRS demand. With 1,960 active
+sentences, the plan selected zero and performed no write.
 
 ## 2026-07-30: Approved exact-running-text aliases for *Momo* 52133
 


### PR DESCRIPTION
## Summary
- record the final activation-only dry-run after the exact-seven Momo preparation
- document why no prepared row was activated: capacity is zero at 1,960 active sentences versus the 1,950 ceiling
- preserve the per-row policy split for the next activation decision

## Verification
- documentation-only diff
- diff check passed before commit
- activation dry-run selected zero and performed no write