### PR TITLE
Stop repeating understood sentences

### DIFF
--- a/backend/app/services/sentence_selector.py
+++ b/backend/app/services/sentence_selector.py
@@ -29,6 +29,7 @@ from app.models import (
     Root,
     Sentence,
     SentenceGrammarFeature,
+    SentenceReviewLog,
     SentenceWord,
     UserGrammarExposure,
     UserLemmaKnowledge,
@@ -127,6 +128,26 @@ def _source_bonus_for_sentence(sent: Sentence) -> float:
     if sent.source in ("book", "corpus"):
         return 1.3
     return 1.0
+
+
+def _never_understood_in_mode_clause(mode: str):
+    """Exclude sentences that have ever received Know All in this mode.
+
+    The denormalized `last_*_comprehension` columns drive short retry timing,
+    but cannot express "ever understood" if a stale client later writes a
+    partial result. The review log is the durable evidence for this one-and-done
+    rule. Legacy NULL review modes are reading reviews.
+    """
+    if mode == "listening":
+        mode_clause = SentenceReviewLog.review_mode == "listening"
+    else:
+        mode_clause = or_(
+            SentenceReviewLog.review_mode == "reading",
+            SentenceReviewLog.review_mode.is_(None),
+        )
+    return ~Sentence.review_logs.any(
+        (SentenceReviewLog.comprehension == "understood") & mode_clause
+    )
 
 
 def _book_sentence_blocked_for_acquiring(sent: Sentence, word_metas: list) -> bool:
@@ -1335,13 +1356,15 @@ def build_session(
     tashkeel_mode = (tashkeel_settings.tashkeel_mode if tashkeel_settings else None) or "always"
     tashkeel_threshold = (tashkeel_settings.tashkeel_stability_threshold if tashkeel_settings else None) or 30.0
 
-    # Comprehension-aware recency cutoffs
-    # Failed sentences can be re-shown quickly so learner gets a positive review,
-    # then ideally sees the same word in a different sentence next time.
-    # An understood sentence should provide word evidence without itself
-    # becoming a daily review card. Keep it out for a full week; the due word
-    # can use another sentence while the material pipeline replenishes variety.
-    cutoff_understood = now - timedelta(days=7)
+    # Comprehension-aware recency cutoffs. Failed sentences can be re-shown
+    # quickly so the learner gets a positive review. An understood sentence is
+    # finished in this mode: future reviews of its words must use new context,
+    # otherwise recognition of a distinctive sentence masquerades as recall of
+    # the vocabulary. Listening and reading keep independent evidence columns,
+    # so a sentence understood in reading may still be useful once in listening.
+    # Legacy rows with a shown timestamp but no comprehension signal retain a
+    # conservative cooldown rather than disappearing forever.
+    cutoff_unrated = now - timedelta(days=30)
     cutoff_partial = now - timedelta(hours=4)
     cutoff_no_idea = now - timedelta(minutes=30)
 
@@ -1623,12 +1646,12 @@ def build_session(
         .filter(
             Sentence.id.in_(sentence_ids_with_due),
             reviewable_sentence_clauses(),
+            _never_understood_in_mode_clause(mode),
             or_(
                 shown_col.is_(None),
-                (comp_col == "understood") & (shown_col < cutoff_understood),
                 (comp_col == "partial") & (shown_col < cutoff_partial),
                 (comp_col == "no_idea") & (shown_col < cutoff_no_idea),
-                (comp_col.is_(None)) & (shown_col < cutoff_understood),
+                (comp_col.is_(None)) & (shown_col < cutoff_unrated),
             ),
         )
         .all()
@@ -1658,6 +1681,7 @@ def build_session(
                 .filter(
                     Sentence.id.in_(potential_rescue_ids),
                     reviewable_sentence_clauses(),
+                    _never_understood_in_mode_clause(mode),
                     comp_col.in_(("partial", "no_idea")),
                 )
                 .all()
@@ -1694,6 +1718,7 @@ def build_session(
                 Sentence.story_id.in_(passage_story_ids),
                 Sentence.source == "passage",
                 reviewable_sentence_clauses(),
+                _never_understood_in_mode_clause(mode),
             )
             .all()
         )
@@ -3131,7 +3156,7 @@ def _find_pregenerated_sentences_for_words(
 
     # Recency filter (same cutoffs as build_session)
     now = datetime.now(timezone.utc)
-    cutoff_understood = now - timedelta(days=7)
+    cutoff_unrated = now - timedelta(days=30)
     cutoff_partial = now - timedelta(hours=4)
     cutoff_no_idea = now - timedelta(minutes=30)
 
@@ -3147,12 +3172,12 @@ def _find_pregenerated_sentences_for_words(
         .filter(
             Sentence.id.in_(sentence_ids_with_target),
             reviewable_sentence_clauses(),
+            _never_understood_in_mode_clause(mode),
             or_(
                 shown_col.is_(None),
-                (comp_col == "understood") & (shown_col < cutoff_understood),
                 (comp_col == "partial") & (shown_col < cutoff_partial),
                 (comp_col == "no_idea") & (shown_col < cutoff_no_idea),
-                (comp_col.is_(None)) & (shown_col < cutoff_understood),
+                (comp_col.is_(None)) & (shown_col < cutoff_unrated),
             ),
         )
         .all()
@@ -3178,6 +3203,7 @@ def _find_pregenerated_sentences_for_words(
                 .filter(
                     Sentence.id.in_(potential_rescue_ids),
                     reviewable_sentence_clauses(),
+                    _never_understood_in_mode_clause(mode),
                     comp_col.in_(("partial", "no_idea")),
                 )
                 .all()

--- a/backend/tests/test_sentence_selector.py
+++ b/backend/tests/test_sentence_selector.py
@@ -6,7 +6,14 @@ from types import SimpleNamespace
 import pytest
 from sqlalchemy.orm import sessionmaker
 
-from app.models import Lemma, ReviewLog, UserLemmaKnowledge, Sentence, SentenceWord
+from app.models import (
+    Lemma,
+    ReviewLog,
+    Sentence,
+    SentenceReviewLog,
+    SentenceWord,
+    UserLemmaKnowledge,
+)
 from app.services.fsrs_service import create_new_card
 from app.services.sentence_selector import (
     BOX1_MIN_EXPOSURES,
@@ -1198,13 +1205,12 @@ class TestGreedySetCover:
         db_session.commit()
 
         result = build_session(db_session, limit=10)
-        # Sentence skipped (shown 2 days ago < 7 day cooldown)
-        # No word-only fallback — word just gets skipped (or on-demand gen attempted)
-        # In test mode with no LLM, uncovered words are simply skipped
+        # An understood sentence is complete for this mode. No word-only
+        # fallback: the due word waits for a different generated context.
         assert result["total_due_words"] == 1
         assert all(item["sentence_id"] != 1 for item in result["items"])
 
-    def test_understood_sentence_returns_after_seven_day_cooldown(self, db_session):
+    def test_understood_sentence_does_not_return_after_long_interval(self, db_session):
         _seed_word(db_session, 1, "كتاب", "book", due_hours=-1)
         sent = _seed_sentence(
             db_session,
@@ -1214,13 +1220,38 @@ class TestGreedySetCover:
             target_lemma_id=1,
             word_surfaces_and_ids=[("الكتاب", 1)],
         )
-        sent.last_reading_shown_at = datetime.now(timezone.utc) - timedelta(days=8)
+        sent.last_reading_shown_at = datetime.now(timezone.utc) - timedelta(days=365)
         sent.last_reading_comprehension = "understood"
         db_session.commit()
 
         result = build_session(db_session, limit=10)
 
-        assert any(item["sentence_id"] == 1 for item in result["items"])
+        assert all(item["sentence_id"] != 1 for item in result["items"])
+
+    def test_historical_know_all_survives_later_partial_state(self, db_session):
+        """A stale later write must not erase durable Know All evidence."""
+        _seed_word(db_session, 1, "كتاب", "book", due_hours=-1)
+        sent = _seed_sentence(
+            db_session,
+            1,
+            "الكتاب",
+            "the book",
+            target_lemma_id=1,
+            word_surfaces_and_ids=[("الكتاب", 1)],
+        )
+        db_session.add(SentenceReviewLog(
+            sentence_id=1,
+            reviewed_at=datetime.now(timezone.utc) - timedelta(days=60),
+            comprehension="understood",
+            review_mode="reading",
+        ))
+        sent.last_reading_shown_at = datetime.now(timezone.utc) - timedelta(days=30)
+        sent.last_reading_comprehension = "partial"
+        db_session.commit()
+
+        result = build_session(db_session, limit=10)
+
+        assert all(item["sentence_id"] != 1 for item in result["items"])
 
     def test_no_due_words_returns_empty(self, db_session):
         _seed_word(db_session, 1, "كتاب", "book", due_hours=24)
@@ -2486,12 +2517,12 @@ class TestRescuePass:
         assert 1 in sentence_ids, \
             "Rescue pass should include stale sentence rather than dropping the word"
 
-    def test_rescue_pass_never_bypasses_understood_cooldown(self, db_session):
-        """Know-all evidence keeps the exact sentence out for seven days."""
+    def test_rescue_pass_never_reuses_understood_sentence(self, db_session):
+        """Know All finishes that exact sentence even after a long interval."""
         _seed_word(db_session, 1, "كتاب", "book", due_hours=-1)
         sent = _seed_sentence(db_session, 1, "الكتاب", "the book", 1,
                               [("الكتاب", 1)])
-        sent.last_reading_shown_at = datetime.now(timezone.utc) - timedelta(days=3)
+        sent.last_reading_shown_at = datetime.now(timezone.utc) - timedelta(days=365)
         sent.last_reading_comprehension = "understood"
         db_session.commit()
 
@@ -2773,3 +2804,18 @@ class TestBookSentenceAcquiringGate:
         )
         assert len(items) == 1
         assert db_session.get(Sentence, items[0]["sentence_id"]).source == "corpus"
+
+    def test_pregenerated_fill_never_reuses_understood_sentence(self, db_session):
+        _, k1 = _seed_word(db_session, 1, "كناس", "sweeper", state="known",
+                           stability=5.0)
+        sent = _seed_sentence(db_session, 1, "الكناس", "the sweeper",
+                              1, [("الكناس", 1)], source="llm")
+        sent.last_reading_shown_at = datetime.now(timezone.utc) - timedelta(days=365)
+        sent.last_reading_comprehension = "understood"
+        db_session.commit()
+
+        items = _find_pregenerated_sentences_for_words(
+            db_session, {1}, {1: 5.0}, {1: k1}, [k1], limit=5,
+        )
+
+        assert items == []

--- a/frontend/lib/__tests__/offline-store.test.ts
+++ b/frontend/lib/__tests__/offline-store.test.ts
@@ -31,6 +31,7 @@ describe("markReviewed / unmarkReviewed", () => {
 
     const raw = store[REVIEWED_KEY];
     const keys: string[] = JSON.parse(raw);
+    expect(keys).toContain("reading:sentence:10");
     expect(keys).toContain("reading:10:42");
     expect(keys).toContain("sess-1:10:42");
   });
@@ -49,6 +50,7 @@ describe("markReviewed / unmarkReviewed", () => {
     await unmarkReviewed("sess-1", 10, 42, "reading");
 
     const keys: string[] = JSON.parse(store[REVIEWED_KEY]);
+    expect(keys).not.toContain("reading:sentence:10");
     expect(keys).not.toContain("reading:10:42");
     expect(keys).not.toContain("sess-1:10:42");
     // Other entry still there
@@ -106,6 +108,43 @@ describe("cacheSessions / getCachedSession", () => {
     expect(result).not.toBeNull();
     expect(result!.items).toHaveLength(1);
     expect(result!.items[0].primary_lemma_id).toBe(20);
+  });
+
+  it("filters a reviewed sentence even when a cached copy has a different primary lemma", async () => {
+    const reviewedSession = makeSession("s-1", [
+      { sentence_id: 1, primary_lemma_id: 10, words: [] },
+    ]);
+    const prefetchedSession = makeSession("s-2", [
+      { sentence_id: 1, primary_lemma_id: 99, words: [] },
+      { sentence_id: 2, primary_lemma_id: 20, words: [] },
+    ]);
+    await cacheSessions("reading", [reviewedSession, prefetchedSession]);
+
+    await markReviewed("s-1", 1, 10, "reading");
+
+    const result = await getCachedSession("reading");
+    expect(result).not.toBeNull();
+    expect(result!.session_id).toBe("s-2");
+    expect(result!.items).toHaveLength(1);
+    expect(result!.items[0].sentence_id).toBe(2);
+  });
+
+  it("filters a cached passage when any child sentence was already reviewed under another primary lemma", async () => {
+    const reviewedSession = makeSession("s-1", [
+      { sentence_id: 1, sentence_ids: [1, 2], primary_lemma_id: 10, words: [] },
+    ]);
+    const prefetchedSession = makeSession("s-2", [
+      { sentence_id: 1, sentence_ids: [1, 2], primary_lemma_id: 99, words: [] },
+      { sentence_id: 3, primary_lemma_id: 30, words: [] },
+    ]);
+    await cacheSessions("reading", [reviewedSession, prefetchedSession]);
+
+    await markReviewed("s-1", 1, 10, "reading", [1, 2]);
+
+    const result = await getCachedSession("reading");
+    expect(result).not.toBeNull();
+    expect(result!.items).toHaveLength(1);
+    expect(result!.items[0].sentence_id).toBe(3);
   });
 
   it("skips depleted cached sessions when a minimum remaining count is requested", async () => {

--- a/frontend/lib/offline-store.ts
+++ b/frontend/lib/offline-store.ts
@@ -75,6 +75,22 @@ function reviewKey(
   return `${mode}:${sentenceId ?? "word"}:${lemmaId}`;
 }
 
+/**
+ * A displayed sentence is the review unit regardless of which due lemma made
+ * the selector choose it. Prefetched sessions can contain the same sentence
+ * with a different primary_lemma_id, so a lemma-scoped key alone lets an
+ * already-reviewed sentence leak back out of the cache.
+ *
+ * Word-only quiz cards still need the lemma-scoped reviewKey above because
+ * they have no sentence identity.
+ */
+function sentenceReviewKey(
+  mode: ReviewMode,
+  sentenceId: number
+): string {
+  return `${mode}:sentence:${sentenceId}`;
+}
+
 function legacyReviewKey(
   sessionId: string,
   sentenceId: number | null,
@@ -148,10 +164,13 @@ export async function getCachedSession(
 
     const session = entry.session;
     const remaining = session.items.filter(
-      (item) => !itemSentenceIds(item).some((sentenceId) =>
-        reviewed.has(reviewKey(mode, sentenceId, item.primary_lemma_id)) ||
-        reviewed.has(legacyReviewKey(session.session_id, sentenceId, item.primary_lemma_id))
-      )
+      (item) => !itemSentenceIds(item).some((sentenceId) => {
+        const sentenceAlreadyReviewed = sentenceId != null
+          && reviewed.has(sentenceReviewKey(mode, sentenceId));
+        return sentenceAlreadyReviewed
+          || reviewed.has(reviewKey(mode, sentenceId, item.primary_lemma_id))
+          || reviewed.has(legacyReviewKey(session.session_id, sentenceId, item.primary_lemma_id));
+      })
     );
     if (remaining.length >= minRemaining) {
       // Strip intros the user already dismissed (24h window). Otherwise a
@@ -211,6 +230,7 @@ export async function markReviewed(
   const reviewed = await getReviewedSet();
   const ids = sentenceIds?.length ? sentenceIds : [sentenceId];
   for (const id of ids) {
+    if (id != null) reviewed.add(sentenceReviewKey(mode, id));
     reviewed.add(reviewKey(mode, id, lemmaId));
     reviewed.add(legacyReviewKey(sessionId, id, lemmaId));
   }
@@ -267,6 +287,7 @@ export async function unmarkReviewed(
   const reviewed = await getReviewedSet();
   const ids = sentenceIds?.length ? sentenceIds : [sentenceId];
   for (const id of ids) {
+    if (id != null) reviewed.delete(sentenceReviewKey(mode, id));
     reviewed.delete(reviewKey(mode, id, lemmaId));
     reviewed.delete(legacyReviewKey(sessionId, id, lemmaId));
   }
@@ -289,6 +310,9 @@ export async function pruneReviewedSet(): Promise<void> {
       const session = entry.session;
       for (const item of session.items) {
         for (const sentenceId of itemSentenceIds(item)) {
+          if (sentenceId != null) {
+            validKeys.add(sentenceReviewKey(mode, sentenceId));
+          }
           validKeys.add(reviewKey(mode, sentenceId, item.primary_lemma_id));
           validKeys.add(legacyReviewKey(session.session_id, sentenceId, item.primary_lemma_id));
         }


### PR DESCRIPTION
## Summary
- make Know All permanently finish the exact sentence within each review mode
- use durable sentence review history so stale later writes cannot erase that evidence
- prevent prefetched cached copies from replaying a sentence under a different primary lemma

## Production evidence
- 75 reading reviews since Aug 12 were distinct within that window
- 6 were nevertheless repeats of previously understood sentences after 7–16 days
- historical sub-7-day repeats existed before the Aug 11 selector fix

## Verification
- backend: 109 sentence-selector tests passed
- frontend: 53 API/offline-store tests passed
- frontend TypeScript check passed